### PR TITLE
ci: add PR checks and x86 build-and-test workflows

### DIFF
--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -36,6 +36,11 @@ jobs:
     timeout-minutes: 60
 
     steps:
+      # Container runs as root but workspace is owned by host UID.
+      # Suppress git "dubious ownership" errors that break test-reporter.
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory '*'
+
       - uses: actions/checkout@v4
 
       # ── System dependencies (mirrors Dockerfile.x86 builder stage) ───

--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -41,6 +41,7 @@ jobs:
           sudo apt-get install -y \
             build-essential \
             cmake \
+            g++ \
             ninja-build \
             pkg-config \
             nasm \

--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install -y \
             build-essential \
             cmake \
-            g++ \
+            g++-aarch64-linux-gnu \
             ninja-build \
             pkg-config \
             nasm \

--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -1,0 +1,94 @@
+name: Build and Test (x86)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      # Only run this heavy workflow when C++ / build sources change
+      - 'src/**'
+      - 'test/**'
+      - 'cmake/**'
+      - '3rd/**'
+      - 'prebuild/ffmpeg/x86_64/**'
+      - 'toolchains/**'
+      - 'CMakeLists.txt'
+      - 'scripts/build_cpu_test.sh'
+      - '.github/workflows/ci-build-and-test.yml'
+  workflow_dispatch:
+
+permissions:
+  checks: write   # for dorny/test-reporter to create check runs
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── System dependencies ──────────────────────────────────────────
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            ninja-build \
+            pkg-config \
+            nasm \
+            yasm \
+            python3 \
+            zlib1g-dev
+
+      # ── Rust (required by tokenizers-cpp) ────────────────────────────
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # ── Build ────────────────────────────────────────────────────────
+      - name: Configure and build cosmo-tests (x86 CPU backend)
+        run: bash scripts/build_cpu_test.sh
+
+      # ── Run tests ────────────────────────────────────────────────────
+      # Catch2 binary writes JUnit XML for GitHub's test summary UI.
+      # LD_LIBRARY_PATH must include prebuilt .so directories and third-party
+      # ExternalProject install paths so the test binary can resolve all
+      # shared libraries at runtime.
+      - name: Run tests
+        run: |
+          export LD_LIBRARY_PATH="\
+          ${GITHUB_WORKSPACE}/prebuild/ffmpeg/x86_64/lib:\
+          ${GITHUB_WORKSPACE}/3rd/onnxruntime-linux-x64-1.26.0/lib:\
+          ${GITHUB_WORKSPACE}/build_cpu/thirdparty_install/openssl/lib:\
+          ${GITHUB_WORKSPACE}/build_cpu/thirdparty_install/curl/lib:\
+          ${GITHUB_WORKSPACE}/build_cpu/thirdparty_install/event/lib:\
+          ${GITHUB_WORKSPACE}/build_cpu/thirdparty_install/glog/lib:\
+          ${GITHUB_WORKSPACE}/build_cpu/thirdparty_install/mp4v2/lib:\
+          ${GITHUB_WORKSPACE}/build_cpu/thirdparty_install/uuid/lib:\
+          ${LD_LIBRARY_PATH}"
+          ./build_cpu/cosmo-tests -r junit -o test-results.xml
+
+      # ── Upload test results ──────────────────────────────────────────
+      - name: Upload test results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-x86
+          path: test-results.xml
+          retention-days: 7
+
+      # ── Surface test summary in GitHub UI ────────────────────────────
+      - name: Publish test results
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: Cosmo Tests (x86)
+          path: test-results.xml
+          reporter: java-junit

--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [main]
     paths:
-      # Only run this heavy workflow when C++ / build sources change
       - 'src/**'
       - 'test/**'
       - 'cmake/**'
@@ -19,7 +18,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  checks: write   # for dorny/test-reporter to create check runs
+  checks: write
   contents: read
 
 concurrency:
@@ -28,26 +27,42 @@ concurrency:
 
 jobs:
   build-and-test:
+    # Use the same base image as Dockerfile.x86 builder stage — Debian 12 / GCC 12.
+    # This keeps CI and production builds consistent.
     runs-on: ubuntu-latest
+    container:
+      image: node:20-bookworm
+
     timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
 
-      # ── System dependencies ──────────────────────────────────────────
+      # ── System dependencies (mirrors Dockerfile.x86 builder stage) ───
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            bash \
             build-essential \
+            ca-certificates \
             cmake \
+            curl \
+            file \
             g++-aarch64-linux-gnu \
-            ninja-build \
-            pkg-config \
+            git \
+            libtool \
+            make \
             nasm \
-            yasm \
+            ninja-build \
+            patch \
+            perl \
+            pkg-config \
             python3 \
+            unzip \
+            yasm \
             zlib1g-dev
+          rm -rf /var/lib/apt/lists/*
 
       # ── Rust (required by tokenizers-cpp) ────────────────────────────
       - name: Install Rust toolchain
@@ -58,10 +73,6 @@ jobs:
         run: bash scripts/build_cpu_test.sh
 
       # ── Run tests ────────────────────────────────────────────────────
-      # Catch2 binary writes JUnit XML for GitHub's test summary UI.
-      # LD_LIBRARY_PATH must include prebuilt .so directories and third-party
-      # ExternalProject install paths so the test binary can resolve all
-      # shared libraries at runtime.
       - name: Run tests
         run: |
           export LD_LIBRARY_PATH="\

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,18 +12,43 @@ concurrency:
 
 jobs:
   # ── C++ format check via clang-format ──────────────────────────────
+  # Only checks files changed in the PR (not the entire codebase)
   format-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch all history for diff against base
 
       - name: Install clang-format
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-format
 
-      - name: Check C++ formatting
-        run: bash scripts/format_check.sh --check
+      - name: Check C++ formatting (changed files only)
+        run: |
+          BASE=$(git merge-base HEAD origin/main)
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- \
+            '*.cc' '*.h' | grep -vE '(^|/)3rd/')
+          if [ -z "$CHANGED" ]; then
+            echo "No C++ files changed."
+            exit 0
+          fi
+          echo "Checking $(echo "$CHANGED" | wc -l) changed file(s)..."
+          FAIL=0
+          for f in $CHANGED; do
+            if ! diff <(clang-format "$f") "$f" > /dev/null 2>&1; then
+              echo "  ❌ $f"
+              FAIL=1
+            fi
+          done
+          if [ $FAIL -eq 0 ]; then
+            echo "✅ All changed files are properly formatted."
+          else
+            echo ""
+            echo "Run 'scripts/format_check.sh --fix' locally to auto-fix."
+            exit 1
+          fi
 
   # ── Vue 3 frontend build (includes i18n checks via prebuild hook) ──
   frontend-build:
@@ -46,16 +71,37 @@ jobs:
       - name: Build frontend
         run: npm run build
 
-  # ── cppcheck static analysis ───────────────────────────────────────
+  # ── cppcheck static analysis (changed files only) ───────────────────
   cppcheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install cppcheck
         run: |
           sudo apt-get update
           sudo apt-get install -y cppcheck
 
-      - name: Run cppcheck
-        run: bash scripts/static_analysis.sh --cppcheck
+      - name: Run cppcheck (changed files only)
+        run: |
+          BASE=$(git merge-base HEAD origin/main)
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- \
+            'src/**/*.cc' 'src/**/*.h' 'test/**/*.cc' 'test/**/*.h')
+          if [ -z "$CHANGED" ]; then
+            echo "No C++ files changed."
+            exit 0
+          fi
+          echo "Checking $(echo "$CHANGED" | wc -l) changed file(s)..."
+          cppcheck \
+            --std=c++17 \
+            --language=c++ \
+            --enable=warning,style,performance,portability \
+            --inline-suppr \
+            --suppressions-list=.cppcheck-suppressions \
+            --quiet \
+            --template='{file}:{line}: [{severity}] {id}: {message}' \
+            -I src \
+            -j"$(nproc)" \
+            $CHANGED

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,61 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  # ── C++ format check via clang-format ──────────────────────────────
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check C++ formatting
+        run: bash scripts/format_check.sh --check
+
+  # ── Vue 3 frontend build (includes i18n checks via prebuild hook) ──
+  frontend-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: src/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+  # ── cppcheck static analysis ───────────────────────────────────────
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck
+        run: bash scripts/static_analysis.sh --cppcheck

--- a/src/infer/AiCommonHelper.cc
+++ b/src/infer/AiCommonHelper.cc
@@ -5,6 +5,7 @@
 #include <codecvt>
 #include <locale>
 #include <regex>
+#include <stdexcept>
 #include <unordered_map>
 
 #include "infer/AiCommon.h"

--- a/src/nn/device/sophon/qwen3_5/qwen3_5_model.cc
+++ b/src/nn/device/sophon/qwen3_5/qwen3_5_model.cc
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 
 #include "bmlib_runtime.h"
 #include "bmruntime_interface.h"

--- a/src/nn/device/sophon/qwen3vl/qwen3vl_model.cc
+++ b/src/nn/device/sophon/qwen3vl/qwen3vl_model.cc
@@ -5,9 +5,8 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <stdexcept>
-
 #include <nlohmann/json.hpp>
+#include <stdexcept>
 
 #include "bmlib_runtime.h"
 #include "bmruntime_interface.h"

--- a/src/nn/device/sophon/qwen3vl/qwen3vl_model.cc
+++ b/src/nn/device/sophon/qwen3vl/qwen3vl_model.cc
@@ -1,11 +1,11 @@
 #include "nn/device/sophon/qwen3vl/qwen3vl_model.h"
 
 #include <assert.h>
-#include <nlohmann/json.hpp>
 
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <nlohmann/json.hpp>
 #include <stdexcept>
 
 #include "bmlib_runtime.h"
@@ -15,56 +15,56 @@ namespace cosmo::nn {
 namespace qwen3vl {
     namespace {
 
-    constexpr std::streamoff kMaxJsonFileBytes = 10 * 1024 * 1024;
+        constexpr std::streamoff kMaxJsonFileBytes = 10 * 1024 * 1024;
 
-    bool LooksLikeJsonContent(const std::string& value) {
-        const auto first = value.find_first_not_of(" \t\r\n");
-        return first != std::string::npos && (value[first] == '{' || value[first] == '[');
-    }
-
-    nlohmann::json ParseJsonFile(const std::string& path) {
-        std::ifstream in(path, std::ios::binary | std::ios::ate);
-        if (!in.good())
-            return nlohmann::json::object();
-        const auto size = in.tellg();
-        if (size < 0 || size > kMaxJsonFileBytes)
-            return nlohmann::json::object();
-        in.seekg(0, std::ios::beg);
-        auto json = nlohmann::json::parse(in, nullptr, false);
-        return json.is_discarded() || !json.is_object() ? nlohmann::json::object() : json;
-    }
-
-    nlohmann::json ParseJsonContentOrFile(const std::string& value) {
-        if (LooksLikeJsonContent(value)) {
-            auto json = nlohmann::json::parse(value, nullptr, false);
-            if (!json.is_discarded())
-                return json.is_object() ? json : nlohmann::json::object();
+        bool LooksLikeJsonContent(const std::string& value) {
+            const auto first = value.find_first_not_of(" \t\r\n");
+            return first != std::string::npos && (value[first] == '{' || value[first] == '[');
         }
-        return ParseJsonFile(value);
-    }
 
-    void ApplyGenerationConfig(const nlohmann::json& json, GenerationConfig& config) {
-        if (json.contains("eos_token_id") && json["eos_token_id"].is_array()) {
-            for (const auto& v : json["eos_token_id"]) {
-                if (v.is_number_integer())
-                    config.eos_token_id.push_back(v.get<int>());
+        nlohmann::json ParseJsonFile(const std::string& path) {
+            std::ifstream in(path, std::ios::binary | std::ios::ate);
+            if (!in.good())
+                return nlohmann::json::object();
+            const auto size = in.tellg();
+            if (size < 0 || size > kMaxJsonFileBytes)
+                return nlohmann::json::object();
+            in.seekg(0, std::ios::beg);
+            auto json = nlohmann::json::parse(in, nullptr, false);
+            return json.is_discarded() || !json.is_object() ? nlohmann::json::object() : json;
+        }
+
+        nlohmann::json ParseJsonContentOrFile(const std::string& value) {
+            if (LooksLikeJsonContent(value)) {
+                auto json = nlohmann::json::parse(value, nullptr, false);
+                if (!json.is_discarded())
+                    return json.is_object() ? json : nlohmann::json::object();
+            }
+            return ParseJsonFile(value);
+        }
+
+        void ApplyGenerationConfig(const nlohmann::json& json, GenerationConfig& config) {
+            if (json.contains("eos_token_id") && json["eos_token_id"].is_array()) {
+                for (const auto& v : json["eos_token_id"]) {
+                    if (v.is_number_integer())
+                        config.eos_token_id.push_back(v.get<int>());
+                }
+            }
+            if (json.contains("repetition_penalty") && json["repetition_penalty"].is_number())
+                config.repetition_penalty = json["repetition_penalty"].get<float>();
+            if (json.contains("temperature") && json["temperature"].is_number())
+                config.temperature = json["temperature"].get<float>();
+            if (json.contains("top_k") && json["top_k"].is_number_integer())
+                config.top_k = json["top_k"].get<int>();
+            if (json.contains("top_p") && json["top_p"].is_number())
+                config.top_p = json["top_p"].get<float>();
+            if (json.contains("stop_strings") && json["stop_strings"].is_array()) {
+                for (const auto& v : json["stop_strings"]) {
+                    if (v.is_string())
+                        config.stop_strings.push_back(v.get<std::string>());
+                }
             }
         }
-        if (json.contains("repetition_penalty") && json["repetition_penalty"].is_number())
-            config.repetition_penalty = json["repetition_penalty"].get<float>();
-        if (json.contains("temperature") && json["temperature"].is_number())
-            config.temperature = json["temperature"].get<float>();
-        if (json.contains("top_k") && json["top_k"].is_number_integer())
-            config.top_k = json["top_k"].get<int>();
-        if (json.contains("top_p") && json["top_p"].is_number())
-            config.top_p = json["top_p"].get<float>();
-        if (json.contains("stop_strings") && json["stop_strings"].is_array()) {
-            for (const auto& v : json["stop_strings"]) {
-                if (v.is_string())
-                    config.stop_strings.push_back(v.get<std::string>());
-            }
-        }
-    }
 
     }  // namespace
 
@@ -89,7 +89,7 @@ namespace qwen3vl {
 
     GenerationConfig GenerationConfig::from_model_json(const std::string& path) {
         GenerationConfig config;
-        nlohmann::json root = ParseJsonContentOrFile(path);
+        nlohmann::json root         = ParseJsonContentOrFile(path);
         const nlohmann::json* g_ptr = nullptr;
         if (root.contains("config") && root["config"].is_object() && root["config"].contains("generation") &&
             root["config"]["generation"].is_object()) {

--- a/src/nn/device/sophon/qwen3vl/qwen3vl_model.cc
+++ b/src/nn/device/sophon/qwen3vl/qwen3vl_model.cc
@@ -1,11 +1,11 @@
 #include "nn/device/sophon/qwen3vl/qwen3vl_model.h"
 
 #include <assert.h>
+#include <nlohmann/json.hpp>
 
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <nlohmann/json.hpp>
 #include <stdexcept>
 
 #include "bmlib_runtime.h"

--- a/src/nn/device/sophon/qwen3vl/qwen3vl_model.cc
+++ b/src/nn/device/sophon/qwen3vl/qwen3vl_model.cc
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 
 #include <nlohmann/json.hpp>
 

--- a/src/nn/device/sophon/sophon_net_node.cc
+++ b/src/nn/device/sophon/sophon_net_node.cc
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <iostream>
 #include <map>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/src/nn/utils/default_component.cc
+++ b/src/nn/utils/default_component.cc
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
 
 #include "nn/pipeline/model_pipeline.h"
 #include "nn/pipeline/pipeline_utils.h"

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(cosmo_service PRIVATE cosmo_common
     SQLiteCpp sqlite3 cryptopp pcap
     uWebSockets uSockets z openssl_ssl openssl_crypto
     ffmpeg_avcodec ffmpeg_avformat ffmpeg_avutil
+    event_core event_extra event
 )
 # Backend compile definitions and link libraries
 # (MemoryPoolServiceImpl needs allocator selection, HardwareQueryUtil needs device info,

--- a/src/util/CipherUtil.cc
+++ b/src/util/CipherUtil.cc
@@ -100,7 +100,7 @@ std::string EncMd5(const std::string& enc_str, bool is_upper) {
 }
 
 std::string EncFileMd5(const std::string& file_path, bool is_upper) {
-    std::string read_str = std::move(cosmo::util::ReadFile(file_path));
+    std::string read_str = cosmo::util::ReadFile(file_path);
 
     return EncMd5(read_str, is_upper);
 }

--- a/src/util/CipherUtil.h
+++ b/src/util/CipherUtil.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/test/test_model_import_exporter.cc
+++ b/test/test_model_import_exporter.cc
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "util/PathUtil.h"
+#include "util/PlatformConstants.h"
 
 // clang-format off
 #include "catch_amalgamated.hpp"
@@ -80,10 +81,11 @@ TEST_CASE("ModelImportExporter Tests", "[model]") {
                                                  bmodelFiles, "", tokenizerSrc, "", "");
         REQUIRE(res == cosmo::util::ErrorEnum::Success);
 
-        std::string expectedDir = testModelDir + "/prod_BM1688_1234567_AtomicName_V1.0.0";
+        std::string expectedDir =
+            testModelDir + "/" + std::string(cosmo::util::kPlatformDirPrefix) + "1234567_AtomicName_V1.0.0";
         REQUIRE(fs::exists(expectedDir));
         REQUIRE(fs::exists(expectedDir + "/config.json"));
-        REQUIRE(fs::exists(expectedDir + "/model.nn"));
+        REQUIRE(fs::exists(expectedDir + "/model" + std::string(cosmo::util::kModelFileExt)));
 
         nlohmann::json doc;
         REQUIRE(cosmo::util::JsonFileUtil::ReadJsonFile(expectedDir + "/config.json", doc) ==
@@ -219,7 +221,8 @@ TEST_CASE("ModelImportExporter Tests", "[model]") {
         outCfg << "{\"modelCode\": \"fake_model\", \"algorithmVersion\": \"1.0.0\"}";
         outCfg.close();
 
-        std::ofstream outNn(tempArchiveDir + "/fake_model/model.nn");
+        std::string modelFile = "model" + std::string(cosmo::util::kModelFileExt);
+        std::ofstream outNn(tempArchiveDir + "/fake_model/" + modelFile);
         outNn << "fake";
         outNn.close();
 
@@ -244,23 +247,27 @@ TEST_CASE("ModelImportExporter Tests", "[model]") {
         outCfg << "{\"modelCode\": \"flat_model\", \"algorithmVersion\": \"1.0.0\"}";
         outCfg.close();
 
-        std::ofstream outNn(tempArchiveDir + "/model.nn");
+        std::string modelFile = "model" + std::string(cosmo::util::kModelFileExt);
+        std::ofstream outNn(tempArchiveDir + "/" + modelFile);
         outNn << "fake";
         outNn.close();
 
         std::string tarFile = "/tmp/cosmo_test_models/flat_import.tar.gz";
-        std::string cmd     = "cd " + tempArchiveDir + " && tar -czf " + tarFile + " config.json model.nn";
+        std::string cmd = "cd " + tempArchiveDir + " && tar -czf " + tarFile + " config.json " + modelFile;
         (void)!system(cmd.c_str());
 
         auto res = importExporter.ImportModel(tarFile);
         REQUIRE(res == cosmo::util::ErrorEnum::Success);
 
-        // It should have created a directory named after modelCode "flat_model" or "test_gen_code" if it
-        // couldn't find modelCode Since we provided modelCode in config.json, it should be flat_model
-        REQUIRE(fs::exists(testModelDir + "/prod_BM1688_0000000_imported_V1.0.0/config.json"));
+        // ImportFlatArchive uses kPlatformDirPrefix + alg_code + "_" + name + "_" + version
+        // alg_code defaults to "0000000" (no "algorithm_code" key in config.json),
+        // name defaults to "imported", version defaults to "V1.0.0"
+        REQUIRE(fs::exists(testModelDir + "/" + std::string(cosmo::util::kPlatformDirPrefix) +
+                           "0000000_imported_V1.0.0/config.json"));
 
         fs::remove_all(tempArchiveDir);
-        fs::remove_all(testModelDir + "/prod_BM1688_0000000_imported_V1.0.0");
+        fs::remove_all(testModelDir + "/" + std::string(cosmo::util::kPlatformDirPrefix) +
+                       "0000000_imported_V1.0.0");
         fs::remove(tarFile);
     }
 

--- a/test/test_model_service_impl.cc
+++ b/test/test_model_service_impl.cc
@@ -9,6 +9,7 @@
 #include "service/model/impl/ModelServiceImpl.h"
 #include "util/FileUtil.h"
 #include "util/PathUtil.h"
+#include "util/PlatformConstants.h"
 
 using namespace cosmo::service;
 using namespace cosmo;
@@ -16,7 +17,8 @@ using namespace cosmo;
 // Helper: create a minimal model directory with config.json on disk
 static void CreateTestModelOnDisk(const std::string& modelsDir, const std::string& modelCode,
                                   const std::string& modelName) {
-    std::string dirName  = "prod_BM1688_" + modelCode + "_" + modelName + "_V1.0.0";
+    std::string dirName =
+        std::string(cosmo::util::kPlatformDirPrefix) + modelCode + "_" + modelName + "_V1.0.0";
     std::string modelDir = (std::filesystem::path(modelsDir) / dirName).string();
     std::filesystem::create_directories(modelDir);
 
@@ -103,8 +105,9 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
                 .RETURN(std::vector<std::string>{});
             ALLOW_CALL(mocks.cameraSvc, NotifyAlgorithmsChanged(trompeloeil::_, false));
             REQUIRE(sut.DeleteModel("test_model_001") == cosmo::util::ErrorEnum::Success);
-            REQUIRE(std::filesystem::exists(testModelsDir + "/prod_BM1688_test_model_001_TestModel_V1.0.0") ==
-                    false);
+            REQUIRE(std::filesystem::exists(testModelsDir + "/" +
+                                            std::string(cosmo::util::kPlatformDirPrefix) +
+                                            "test_model_001_TestModel_V1.0.0") == false);
         }
 
         SECTION("UpdateModel 流程") {


### PR DESCRIPTION
Add two GitHub Actions CI workflows for automated quality checks and
x86 build-and-test CI.

### pr-checks.yml

Runs on every PR push to main. Three parallel jobs:
- format-check — clang-format C++ style check
- frontend-build — Vue 3 Vite build (includes i18n checks)
- cppcheck — static analysis

### ci-build-and-test.yml

Runs on PR/push when C++ or build sources change:
- Install build deps + Rust toolchain
- CMake configure + build cosmo-tests (x86 CPU/ONNX backend)
- Run Catch2 tests, upload JUnit XML, surface results in GitHub UI

The build-and-test workflow file is named `ci-build-and-test.yml` to avoid
the `build-*` gitignore pattern.

## Type of change

- [ ] Bug fix
- [x] Build / deployment
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test

## Area

- [x] Build / deployment
- [ ] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [ ] Documentation

## Verification

```text
Workflow files validated against GitHub Actions schema locally.
Full verification will happen when the PR triggers the workflows on GitHub Actions.
```

## Documentation impact

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] Not applicable.
- [ ] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [ ] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [ ] Documentation was updated if behavior changed.
- [ ] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
