### PR TITLE
docs(changelog): rename 'Pre-release' to 'Release' hardening pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ First stable public release: a security and CI hardening pass plus feature, refa
 
 ### Security
 
-- Pre-release hardening pass: shell-injection guards, null-safety and lifecycle fixes across `infer`/`mem`/`nn`/`service`, default-password enforcement, and child-process signal hygiene.
+- Release hardening pass: shell-injection guards, null-safety and lifecycle fixes across `infer`/`mem`/`nn`/`service`, default-password enforcement, and child-process signal hygiene.
 - Updated `SECURITY.md` with supported versions, response SLA, and hardening notes, and unified the vulnerability contact to `hello@cosmowander.ai`.
 
 ### Docs


### PR DESCRIPTION
The v1.0.0 Security entry said 'Pre-release hardening pass'. With the release shipped, 'Pre-release' reads like the release is not yet final. This is a historical entry describing what v1.0.0 shipped, so 'Release hardening pass' is the accurate wording.

Docs-only; no code or behavior change.

## Summary

Describe the change and why it is needed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build / deployment
- [ ] Refactor
- [ ] Test

## Area

- [ ] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [ ] Build / deployment
- [ ] Documentation

## Verification

List the commands or manual checks you ran.

```text

```

## Documentation impact

- [ ] Documentation was updated.
- [ ] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [ ] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [ ] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [ ] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [ ] No secrets, tokens, private keys, or certificates are included.
- [ ] No real device SN values, customer names, or private IPs are included.
- [ ] No private model weights or proprietary download links are included.
- [ ] New dependencies have an acceptable license and are documented.
- [ ] Documentation was updated if behavior changed.
- [ ] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Notes for reviewers

Mention any known limitations, follow-up work, or compatibility concerns.
