### PR TITLE
fix(ci): pin frontend node to 22 to match build image npm 10

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -65,7 +65,11 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          # Node 22 LTS ships npm 10, matching the build image used for
+          # production frontend builds. Node 24 ships npm 11, whose stricter
+          # lockfile validation rejects the npm 10-generated lockfile and
+          # would test a different dependency resolution than what ships.
+          node-version: 22
           cache: npm
           cache-dependency-path: src/web/package-lock.json
 


### PR DESCRIPTION
## 背景

`.github/workflows/pr-checks.yml` 的 `frontend-build` job 使用 node 24(自带 npm 11)执行 `npm ci`,而生产编译镜像使用 npm 10。npm 11 对 lockfile 的严格校验会拒绝按 npm 10 维护的 `src/web/package-lock.json`,导致 CI 误报失败(此前 PR #5 的 `frontend-build` 失败即同因)。

## 修改

将 `actions/setup-node` 的 `node-version` 由 `24` 改为 `22`。Node 22 LTS 自带 npm 10,与编译镜像完全一致 —— CI 校验的就是生产构建实际使用的依赖解析。lockfile 不变。

```diff
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
```

## 取舍

- ❌ 修 lockfile 适配 npm 11:编译镜像仍是 npm 10,构建 npm 11 生成的 lockfile 存在解析不一致风险
- ❌ 两端都升 npm 11:需改动构建镜像,改动面最大
- ✅ **对齐到 npm 10(Node 22)**:最小改动,CI 与生产构建同版本
