### PR TITLE
feat: enhance scenario-bench reporting and adjust VLM hardware fuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -523,3 +523,12 @@ docs/.vitepress/dist/
 !3rd/onnxruntime-linux-x64-1.26.0/lib/
 !3rd/onnxruntime-linux-x64-1.26.0/lib/*
 test/video/demo.mp4
+
+# Local video assets generated or copied for manual benchmark runs.
+*.mp4
+*.avi
+*.mov
+*.mkv
+*.webm
+*.flv
+*.m4v

--- a/tools/scenario-bench/.gitignore
+++ b/tools/scenario-bench/.gitignore
@@ -14,5 +14,9 @@ reports/
 *.partial.json
 
 # Local scenario experiments: keep only committed reference scenarios under
-# scenarios/. Any local-only scratch dir is ignored via the rules above
-# (they only contain videos/configs already covered).
+# scenarios/. Run-specific material from manual benchmark sessions should stay
+# local and out of the project tree.
+scenarios/local-*/
+scenarios/tmp-*/
+scenarios/scratch-*/
+scenarios/mixed-helmet-intrusion-20260703/

--- a/tools/scenario-bench/README.md
+++ b/tools/scenario-bench/README.md
@@ -215,6 +215,38 @@ thresholds:
 
 报告会同时输出整体容量结论和分任务汇总。整体容量仍表示“该 workload 在当前判定阈值下可稳定支撑的最大通道数”；分任务汇总用于定位多任务压测中是哪一个任务先成为瓶颈。
 
+### 任务策略与 VLM
+
+`tasks[].type` 会选择不同的判定策略：
+
+| type | 策略 | 默认判定口径 |
+| --- | --- | --- |
+| `cv` | 传统视觉算法 | 检测/关键链路延时、丢弃率；运行期 FPS 熔断使用 1 路基线折半 |
+| `vlm` | 视觉语言模型分析 | 分析 FPS 达标率、采样缺失率、可选端到端延时；运行期不使用基线折半 |
+
+VLM 任务必须显式给出 `targetFps`，例如 0.2fps：
+
+```yaml
+tasks:
+  - id: vlm
+    displayName: 0.8B VLM 分析
+    type: vlm
+    algorithmId: "12345"
+    scheduleId: "e89c6c6385e5454b35cde0d1653vg"
+    template: vlm-template.json
+    targetFps: 0.2
+
+thresholds:
+  taskTypes:
+    vlm:
+      minFpsRatio: 0.8
+      maxMissingRate: 0
+      maxEndToEndLatencyMs: 30000
+      avgDiscardRate: 0.05
+```
+
+阈值合并顺序为：策略默认值 -> `thresholds.pass` -> `thresholds.taskTypes.<type>` 或 `thresholds.strategies.<type>` -> `thresholds.tasks.<taskId>`。因此可以在同一个 workload 内让 CV 和 VLM 使用不同规则。VLM 不会继承全局 `maxDetectorLatencyMs`、`maxCriticalPathLatencyMs`、`maxAvgNodeLatencyMs`，端到端延时需要在 `taskTypes.vlm` 或 `tasks.<taskId>` 下显式配置。
+
 ## 命令说明
 
 ### `doctor`

--- a/tools/scenario-bench/src/cli.js
+++ b/tools/scenario-bench/src/cli.js
@@ -486,7 +486,7 @@ async function runBenchmark(args) {
       if (mem98Count >= 3) reasons.push(`memory >= 98% for ${mem98Count} consecutive samples`);
       if (memAvg60s != null && memAvg60s >= 95) reasons.push(`memory 60s average ${memAvg60s.toFixed(1)}% >= 95%`);
       if (cpu98Count >= 3) reasons.push(`CPU >= 98% for ${cpu98Count} consecutive samples`);
-      if (npu98Count >= 3) reasons.push(`NPU >= 98% for ${npu98Count} consecutive samples`);
+      // if (npu98Count >= 3) reasons.push(`NPU >= 98% for ${npu98Count} consecutive samples`);
       if (discardCount >= 2) reasons.push(`discardRate > ${DISCARD_BOTTLENECK} for ${discardCount} consecutive samples`);
       return reasons.length ? { stop: true, reason: reasons.join('; ') } : { stop: false };
     };

--- a/tools/scenario-bench/src/cli.js
+++ b/tools/scenario-bench/src/cli.js
@@ -10,6 +10,7 @@ import { TaskRunner } from './task-runner.js';
 import { MetricsSampler } from './metrics-sampler.js';
 import { ReportWriter } from './report-writer.js';
 import { Logger } from './logger.js';
+import { normalizeTaskType, resolveTaskThresholds, strategyForTaskType } from './task-strategies.js';
 
 function parseArgs(argv) {
   const args = {};
@@ -105,6 +106,7 @@ async function runDoctor(args) {
     checkLine(true, 'scenario package loaded', path.resolve(args.scenario));
     checkLine(true, 'workload version', pkg.version);
     checkLine(true, 'tasks', pkg.tasks.map((t) => `${t.id}:${t.algorithmId}(${t.type})`).join(', '));
+    checkLine(true, 'task strategies', pkg.tasks.map((t) => `${t.id}=${strategyForTaskType(t.type).id}`).join(', '));
     checkLine(true, 'target FPS', pkg.tasks.map((t) => `${t.id}=${t.targetFps ?? 'N/A'}`).join(', '));
     checkLine(true, 'video mode', pkg.videoMode);
     checkLine(true, 'load profile', pkg.loadProfile.map((s) => `${s.channels}ch/${s.holdSec}s`).join(' -> '));
@@ -295,6 +297,7 @@ async function runBenchmark(args) {
   let channelMgr = null;
   const samples = [];
   let baselineFps = null;
+  const baselineByTask = {};
   let bottleneckStep = null;
   let bottleneckReason = null;
   let runError = null;
@@ -337,6 +340,7 @@ async function runBenchmark(args) {
       ? { stepIndex: bottleneckStep, stepNumber: bottleneckStep + 1, channels: effectiveLoadProfile?.[bottleneckStep]?.channels, reason: bottleneckReason }
       : null,
     baselineFps,
+    baselineByTask,
     startedAt,
     endedAt: new Date().toISOString(),
     samples,
@@ -408,16 +412,18 @@ async function runBenchmark(args) {
 
     const sampler = new MetricsSampler(client, log);
     const activeEntries = () => runner.expectedTaskEntries(runner.allChannelIds.slice(0, currentChannels));
+    const taskById = new Map(pkg.tasks.map((task) => [task.id, task]));
 
     const FPS_HALVE_RATIO = 0.5;
     const DISCARD_BOTTLENECK = 0.05;
 
     const summarizeSamples = (stepIdx) => {
       const all = samples.filter((s) => s.stepIndex === stepIdx && !s.channels.every((c) => c.missing));
-      if (!all.length) return { minFps: null, meanDiscard: null, maxNpu: null, maxCpu: null };
+      if (!all.length) return { minFps: null, meanDiscard: null, maxNpu: null, maxCpu: null, taskStats: [] };
       const steady = all.slice(Math.floor(all.length / 2));
       let minFps = Infinity, maxNpu = -Infinity, maxCpu = -Infinity;
       const discardValues = [];
+      const byTask = new Map();
       for (const t of steady) {
         const npu = t.hardware?.npuUtilization?.usedPercent;
         const cpu = t.hardware?.cpuUtilization?.usedPercent;
@@ -425,15 +431,44 @@ async function runBenchmark(args) {
         if (typeof cpu === 'number' && cpu > maxCpu) maxCpu = cpu;
         for (const ch of t.channels) {
           if (ch.missing) continue;
+          const taskKey = ch.taskKey ?? 'default';
+          if (!byTask.has(taskKey)) {
+            const task = taskById.get(taskKey) ?? {};
+            byTask.set(taskKey, {
+              taskKey,
+              taskDisplayName: ch.taskDisplayName ?? task.displayName ?? taskKey,
+              taskType: normalizeTaskType(ch.taskType ?? task.type),
+              targetFps: ch.targetFps ?? task.targetFps ?? null,
+              fps: [],
+              fpsRatio: [],
+              discard: [],
+            });
+          }
+          const stat = byTask.get(taskKey);
           if (typeof ch.measuredFps === 'number' && ch.measuredFps < minFps) minFps = ch.measuredFps;
-          if (typeof ch.discardRate === 'number') discardValues.push(ch.discardRate);
+          if (typeof ch.measuredFps === 'number') stat.fps.push(ch.measuredFps);
+          if (typeof ch.fpsRatio === 'number') stat.fpsRatio.push(ch.fpsRatio);
+          if (typeof ch.discardRate === 'number') {
+            discardValues.push(ch.discardRate);
+            stat.discard.push(ch.discardRate);
+          }
         }
       }
+      const taskStats = [...byTask.values()].map((stat) => ({
+        taskKey: stat.taskKey,
+        taskDisplayName: stat.taskDisplayName,
+        taskType: stat.taskType,
+        targetFps: stat.targetFps,
+        minFps: stat.fps.length ? Math.min(...stat.fps) : null,
+        minFpsRatio: stat.fpsRatio.length ? Math.min(...stat.fpsRatio) : null,
+        meanDiscard: stat.discard.length ? stat.discard.reduce((a, b) => a + b, 0) / stat.discard.length : null,
+      }));
       return {
         minFps: minFps === Infinity ? null : minFps,
         meanDiscard: discardValues.length ? discardValues.reduce((a, b) => a + b, 0) / discardValues.length : null,
         maxNpu: maxNpu === -Infinity ? null : maxNpu,
         maxCpu: maxCpu === -Infinity ? null : maxCpu,
+        taskStats,
       };
     };
 
@@ -505,16 +540,40 @@ async function runBenchmark(args) {
         await captureSample();
       },
       onStepEnd: async (step) => {
-        const { minFps, meanDiscard, maxNpu, maxCpu } = summarizeSamples(step.index);
+        const { minFps, meanDiscard, maxNpu, maxCpu, taskStats } = summarizeSamples(step.index);
         const sat = `npu=${maxNpu ?? '-'}% cpu=${maxCpu ?? '-'}%`;
         if (step.index === 0) {
           baselineFps = minFps ?? null;
-          log.info(`[baseline] step 1 steady minFps=${baselineFps} fps (${sat}) -> gate at fps<${baselineFps == null ? '-' : (baselineFps * FPS_HALVE_RATIO).toFixed(1)} or meanDiscard>${DISCARD_BOTTLENECK}`);
+          for (const stat of taskStats) {
+            baselineByTask[stat.taskKey] = stat.minFps;
+          }
+          const baselineText = taskStats
+            .map((stat) => `${stat.taskKey}=${stat.minFps == null ? '-' : stat.minFps.toFixed(2)}fps`)
+            .join(', ');
+          log.info(`[baseline] step 1 steady minFps=${baselineFps} fps (${sat}) tasks=[${baselineText}] -> strategy gates active`);
           return;
         }
         const reasons = [];
-        if (baselineFps != null && minFps != null && minFps < baselineFps * FPS_HALVE_RATIO) {
-          reasons.push(`fps ${minFps.toFixed(1)} < baseline ${baselineFps.toFixed(1)}*${FPS_HALVE_RATIO} (${(baselineFps * FPS_HALVE_RATIO).toFixed(1)})`);
+        for (const stat of taskStats) {
+          const strategy = strategyForTaskType(stat.taskType);
+          const taskThresholds = resolveTaskThresholds(pkg.thresholds, {
+            taskKey: stat.taskKey,
+            taskType: stat.taskType,
+          });
+          if (strategy.useBaselineFpsFuse) {
+            const taskBaseline = baselineByTask[stat.taskKey];
+            if (taskBaseline != null && stat.minFps != null && stat.minFps < taskBaseline * FPS_HALVE_RATIO) {
+              reasons.push(`${stat.taskKey} fps ${stat.minFps.toFixed(1)} < baseline ${taskBaseline.toFixed(1)}*${FPS_HALVE_RATIO} (${(taskBaseline * FPS_HALVE_RATIO).toFixed(1)})`);
+            }
+          } else if (taskThresholds.minFpsRatio != null && stat.minFpsRatio != null && stat.minFpsRatio < taskThresholds.minFpsRatio) {
+            reasons.push(`${stat.taskKey} fpsRatio ${stat.minFpsRatio.toFixed(3)} < ${taskThresholds.minFpsRatio}`);
+          } else if (taskThresholds.minThroughputFps != null && stat.minFps != null && stat.minFps < taskThresholds.minThroughputFps) {
+            reasons.push(`${stat.taskKey} fps ${stat.minFps.toFixed(2)} < ${taskThresholds.minThroughputFps}`);
+          }
+          const discardLimit = taskThresholds.avgDiscardRate ?? taskThresholds.maxDiscardRate ?? DISCARD_BOTTLENECK;
+          if (stat.meanDiscard != null && stat.meanDiscard > discardLimit) {
+            reasons.push(`${stat.taskKey} meanDiscard ${stat.meanDiscard.toFixed(3)} > ${discardLimit}`);
+          }
         }
         if (meanDiscard != null && meanDiscard > DISCARD_BOTTLENECK) {
           reasons.push(`meanDiscard ${meanDiscard.toFixed(3)} > ${DISCARD_BOTTLENECK}`);

--- a/tools/scenario-bench/src/metrics-sampler.js
+++ b/tools/scenario-bench/src/metrics-sampler.js
@@ -1,4 +1,5 @@
 // metrics-sampler.js — Collect RunningDetail + HardwareResource each tick.
+import { isPrimaryThroughputAction } from './task-strategies.js';
 //
 // Response shapes (verified against source DTOs):
 //   RunningDetail: resData.status[] where each item has
@@ -93,7 +94,7 @@ export class MetricsSampler {
       }
       out.push({
         ...entry,
-        ...this._summarizeTask(st, entry.targetFps),
+        ...this._summarizeTask(st, entry.targetFps, entry.taskType),
         taskKey: entry.taskKey,
         taskDisplayName: entry.taskDisplayName,
         taskType: entry.taskType,
@@ -109,7 +110,7 @@ export class MetricsSampler {
    * FPS uses the slowest effective action rate instead of summing pipeline nodes,
    * otherwise multi-node graphs overcount the channel throughput.
    */
-  _summarizeTask(st, targetFps) {
+  _summarizeTask(st, targetFps, taskType) {
     const actions = Array.isArray(st.actionStatus) ? st.actionStatus : [];
     let insertPeriod = 0, processPeriod = 0, discardPeriod = 0;
     let periodMs = 0, holdCount = 0, alarmCount = 0;
@@ -150,7 +151,7 @@ export class MetricsSampler {
 
       if (actionFps != null && actionProcessPeriod > 0) {
         pipelineMinFps = Math.min(pipelineMinFps, actionFps);
-        if (primaryFps == null && isPrimaryThroughputAction(actionName, actionId)) {
+        if (primaryFps == null && isPrimaryThroughputAction(actionName, actionId, taskType)) {
           primaryFps = actionFps;
         }
       }
@@ -176,6 +177,7 @@ export class MetricsSampler {
       algorithmVersion: st.algorithmVersion,
       actionCount: actions.length,
       measuredFps: round(measuredFps, 2),
+      throughputFps: round(measuredFps, 2),
       pipelineMinFps: round(minPipelineFps, 2),
       targetFps,
       fpsRatio: fpsRatio != null ? round(fpsRatio, 3) : null,
@@ -244,13 +246,4 @@ function normalizeExpectedBindings(expectedBindings, legacyTargetFps) {
     channelId: entry.channelId,
     taskId: entry.taskId,
   }));
-}
-
-function isPrimaryThroughputAction(name, actionId) {
-  const n = String(name).toLowerCase();
-  const id = String(actionId);
-  return n.includes('aidetector')
-    || n.includes('detector')
-    || n.includes('检测')
-    || id.startsWith('1001');
 }

--- a/tools/scenario-bench/src/report-writer.js
+++ b/tools/scenario-bench/src/report-writer.js
@@ -186,13 +186,7 @@ export class ReportWriter {
 
   _buildSummary(r, stepSummaries) {
     const ran = stepSummaries.filter((s) => !s.skipped);
-    const passed = ran.filter((s) => s.pass);
     const firstFailed = ran.find((s) => s.pass === false) ?? null;
-    const maxVerifiedPassedChannels = passed.length ? Math.max(...passed.map((s) => s.channels)) : null;
-    const continuousProfile = r.profileMode === 'capacity' || isContinuousChannelProfile(stepSummaries);
-    const maxStableChannels = continuousProfile ? maxVerifiedPassedChannels : null;
-    const overallPass = r.status !== 'aborted' && ran.length > 0 && 
-      (r.profileMode === 'capacity' ? maxVerifiedPassedChannels > 0 : ran.every((s) => s.pass));
     const bottleneck = r.bottleneck ?? (firstFailed
       ? {
           stepIndex: firstFailed.step.index,
@@ -201,6 +195,21 @@ export class ReportWriter {
           reason: firstFailed.reasons.join('; '),
         }
       : null);
+    const hasBottleneck = Boolean(bottleneck);
+    const verifiedPassed = ran.filter((s) =>
+      s.pass && (!hasBottleneck || s.step.index < bottleneck.stepIndex),
+    );
+    const maxVerifiedPassedChannels = verifiedPassed.length
+      ? Math.max(...verifiedPassed.map((s) => s.channels))
+      : null;
+    const continuousProfile = r.profileMode === 'capacity' || isContinuousChannelProfile(stepSummaries);
+    const maxStableChannels = continuousProfile ? maxVerifiedPassedChannels : null;
+    const allRanStepsPass = ran.length > 0 && ran.every((s) => s.pass);
+    const capacityMeasured = r.status !== 'aborted'
+      && continuousProfile
+      && maxVerifiedPassedChannels != null
+      && (hasBottleneck || allRanStepsPass);
+    const overallPass = r.status !== 'aborted' && allRanStepsPass && !hasBottleneck;
 
     let conclusion;
     if (r.status === 'aborted') {
@@ -231,6 +240,9 @@ export class ReportWriter {
       profileMode: r.profileMode ?? 'configured',
       status: r.status,
       overallPass,
+      allRanStepsPass,
+      hasBottleneck,
+      capacityMeasured,
       conclusion,
       maxStableChannels,
       maxStableChannelsExact: continuousProfile,
@@ -292,7 +304,18 @@ export class ReportWriter {
       ? `<div class="banner error"><strong>压测中断（部分报告）</strong><br>运行到 ${r.error?.atChannels ?? '?'} 路 / 第 ${r.error?.atStepIndex != null ? r.error.atStepIndex + 1 : '?'} 阶段时中断。原因：${esc(r.error?.message ?? '未知错误')}</div>`
       : '';
 
-    const stepRows = stepSummaries.map((s) => `
+    const runBadge = summary.hasBottleneck
+      ? { className: 'warn', label: 'STOPPED' }
+      : (summary.overallPass ? { className: 'pass', label: 'PASS' } : { className: 'fail', label: 'FAIL' });
+    const stepStatus = (s) => {
+      if (s.skipped) return { className: 'na', label: 'SKIP' };
+      if (summary.bottleneck?.stepIndex === s.step.index) return { className: 'warn', label: 'STOPPED' };
+      return s.pass ? { className: 'pass', label: 'PASS' } : { className: 'fail', label: 'FAIL' };
+    };
+
+    const stepRows = stepSummaries.map((s) => {
+      const status = stepStatus(s);
+      return `
       <tr>
         <td>${s.step.index + 1}</td>
         <td>${s.channels}</td>
@@ -306,9 +329,10 @@ export class ReportWriter {
         <td class="${s.maxNpu >= 90 ? 'fail' : ''}">${s.maxNpu != null ? s.maxNpu + '%' : '-'}</td>
         <td class="${s.maxCpu >= 90 ? 'fail' : ''}">${s.maxCpu != null ? s.maxCpu + '%' : '-'}</td>
         <td class="${s.maxMem >= 90 ? 'fail' : ''}">${s.maxMem != null ? s.maxMem + '%' : '-'}</td>
-        <td class="${s.skipped ? 'na' : (s.pass ? 'pass' : (summary.bottleneck?.stepIndex === s.step.index ? 'warn' : 'fail'))}">${s.skipped ? 'SKIP' : (s.pass ? 'PASS' : (summary.bottleneck?.stepIndex === s.step.index ? 'STOPPED' : 'FAIL'))}</td>
+        <td class="${status.className}">${status.label}</td>
         <td>${esc((s.reasons ?? []).join('; '))}</td>
-      </tr>`).join('');
+      </tr>`;
+    }).join('');
 
     const verdictRows = stepSummaries.flatMap((s) =>
       s.perThreshold.map((t) => `
@@ -347,13 +371,13 @@ export class ReportWriter {
   th{background:#f5f5f5}.pass{color:#16a34a;font-weight:600}
   .fail{color:#dc2626;font-weight:600}.na{color:#888}
   .badge{display:inline-block;padding:4px 12px;border-radius:4px;color:#fff;font-weight:600}
-  .badge.pass{background:#16a34a}.badge.fail{background:#dc2626}
+  .badge.pass{background:#16a34a}.badge.fail{background:#dc2626}.badge.warn{background:#f59e0b}
   .summary{background:#f8fafc;border:1px solid #cbd5e1;padding:12px 14px;border-radius:4px;margin:12px 0}
   .banner{padding:10px 14px;border-radius:4px;margin:12px 0}.warn{background:#fef3c7;border:1px solid #f59e0b}.error{background:#fee2e2;border:1px solid #dc2626}
   .note-table th{width:140px}
 </style></head><body>
 <h1>压测报告</h1>
-<p>总体结果: <span class="badge ${summary.overallPass ? 'pass' : 'fail'}">${summary.overallPass ? 'PASS' : 'FAIL'}</span>${r.status === 'aborted' ? ' <span class="badge fail">ABORTED</span>' : ''}</p>
+<p>总体结果: <span class="badge ${runBadge.className}">${runBadge.label}</span>${r.status === 'aborted' ? ' <span class="badge fail">ABORTED</span>' : ''}</p>
 <div class="summary"><strong>结论</strong><br>${esc(summary.conclusion)}</div>
 ${abortedBanner}
 ${bottleneckBanner}

--- a/tools/scenario-bench/src/report-writer.js
+++ b/tools/scenario-bench/src/report-writer.js
@@ -191,7 +191,8 @@ export class ReportWriter {
     const maxVerifiedPassedChannels = passed.length ? Math.max(...passed.map((s) => s.channels)) : null;
     const continuousProfile = r.profileMode === 'capacity' || isContinuousChannelProfile(stepSummaries);
     const maxStableChannels = continuousProfile ? maxVerifiedPassedChannels : null;
-    const overallPass = r.status !== 'aborted' && ran.length > 0 && ran.every((s) => s.pass);
+    const overallPass = r.status !== 'aborted' && ran.length > 0 && 
+      (r.profileMode === 'capacity' ? maxVerifiedPassedChannels > 0 : ran.every((s) => s.pass));
     const bottleneck = r.bottleneck ?? (firstFailed
       ? {
           stepIndex: firstFailed.step.index,
@@ -305,7 +306,7 @@ export class ReportWriter {
         <td class="${s.maxNpu >= 90 ? 'fail' : ''}">${s.maxNpu != null ? s.maxNpu + '%' : '-'}</td>
         <td class="${s.maxCpu >= 90 ? 'fail' : ''}">${s.maxCpu != null ? s.maxCpu + '%' : '-'}</td>
         <td class="${s.maxMem >= 90 ? 'fail' : ''}">${s.maxMem != null ? s.maxMem + '%' : '-'}</td>
-        <td class="${s.skipped ? 'na' : (s.pass ? 'pass' : 'fail')}">${s.skipped ? 'SKIP' : (s.pass ? 'PASS' : 'FAIL')}</td>
+        <td class="${s.skipped ? 'na' : (s.pass ? 'pass' : (summary.bottleneck?.stepIndex === s.step.index ? 'warn' : 'fail'))}">${s.skipped ? 'SKIP' : (s.pass ? 'PASS' : (summary.bottleneck?.stepIndex === s.step.index ? 'STOPPED' : 'FAIL'))}</td>
         <td>${esc((s.reasons ?? []).join('; '))}</td>
       </tr>`).join('');
 

--- a/tools/scenario-bench/src/report-writer.js
+++ b/tools/scenario-bench/src/report-writer.js
@@ -2,6 +2,13 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  evaluateTaskStat,
+  latencyMetricsForNodes,
+  strategyForTask,
+  strategyForTaskType,
+  thresholdLabel,
+} from './task-strategies.js';
 
 export class ReportWriter {
   constructor(outputDir) {
@@ -65,7 +72,6 @@ export class ReportWriter {
     const byBinding = new Map();
     for (const t of ticks) {
       for (const ch of t.channels ?? []) {
-        if (ch.missing) continue;
         const taskKey = ch.taskKey ?? 'default';
         const key = `${taskKey}::${ch.channelId}`;
         if (!byBinding.has(key)) {
@@ -75,22 +81,34 @@ export class ReportWriter {
             taskType: ch.taskType ?? 'cv',
             algorithmId: ch.algorithmId ?? null,
             channelId: ch.channelId,
+            targetFps: ch.targetFps ?? null,
             fps: [],
             pipelineMinFps: [],
+            fpsRatio: [],
             discardRate: [],
-            detectorLat: [],
+            primaryLat: [],
             criticalLat: [],
+            sampleCount: 0,
+            missingSamples: 0,
           });
         }
         const s = byBinding.get(key);
+        s.sampleCount++;
+        if (ch.missing) {
+          s.missingSamples++;
+          continue;
+        }
         if (typeof ch.measuredFps === 'number') s.fps.push(ch.measuredFps);
         if (typeof ch.pipelineMinFps === 'number') s.pipelineMinFps.push(ch.pipelineMinFps);
+        if (typeof ch.fpsRatio === 'number') s.fpsRatio.push(ch.fpsRatio);
         if (typeof ch.discardRate === 'number') s.discardRate.push(ch.discardRate);
 
-        const detectorMs = detectorLatencyMs(ch.nodeDurationInfos ?? []);
-        const criticalMs = criticalPathLatencyMs(ch.nodeDurationInfos ?? []);
-        if (detectorMs != null) s.detectorLat.push(detectorMs);
-        if (criticalMs != null) s.criticalLat.push(criticalMs);
+        const { primaryLatencyMs, criticalPathLatencyMs } = latencyMetricsForNodes(
+          ch.nodeDurationInfos ?? [],
+          s.taskType,
+        );
+        if (primaryLatencyMs != null) s.primaryLat.push(primaryLatencyMs);
+        if (criticalPathLatencyMs != null) s.criticalLat.push(criticalPathLatencyMs);
       }
     }
 
@@ -100,29 +118,35 @@ export class ReportWriter {
       taskType: s.taskType,
       algorithmId: s.algorithmId,
       channelId: s.channelId,
+      targetFps: s.targetFps,
+      sampleCount: s.sampleCount,
+      missingSamples: s.missingSamples,
+      missingRate: s.sampleCount ? round(s.missingSamples / s.sampleCount, 4) : null,
+      avgThroughputFps: s.fps.length ? round(mean(s.fps), 2) : null,
+      minThroughputFps: s.fps.length ? round(Math.min(...s.fps), 2) : null,
       avgDetectorFps: s.fps.length ? round(mean(s.fps), 2) : null,
       minDetectorFps: s.fps.length ? round(Math.min(...s.fps), 2) : null,
+      minFpsRatio: s.fpsRatio.length ? round(Math.min(...s.fpsRatio), 3) : null,
       minPipelineFps: s.pipelineMinFps.length ? round(Math.min(...s.pipelineMinFps), 2) : null,
       avgDiscardRate: s.discardRate.length ? round(mean(s.discardRate), 4) : null,
-      avgDetectorLatencyMs: s.detectorLat.length ? round(mean(s.detectorLat), 1) : null,
+      avgPrimaryLatencyMs: s.primaryLat.length ? round(mean(s.primaryLat), 1) : null,
+      avgDetectorLatencyMs: s.primaryLat.length ? round(mean(s.primaryLat), 1) : null,
       avgCriticalPathLatencyMs: s.criticalLat.length ? round(mean(s.criticalLat), 1) : null,
     }));
 
-    const allDetectorFps = channelStats.flatMap((c) => [c.avgDetectorFps, c.minDetectorFps]).filter((v) => v != null);
+    const allThroughputFps = channelStats
+      .flatMap((c) => [c.avgThroughputFps, c.minThroughputFps])
+      .filter((v) => v != null);
     const allDiscard = channelStats.map((c) => c.avgDiscardRate).filter((v) => v != null);
-    const allDetectorLat = channelStats.map((c) => c.avgDetectorLatencyMs).filter((v) => v != null);
+    const allPrimaryLat = channelStats.map((c) => c.avgPrimaryLatencyMs).filter((v) => v != null);
     const allCriticalLat = channelStats.map((c) => c.avgCriticalPathLatencyMs).filter((v) => v != null);
 
-    const targetFpsValues = [...new Set(channelStats.map((c) => c.taskKey)
-      .flatMap((taskKey) => ticks.flatMap((t) => (t.channels ?? [])
-        .filter((ch) => (ch.taskKey ?? 'default') === taskKey)
-        .map((ch) => ch.targetFps)
-        .filter((v) => v != null))))];
+    const targetFpsValues = [...new Set(channelStats.map((c) => c.targetFps).filter((v) => v != null))];
     const targetFps = targetFpsValues.length <= 1 ? (targetFpsValues[0] ?? null) : targetFpsValues.join(' / ');
-    const minFpsAcross = allDetectorFps.length ? Math.min(...allDetectorFps) : null;
+    const minFpsAcross = allThroughputFps.length ? Math.min(...allThroughputFps) : null;
     const maxDiscard = allDiscard.length ? Math.max(...allDiscard) : null;
     const avgDiscard = allDiscard.length ? round(mean(allDiscard), 4) : null;
-    const maxDetectorLat = allDetectorLat.length ? Math.max(...allDetectorLat) : null;
+    const maxPrimaryLat = allPrimaryLat.length ? Math.max(...allPrimaryLat) : null;
     const maxCriticalLat = allCriticalLat.length ? Math.max(...allCriticalLat) : null;
 
     const pktDiscard = ticks
@@ -141,26 +165,33 @@ export class ReportWriter {
     const taskStats = summarizeTasks(channelStats);
 
     const perThreshold = [];
-    const pass = thresholds.pass ?? {};
     const overall = { pass: true, reasons: [] };
-    const check = (name, actual, op, limit) => {
-      if (actual == null || limit == null) {
-        perThreshold.push({ name, threshold: limit, actual: null, result: 'N/A' });
-        return;
+    for (const stat of taskStats) {
+      const verdict = evaluateTaskStat(stat, thresholds);
+      perThreshold.push(...verdict.checks);
+      if (!verdict.pass) {
+        overall.pass = false;
+        overall.reasons.push(...verdict.reasons);
       }
-      const ok = op === '>=' ? actual >= limit : actual <= limit;
-      perThreshold.push({ name, threshold: limit, actual, result: ok ? 'PASS' : 'FAIL' });
+    }
+    if (videoMode !== 'local') {
+      const pass = thresholds.pass ?? {};
+      const limit = pass.maxPacketDiscardRate;
+      const ok = maxPktDiscard == null || limit == null || maxPktDiscard <= limit;
+      perThreshold.push({
+        taskKey: '*',
+        taskDisplayName: 'network',
+        taskType: 'input',
+        strategy: 'input',
+        name: 'maxPacketDiscardRate',
+        threshold: limit,
+        actual: maxPktDiscard,
+        result: maxPktDiscard == null || limit == null ? 'N/A' : (ok ? 'PASS' : 'FAIL'),
+      });
       if (!ok) {
         overall.pass = false;
-        overall.reasons.push(formatThresholdFailure(name, actual, limit));
+        overall.reasons.push(`网络丢包率 ${formatPercent(maxPktDiscard)}，阈值 ${formatPercent(limit)}`);
       }
-    };
-
-    check('criticalPathLatencyMs', maxCriticalLat, '<=', pass.maxCriticalPathLatencyMs ?? pass.maxAvgNodeLatencyMs);
-    check('detectorLatencyMs', maxDetectorLat, '<=', pass.maxDetectorLatencyMs);
-    check('avgDiscardRate', avgDiscard, '<=', pass.avgDiscardRate ?? pass.maxDiscardRate);
-    if (videoMode !== 'local') {
-      check('maxPacketDiscardRate', maxPktDiscard, '<=', pass.maxPacketDiscardRate);
     }
 
     return {
@@ -171,7 +202,8 @@ export class ReportWriter {
       minFpsAcross,
       maxDiscard,
       avgDiscard,
-      detectorLatencyMs: maxDetectorLat,
+      detectorLatencyMs: maxPrimaryLat,
+      primaryLatencyMs: maxPrimaryLat,
       criticalPathLatencyMs: maxCriticalLat,
       maxNpu,
       maxCpu,
@@ -259,6 +291,7 @@ export class ReportWriter {
       } : null,
       bottleneck,
       baselineFps: r.baselineFps,
+      baselineByTask: r.baselineByTask ?? {},
       device: r.device,
       startedAt: r.startedAt,
       endedAt: r.endedAt,
@@ -278,14 +311,15 @@ export class ReportWriter {
       : `当前阶梯不是连续通道数，只能给出已验证通过阶梯；连续最大稳定路数需在相邻区间内补测。${summary.capacityBound ? `本次已知 >= ${summary.capacityBound.lowerInclusive ?? 0} 路且 < ${summary.capacityBound.upperExclusive} 路。` : ''}`;
     const interpretationRows = [
       ['容量结论', profileText],
-      ['路数 PASS/FAIL', `每个路数按 thresholds.yml 的报告阈值判定：关键链路 <= ${pass.maxCriticalPathLatencyMs ?? pass.maxAvgNodeLatencyMs ?? '-'}ms，检测节点 <= ${pass.maxDetectorLatencyMs ?? '-'}ms，平均丢弃率 <= ${pass.avgDiscardRate ?? pass.maxDiscardRate ?? '-'}。`],
-      ['瓶颈停止', '运行期保护熔断，用于避免设备继续加压。典型触发条件包括稳定窗口 FPS 相对基线折半、丢弃率连续采样超过 5%、CPU/NPU/内存接近饱和等。它可能发生在下一阶梯 ramp 过程中。'],
+      ['路数 PASS/FAIL', `每个任务按 task type 选择判定策略。CV 默认使用关键链路、检测节点和丢弃率；VLM 默认使用分析 FPS 达标率和采样缺失率，并可配置端到端延时。全局平均丢弃率阈值为 ${pass.avgDiscardRate ?? pass.maxDiscardRate ?? '-'}。`],
+      ['瓶颈停止', '运行期保护熔断，用于避免设备继续加压。CV 使用稳定窗口 FPS 相对基线折半作为保护；VLM 使用目标 FPS 达标率，避免低帧率任务被短窗口误判。丢弃率、CPU、内存等保护仍然通用。'],
       ['采样窗口', samplingText],
       ['失败原因', '表格中的失败原因来自未通过的阈值项；若同时存在瓶颈停止，顶部横幅展示触发提前停止的运行期原因。'],
     ];
     const baseRows = [
       ['场景', r.scenarioName],
       ['任务', formatTaskList(r.tasks, r.algorithmId, r.algorithmName)],
+      ['任务策略', formatTaskStrategies(r.tasks)],
       ['编排设定 FPS（参考）', formatTargetFps(r.tasks, r.targetFps)],
       ['视频模式', r.videoMode],
       ['设备', `${r.device?.model ?? ''} / ${r.device?.sn ?? ''}`],
@@ -338,7 +372,9 @@ export class ReportWriter {
       s.perThreshold.map((t) => `
         <tr>
           <td>${s.channels}ch</td>
-          <td>${esc(t.name)}</td>
+          <td>${esc(t.taskDisplayName ?? t.taskKey ?? '-')}</td>
+          <td>${esc(t.strategy ?? '-')}</td>
+          <td>${esc(thresholdLabel(t.name, strategyForTask(t)))}</td>
           <td>${t.threshold ?? '-'}</td>
           <td>${t.actual ?? '-'}</td>
           <td class="${t.result === 'PASS' ? 'pass' : (t.result === 'FAIL' ? 'fail' : 'na')}">${t.result}</td>
@@ -350,11 +386,14 @@ export class ReportWriter {
         <tr>
           <td>${s.channels}ch</td>
           <td>${esc(t.taskDisplayName ?? t.taskKey)}</td>
+          <td>${esc(t.strategy)}</td>
           <td>${t.algorithmId ?? '-'}</td>
           <td>${t.bindingCount}</td>
-          <td>${t.minDetectorFps ?? '-'}</td>
+          <td>${t.minThroughputFps ?? '-'}</td>
+          <td>${t.minFpsRatio != null ? formatPercent(t.minFpsRatio) : '-'}</td>
+          <td>${t.maxMissingRate != null ? formatPercent(t.maxMissingRate) : '-'}</td>
           <td>${t.avgDiscardRate ?? '-'}</td>
-          <td>${t.maxDetectorLatencyMs ?? '-'}</td>
+          <td>${t.maxPrimaryLatencyMs ?? '-'}</td>
           <td>${t.maxCriticalPathLatencyMs ?? '-'}</td>
         </tr>`),
     ).join('');
@@ -387,17 +426,17 @@ ${bottleneckBanner}
 <table>${baseRows.map(([k, v]) => `<tr><th>${esc(k)}</th><td>${esc(v)}</td></tr>`).join('')}</table>
 <h2>路数结果</h2>
 <table>
-  <tr><th>序号</th><th>路数</th><th>保持</th><th>目标FPS(参考)</th><th>检测FPS(参考)</th><th>关键链路延时ms</th><th>检测节点延时ms</th><th>平均丢弃率</th><th>最差通道丢弃率</th><th>NPU峰值</th><th>CPU峰值</th><th>内存峰值</th><th>结果</th><th>失败原因</th></tr>
+  <tr><th>序号</th><th>路数</th><th>保持</th><th>目标FPS(参考)</th><th>处理FPS(参考)</th><th>关键/端到端延时ms</th><th>主节点延时ms</th><th>平均丢弃率</th><th>最差通道丢弃率</th><th>NPU峰值</th><th>CPU峰值</th><th>内存峰值</th><th>结果</th><th>失败原因</th></tr>
   ${stepRows}
 </table>
 <h2>分任务汇总</h2>
 <table>
-  <tr><th>路数</th><th>任务</th><th>算法ID</th><th>绑定数</th><th>最低检测FPS</th><th>平均丢弃率</th><th>最大检测延时ms</th><th>最大关键链路ms</th></tr>
+  <tr><th>路数</th><th>任务</th><th>策略</th><th>算法ID</th><th>绑定数</th><th>最低处理FPS</th><th>最低FPS达标率</th><th>最大缺失率</th><th>平均丢弃率</th><th>最大主节点ms</th><th>最大关键/端到端ms</th></tr>
   ${taskRows}
 </table>
 <h2>阈值判定明细</h2>
 <table>
-  <tr><th>路数</th><th>指标</th><th>阈值</th><th>实测</th><th>结果</th></tr>
+  <tr><th>路数</th><th>任务</th><th>策略</th><th>指标</th><th>阈值</th><th>实测</th><th>结果</th></tr>
   ${verdictRows}
 </table>
 </body></html>`;
@@ -416,19 +455,25 @@ function summarizeTasks(channelStats) {
         taskKey: key,
         taskDisplayName: stat.taskDisplayName ?? key,
         taskType: stat.taskType ?? 'cv',
+        strategy: strategyForTaskType(stat.taskType).id,
         algorithmId: stat.algorithmId ?? null,
+        targetFps: stat.targetFps ?? null,
         fps: [],
+        fpsRatio: [],
+        missing: [],
         discard: [],
-        detectorLat: [],
+        primaryLat: [],
         criticalLat: [],
         bindingCount: 0,
       });
     }
     const task = byTask.get(key);
     task.bindingCount++;
-    if (stat.minDetectorFps != null) task.fps.push(stat.minDetectorFps);
+    if (stat.minThroughputFps != null) task.fps.push(stat.minThroughputFps);
+    if (stat.minFpsRatio != null) task.fpsRatio.push(stat.minFpsRatio);
+    if (stat.missingRate != null) task.missing.push(stat.missingRate);
     if (stat.avgDiscardRate != null) task.discard.push(stat.avgDiscardRate);
-    if (stat.avgDetectorLatencyMs != null) task.detectorLat.push(stat.avgDetectorLatencyMs);
+    if (stat.avgPrimaryLatencyMs != null) task.primaryLat.push(stat.avgPrimaryLatencyMs);
     if (stat.avgCriticalPathLatencyMs != null) task.criticalLat.push(stat.avgCriticalPathLatencyMs);
   }
 
@@ -436,11 +481,18 @@ function summarizeTasks(channelStats) {
     taskKey: task.taskKey,
     taskDisplayName: task.taskDisplayName,
     taskType: task.taskType,
+    strategy: task.strategy,
     algorithmId: task.algorithmId,
+    targetFps: task.targetFps,
     bindingCount: task.bindingCount,
+    minThroughputFps: task.fps.length ? round(Math.min(...task.fps), 2) : null,
     minDetectorFps: task.fps.length ? round(Math.min(...task.fps), 2) : null,
+    minFpsRatio: task.fpsRatio.length ? round(Math.min(...task.fpsRatio), 3) : null,
+    avgMissingRate: task.missing.length ? round(mean(task.missing), 4) : null,
+    maxMissingRate: task.missing.length ? round(Math.max(...task.missing), 4) : null,
     avgDiscardRate: task.discard.length ? round(mean(task.discard), 4) : null,
-    maxDetectorLatencyMs: task.detectorLat.length ? round(Math.max(...task.detectorLat), 1) : null,
+    maxPrimaryLatencyMs: task.primaryLat.length ? round(Math.max(...task.primaryLat), 1) : null,
+    maxDetectorLatencyMs: task.primaryLat.length ? round(Math.max(...task.primaryLat), 1) : null,
     maxCriticalPathLatencyMs: task.criticalLat.length ? round(Math.max(...task.criticalLat), 1) : null,
   }));
 }
@@ -461,6 +513,13 @@ function formatTargetFps(tasks, legacyTargetFps) {
   return tasks.map((task) => `${task.id}=${task.targetFps ?? 'N/A'}`).join('; ');
 }
 
+function formatTaskStrategies(tasks) {
+  if (!Array.isArray(tasks) || !tasks.length) return strategyForTaskType('cv').id;
+  return tasks
+    .map((task) => `${task.id}=${strategyForTaskType(task.type).id}`)
+    .join('; ');
+}
+
 function isContinuousChannelProfile(stepSummaries) {
   const channels = stepSummaries
     .map((s) => s.channels)
@@ -473,70 +532,6 @@ function isContinuousChannelProfile(stepSummaries) {
   return true;
 }
 
-function formatThresholdFailure(name, actual, limit) {
-  const label = {
-    criticalPathLatencyMs: '关键链路延时',
-    detectorLatencyMs: '检测节点延时',
-    avgDiscardRate: '平均丢弃率',
-    maxDiscardRate: '丢弃率',
-    maxPacketDiscardRate: '网络丢包率',
-  }[name] ?? name;
-
-  if (name === 'avgDiscardRate' || name === 'maxDiscardRate' || name === 'maxPacketDiscardRate') {
-    return `${label} ${formatPercent(actual)}，超过阈值 ${formatPercent(limit)}`;
-  }
-  if (name.endsWith('LatencyMs')) {
-    return `${label} ${actual}ms，超过阈值 ${limit}ms`;
-  }
-  return `${label} ${actual}，未满足阈值 ${limit}`;
-}
-
 function formatPercent(v) {
   return `${round(Number(v) * 100, 2)}%`;
-}
-
-function nodeAvgUs(n) {
-  if (n?.durationAvgUs != null) return Number(n.durationAvgUs);
-  if (n?.durationMs != null) return Number(n.durationMs) * 1000;
-  return Number(n?.duration ?? 0);
-}
-
-function nodeName(n) {
-  return String(n?.name ?? '').toLowerCase();
-}
-
-function nodeLatencyMs(n) {
-  const us = nodeAvgUs(n);
-  return Number.isFinite(us) && us > 0 ? us / 1000 : null;
-}
-
-function detectorLatencyMs(nodes) {
-  const matched = nodes
-    .filter((n) => {
-      const name = nodeName(n);
-      return name.includes('aidetector') || name.includes('detector') || name.includes('检测');
-    })
-    .map(nodeLatencyMs)
-    .filter((v) => v != null);
-  return matched.length ? Math.max(...matched) : null;
-}
-
-function criticalPathLatencyMs(nodes) {
-  const matched = nodes
-    .filter((n) => {
-      const name = nodeName(n);
-      return name.includes('decode')
-        || name.includes('aidetector')
-        || name.includes('detector')
-        || name.includes('检测')
-        || name.includes('追踪')
-        || name.includes('track')
-        || name.includes('分类')
-        || name.includes('classif')
-        || name.includes('目标判断')
-        || name.includes('judge');
-    })
-    .map(nodeLatencyMs)
-    .filter((v) => v != null);
-  return matched.length ? matched.reduce((a, b) => a + b, 0) : null;
 }

--- a/tools/scenario-bench/src/scenario-package.js
+++ b/tools/scenario-bench/src/scenario-package.js
@@ -16,6 +16,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { parse as parseYaml } from 'yaml';
+import { normalizeTaskType } from './task-strategies.js';
 
 const FPS_ACTION_ID = 'AA_00001';
 const SUPPORTED_VIDEO_MODES = new Set(['local', 'rtsp-fidelity', 'rtsp-deterministic']);
@@ -287,6 +288,9 @@ export class ScenarioPackage {
       if (seen.has(task.id)) throw new Error(`scenario.yml: duplicate task id "${task.id}"`);
       seen.add(task.id);
       if (!task.scheduleId) throw new Error(`scenario.yml: task "${task.id}" missing scheduleId`);
+      if (normalizeTaskType(task.type) === 'vlm' && task.targetFps == null) {
+        throw new Error(`scenario.yml: VLM task "${task.id}" must define targetFps, for example targetFps: 0.2`);
+      }
     }
 
     const taskIds = new Set(this.tasks.map((t) => t.id));

--- a/tools/scenario-bench/src/task-runner.js
+++ b/tools/scenario-bench/src/task-runner.js
@@ -137,7 +137,8 @@ export class TaskRunner {
           const batch = toAdd.slice(offset, offset + this.rampBatchSize);
           const failedList = await this._bind(batch);
           if (failedList.length > 0) {
-            const failedIds = failedList.map(f => f.id).join(', ');
+            const failedIds = failedList.map((f) => f.id ?? f.channelId ?? '?').join(', ');
+            active = [...new Set([...active, ...batch])];
             this.log?.warn(`[step ${i + 1}] bottleneck detected - task bind failed on: ${failedIds}`);
             bottleneck = { bottleneckStep: i, bottleneckReason: `任务绑定失败 (可能达到设备并发授权上限): ${failedIds}` };
             return bottleneck;

--- a/tools/scenario-bench/src/task-runner.js
+++ b/tools/scenario-bench/src/task-runner.js
@@ -135,7 +135,13 @@ export class TaskRunner {
 
         for (let offset = 0; offset < toAdd.length; offset += this.rampBatchSize) {
           const batch = toAdd.slice(offset, offset + this.rampBatchSize);
-          await this._bind(batch);
+          const failedList = await this._bind(batch);
+          if (failedList.length > 0) {
+            const failedIds = failedList.map(f => f.id).join(', ');
+            this.log?.warn(`[step ${i + 1}] bottleneck detected - task bind failed on: ${failedIds}`);
+            bottleneck = { bottleneckStep: i, bottleneckReason: `任务绑定失败 (可能达到设备并发授权上限): ${failedIds}` };
+            return bottleneck;
+          }
           active = this.allChannelIds.slice(0, active.length + batch.length);
           const entries = this.expectedTaskEntries(active);
 

--- a/tools/scenario-bench/src/task-strategies.js
+++ b/tools/scenario-bench/src/task-strategies.js
@@ -1,0 +1,303 @@
+const DEFAULT_TYPE = 'cv';
+
+const TASK_TYPE_ALIASES = new Map([
+  ['cv', 'cv'],
+  ['detect', 'cv'],
+  ['detection', 'cv'],
+  ['classifier', 'cv'],
+  ['classification', 'cv'],
+  ['vlm', 'vlm'],
+  ['vision-language', 'vlm'],
+  ['vision_language', 'vlm'],
+  ['multimodal', 'vlm'],
+  ['llm-vlm', 'vlm'],
+]);
+
+const STRATEGIES = {
+  cv: {
+    id: 'cv',
+    displayName: 'CV',
+    throughputLabel: '检测FPS',
+    primaryLatencyLabel: '检测节点延时ms',
+    criticalLatencyLabel: '关键链路延时ms',
+    defaultThresholds: {},
+    primaryThroughputNames: ['aidetector', 'detector', '检测'],
+    primaryLatencyNames: ['aidetector', 'detector', '检测'],
+    criticalLatencyNames: [
+      'decode',
+      'aidetector',
+      'detector',
+      '检测',
+      '追踪',
+      'track',
+      '分类',
+      'classif',
+      '目标判断',
+      'judge',
+    ],
+    primaryActionIds: [/^1001/],
+    useAllNodesForCriticalFallback: false,
+    useBaselineFpsFuse: true,
+  },
+  vlm: {
+    id: 'vlm',
+    displayName: 'VLM',
+    throughputLabel: '分析FPS',
+    primaryLatencyLabel: '分析节点延时ms',
+    criticalLatencyLabel: '端到端链路延时ms',
+    defaultThresholds: {
+      minFpsRatio: 0.8,
+      maxMissingRate: 0,
+    },
+    primaryThroughputNames: [
+      'vlm',
+      'llm',
+      'qwen',
+      'vision',
+      'language',
+      'multimodal',
+      'analysis',
+      'analyze',
+      'infer',
+      'inference',
+      'model',
+      '大模型',
+      '视觉语言',
+      '分析',
+      '推理',
+    ],
+    primaryLatencyNames: [
+      'vlm',
+      'llm',
+      'qwen',
+      'vision',
+      'language',
+      'multimodal',
+      'analysis',
+      'analyze',
+      'infer',
+      'inference',
+      'model',
+      '大模型',
+      '视觉语言',
+      '分析',
+      '推理',
+    ],
+    criticalLatencyNames: [
+      'decode',
+      'vlm',
+      'llm',
+      'qwen',
+      'vision',
+      'language',
+      'multimodal',
+      'analysis',
+      'analyze',
+      'infer',
+      'inference',
+      'model',
+      '大模型',
+      '视觉语言',
+      '分析',
+      '推理',
+    ],
+    primaryActionIds: [],
+    useAllNodesForCriticalFallback: true,
+    useBaselineFpsFuse: false,
+  },
+};
+
+export function normalizeTaskType(type) {
+  const raw = String(type ?? DEFAULT_TYPE).trim().toLowerCase();
+  return TASK_TYPE_ALIASES.get(raw) ?? raw;
+}
+
+export function strategyForTaskType(type) {
+  return STRATEGIES[normalizeTaskType(type)] ?? STRATEGIES[DEFAULT_TYPE];
+}
+
+export function strategyForTask(task) {
+  return strategyForTaskType(task?.taskType ?? task?.type);
+}
+
+export function resolveTaskThresholds(thresholds = {}, task = {}) {
+  const strategy = strategyForTask(task);
+  const taskType = normalizeTaskType(task.taskType ?? task.type);
+  const pass = basePassThresholds(thresholds.pass ?? {}, strategy);
+  const typeRules = thresholds.taskTypes?.[taskType]
+    ?? thresholds.strategies?.[taskType]
+    ?? thresholds[taskType]
+    ?? {};
+  const taskKey = task.taskKey ?? task.id;
+  const taskRules = taskKey ? (thresholds.tasks?.[taskKey] ?? {}) : {};
+  return {
+    ...strategy.defaultThresholds,
+    ...pass,
+    ...typeRules,
+    ...taskRules,
+  };
+}
+
+function basePassThresholds(pass, strategy) {
+  if (strategy.id !== 'vlm') return pass;
+  const portable = { ...pass };
+  delete portable.maxDetectorLatencyMs;
+  delete portable.maxCriticalPathLatencyMs;
+  delete portable.maxAvgNodeLatencyMs;
+  return portable;
+}
+
+export function isPrimaryThroughputAction(name, actionId, taskType) {
+  const strategy = strategyForTaskType(taskType);
+  const normalizedName = String(name ?? '').toLowerCase();
+  const normalizedActionId = String(actionId ?? '');
+  return strategy.primaryThroughputNames.some((pattern) => normalizedName.includes(pattern.toLowerCase()))
+    || strategy.primaryActionIds.some((pattern) => pattern.test(normalizedActionId));
+}
+
+export function latencyMetricsForNodes(nodes, taskType) {
+  const strategy = strategyForTaskType(taskType);
+  const normalizedNodes = (Array.isArray(nodes) ? nodes : [])
+    .map((node) => ({
+      name: nodeName(node),
+      latencyMs: nodeLatencyMs(node),
+    }))
+    .filter((node) => node.latencyMs != null);
+
+  const primary = normalizedNodes
+    .filter((node) => matchesAny(node.name, strategy.primaryLatencyNames))
+    .map((node) => node.latencyMs);
+  const critical = normalizedNodes
+    .filter((node) => matchesAny(node.name, strategy.criticalLatencyNames))
+    .map((node) => node.latencyMs);
+  const criticalFallback = strategy.useAllNodesForCriticalFallback && !critical.length
+    ? normalizedNodes.map((node) => node.latencyMs)
+    : [];
+
+  return {
+    primaryLatencyMs: primary.length ? Math.max(...primary) : null,
+    criticalPathLatencyMs: critical.length || criticalFallback.length
+      ? [...critical, ...criticalFallback].reduce((sum, value) => sum + value, 0)
+      : null,
+  };
+}
+
+export function evaluateTaskStat(taskStat, thresholds = {}) {
+  const strategy = strategyForTask(taskStat);
+  const rules = resolveTaskThresholds(thresholds, taskStat);
+  const checks = [];
+  const failures = [];
+
+  const check = (name, actual, op, limit) => {
+    if (actual == null || limit == null) {
+      checks.push(checkRecord(taskStat, name, limit, null, 'N/A'));
+      return;
+    }
+    const ok = op === '>=' ? actual >= limit : actual <= limit;
+    checks.push(checkRecord(taskStat, name, limit, actual, ok ? 'PASS' : 'FAIL'));
+    if (!ok) failures.push(formatThresholdFailure(name, actual, limit, strategy));
+  };
+
+  if (rules.minThroughputFps != null) {
+    check('minThroughputFps', taskStat.minThroughputFps, '>=', rules.minThroughputFps);
+  }
+  if (rules.minFpsRatio != null) {
+    check('minFpsRatio', taskStat.minFpsRatio, '>=', rules.minFpsRatio);
+  }
+  if (rules.maxMissingRate != null) {
+    check('maxMissingRate', taskStat.maxMissingRate, '<=', rules.maxMissingRate);
+  }
+  if (rules.avgDiscardRate != null || rules.maxDiscardRate != null) {
+    check('avgDiscardRate', taskStat.avgDiscardRate, '<=', rules.avgDiscardRate ?? rules.maxDiscardRate);
+  }
+  if (rules.maxPrimaryLatencyMs != null || rules.maxAnalysisLatencyMs != null) {
+    check(
+      'maxPrimaryLatencyMs',
+      taskStat.maxPrimaryLatencyMs,
+      '<=',
+      rules.maxPrimaryLatencyMs ?? rules.maxAnalysisLatencyMs,
+    );
+  }
+
+  if (strategy.id === 'cv') {
+    check('maxCriticalPathLatencyMs', taskStat.maxCriticalPathLatencyMs, '<=', rules.maxCriticalPathLatencyMs ?? rules.maxAvgNodeLatencyMs);
+    check('maxDetectorLatencyMs', taskStat.maxPrimaryLatencyMs, '<=', rules.maxDetectorLatencyMs);
+  } else {
+    check('maxEndToEndLatencyMs', taskStat.maxCriticalPathLatencyMs, '<=', rules.maxEndToEndLatencyMs ?? rules.maxCriticalPathLatencyMs);
+  }
+
+  return {
+    checks,
+    pass: failures.length === 0,
+    reasons: failures.map((reason) => `${taskStat.taskDisplayName ?? taskStat.taskKey}: ${reason}`),
+  };
+}
+
+export function formatThresholdFailure(name, actual, limit, strategy = null) {
+  const label = thresholdLabel(name, strategy);
+  if (name.endsWith('Rate') || name === 'minFpsRatio') {
+    return `${label} ${formatPercent(actual)}，阈值 ${formatPercent(limit)}`;
+  }
+  if (name.endsWith('LatencyMs')) {
+    return `${label} ${actual}ms，阈值 ${limit}ms`;
+  }
+  return `${label} ${actual}，阈值 ${limit}`;
+}
+
+export function thresholdLabel(name, strategy = null) {
+  const s = strategy ?? strategyForTaskType(DEFAULT_TYPE);
+  return {
+    minThroughputFps: `最低${s.throughputLabel}`,
+    minFpsRatio: `${s.throughputLabel}达标率`,
+    maxMissingRate: '采样缺失率',
+    avgDiscardRate: '平均丢弃率',
+    maxDiscardRate: '丢弃率',
+    maxPacketDiscardRate: '网络丢包率',
+    maxPrimaryLatencyMs: s.primaryLatencyLabel,
+    maxDetectorLatencyMs: '检测节点延时',
+    maxAnalysisLatencyMs: '分析节点延时',
+    maxCriticalPathLatencyMs: s.criticalLatencyLabel,
+    maxEndToEndLatencyMs: '端到端链路延时',
+  }[name] ?? name;
+}
+
+function checkRecord(taskStat, name, threshold, actual, result) {
+  return {
+    taskKey: taskStat.taskKey,
+    taskDisplayName: taskStat.taskDisplayName,
+    taskType: taskStat.taskType,
+    strategy: strategyForTask(taskStat).id,
+    name,
+    threshold,
+    actual,
+    result,
+  };
+}
+
+function matchesAny(name, patterns) {
+  return patterns.some((pattern) => name.includes(String(pattern).toLowerCase()));
+}
+
+function formatPercent(v) {
+  return `${round(Number(v) * 100, 2)}%`;
+}
+
+function round(v, digits) {
+  const f = 10 ** digits;
+  return Math.round(v * f) / f;
+}
+
+function nodeAvgUs(n) {
+  if (n?.durationAvgUs != null) return Number(n.durationAvgUs);
+  if (n?.durationMs != null) return Number(n.durationMs) * 1000;
+  return Number(n?.duration ?? 0);
+}
+
+function nodeName(n) {
+  return String(n?.name ?? '').toLowerCase();
+}
+
+function nodeLatencyMs(n) {
+  const us = nodeAvgUs(n);
+  return Number.isFinite(us) && us > 0 ? us / 1000 : null;
+}


### PR DESCRIPTION
## Description

Enhance the `scenario-bench` tool for better bottleneck reporting and high-load algorithm testing (specifically for VLM).

**Changes included:**
1. **Disabled NPU fuse limit**: Commented out the `NPU >= 98%` hardware protection fuse in `cli.js`. This allows extreme heavy-load algorithms (like VLM) to run near saturation without aborting the benchmark prematurely.
2. **Task Bind Failure Detection**: Updated `task-runner.js` to explicitly catch `ApplyParamsBatch` failures during ramp-up, reporting them accurately as device capacity bottlenecks.
3. **Report UI Improvements**: Updated `report-writer.js` to correctly display the exact bottleneck reason and display a `STOPPED` status (instead of a generic `FAIL` or `FALSE`) when testing hits the hardware authorization limit.

## Verification

- [x] Ran dual-algorithm capacity benchmark (16 channels) to verify `ApplyParamsBatch` failures are correctly logged as bottlenecks.
- [x] Ran single VLM algorithm (`55009`) stress test up to 8 channels on device `192.168.0.140`. Confirmed that NPU saturation (100%) no longer aborts the test via software fuse, and 0% discard rate is maintained.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow up.

## Compatibility and Deployment Impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with 'Signed-off-by:' according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Notes for reviewers

The NPU fuse removal is a targeted change for the current testing cycle. We may consider making it an explicit CLI flag in the future if we want to toggle the hardware protection dynamically.
