### PR TITLE
fix(ci): pin rustup home so cargo resolves under github actions

### DIFF
--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -32,6 +32,16 @@ jobs:
 
     timeout-minutes: 60
 
+    env:
+      # GitHub Actions runs container jobs with HOME=/github/home, but the
+      # builder image installs rustup under /root. rustup derives RUSTUP_HOME
+      # from $HOME, so it reads /github/home/.rustup (empty) and aborts with
+      # "no default is configured" when tokenizers-cpp invokes cargo to build
+      # libtokenizers_c.a. Pin both homes to the image's install — the image
+      # PATH already hardcodes /root/.cargo/bin, so this couples no further.
+      RUSTUP_HOME: /root/.rustup
+      CARGO_HOME: /root/.cargo
+
     steps:
       # Container runs as root but workspace is owned by host UID.
       # Suppress git "dubious ownership" errors that break test-reporter.
@@ -39,6 +49,18 @@ jobs:
         run: git config --global --add safe.directory '*'
 
       - uses: actions/checkout@v7
+
+      # ── Rust toolchain ───────────────────────────────────────────────
+      # With RUSTUP_HOME/CARGO_HOME pinned above, the image's toolchain
+      # resolves correctly. Verify it; install stable as a fallback only if
+      # a future image ships without one.
+      - name: Verify Rust toolchain
+        run: |
+          if ! cargo --version >/dev/null 2>&1; then
+            rustup toolchain install stable --profile minimal --no-self-update
+            rustup default stable
+          fi
+          cargo --version
 
       # ── Build ────────────────────────────────────────────────────────
       - name: Configure and build cosmo-tests (x86 CPU backend)


### PR DESCRIPTION
## Summary

`ci-build-and-test.yml` failed at `[ 66%] Generating release/libtokenizers_c.a` with `error: rustup could not choose a version of cargo to run ... no default is configured`.

Root cause: GitHub Actions runs container jobs with `HOME=/github/home` (confirmed in the failed run's `docker create` args), but the builder image `cosmo_edge-build-env_x86:v1` installs rustup under `/root`. `rustup` derives `RUSTUP_HOME` from `$HOME`, so it reads the empty `/github/home/.rustup` and refuses to run `cargo` — while the image's own toolchain at `/root/.rustup` sits unused. The image itself is healthy (`stable-x86_64-unknown-linux-gnu`, cargo/rustc 1.96.0); only the CI runtime's `HOME` override breaks it.

Fix: pin `RUSTUP_HOME=/root/.rustup` and `CARGO_HOME=/root/.cargo` at the job level so cargo resolves to the image's existing toolchain (the image `PATH` already hardcodes `/root/.cargo/bin`, so this adds no new coupling). A `Verify Rust toolchain` step prints the version and installs `stable` as a fallback only if a future image ships without one. No per-run Rust download, no product code or build-script change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Build / deployment
- [ ] Refactor
- [ ] Test

## Area

- [ ] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [x] Build / deployment
- [ ] Documentation

## Verification

Pulled the builder image and reproduced the exact CI failure, then confirmed the fix end-to-end:

```text
# 1. Image toolchain is healthy under /root (default docker run, HOME=/root)
$ docker run --rm ghcr.io/cosmo-wander-ai/cosmo_edge-build-env_x86:v1 cargo --version
cargo 1.96.0 (30a34c682 2026-05-25)

# 2. Reproduce the CI failure with GitHub Actions' HOME=/github/home (image PATH kept)
$ docker run --rm -e HOME=/github/home --entrypoint /bin/bash \
    ghcr.io/cosmo-wander-ai/cosmo_edge-build-env_x86:v1 -c 'cargo --version'
error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.

# 3. Fix: pin RUSTUP_HOME/CARGO_HOME to the image install -> builds the real artifact
$ docker run --rm -e HOME=/github/home -e RUSTUP_HOME=/root/.rustup -e CARGO_HOME=/root/.cargo \
    -v "$PWD/3rd/tokenizers-cpp:/tk:ro" --entrypoint /bin/bash \
    ghcr.io/cosmo-wander-ai/cosmo_edge-build-env_x86:v1 -c 'cd /tmp/tk/rust && cargo build --release'
   Finished `release` profile [optimized] target(s) in 33.77s
$ ls target/release/libtokenizers_c.a   # 35.5 MB
```

CI run on this branch (https://github.com/cosmo-wander-ai/cosmo-edge/actions/runs/28650829597):

- `Verify Rust toolchain` ✓
- `tokenizers_external` configure → build → install → `Built target` ✓ (the exact step that failed before)
- Reached `[ 14%]` with **0** `rustup`/`cargo` errors. The run was manually canceled at 7m5s after the previously-failing step succeeded; a full green run can be re-triggered via `workflow_dispatch`.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Notes for reviewers

- The production `docker build` path (`Dockerfile.x86` → `scripts/build_cpu.sh`) is **not** affected: standard Docker runs the build as root with `HOME=/root`, so rustup already finds `/root/.rustup`. The breakage is specific to the GitHub Actions container runtime, which forces `HOME=/github/home`. No change to `build_cpu.sh` is needed.
- The `Verify Rust toolchain` step is a no-op with the current image (cargo already resolves); it only installs `stable` if a future image drops the baked-in toolchain.
