### PR TITLE
 fix(event): guard null string_view in websocket close callback

### DIFF
--- a/src/service/event/impl/EventNotifierImpl.cc
+++ b/src/service/event/impl/EventNotifierImpl.cc
@@ -105,7 +105,8 @@ void EventNotifierImpl::InitWebSocketServer(const std::function<void(std::string
          [](auto*) { LOG_INFO("{}", "Websocket message - PONG"); },
          // close
          [this](auto* closed_ws, int code, std::string_view message) {
-             LOG_INFO("A websocket disconnect, code:{}, message: \"{}\"", code, message);
+             LOG_INFO("A websocket disconnect, code:{}, message: \"{}\"", code,
+                      message.data() ? message : std::string_view{});
              std::lock_guard<std::mutex> lock(ws_mtx_);
              for (auto& it_map : ws_connections_) {
                  auto it_vec = find(it_map.second.begin(), it_map.second.end(), closed_ws);


### PR DESCRIPTION
## 变更说明

修复 GCC 静态分析器报告的 `-Wnull-dereference` 警告。

### 问题
CI 构建中 `EventNotifierImpl.cc:107` 处 GCC 报告潜在空指针解引用：
warning: potential null pointer dereference [-Wnull-dereference]
  [this](auto* closed_ws, int code, std::string_view message) {

### 根因
Lambda 被 `fu2::function` 包装进行类型擦除，GCC 静态分析器推断 `std::string_view message` 参数可能由空指针构造（C++17 中 `std::string_view{nullptr}` 是未定义行为）。

### 修复
对 `message.data()` 添加空指针检查：
```cpp
LOG_INFO("A websocket disconnect, code:{}, message: \"{}\"", code,
         message.data() ? message : std::string_view{});
```
