### PR TITLE
docs: link repository to official website

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: mailto:hello@cosmowander.ai
     about: Please report security issues privately instead of opening a public issue.
   - name: Documentation
-    url: https://cosmo-wander-ai.github.io/cosmo-edge/
+    url: https://www.cosmowander.ai/docs/
     about: Read the documentation before opening an issue.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@
 [![Release](https://img.shields.io/badge/release-v1.0.0-green?style=flat-square)](https://github.com/cosmo-wander-ai/cosmo-edge/releases)
 [![Stress Test](https://img.shields.io/badge/stress%20test-200%20video%20samples-brightgreen?style=flat-square)](#validation)
 [![Pipelines](https://img.shields.io/badge/pipelines-26%20validated-brightgreen?style=flat-square)](#validation)
+[![Website](https://img.shields.io/badge/website-cosmowander.ai-3B82F6?style=flat-square)](https://www.cosmowander.ai/)
+[![Docs](https://img.shields.io/badge/docs-online-2563EB?style=flat-square)](https://www.cosmowander.ai/docs/)
 [![GitHub](https://img.shields.io/badge/GitHub-cosmo--edge-181717?style=flat-square&logo=github)](https://github.com/cosmo-wander-ai/cosmo-edge)
 [![Gitee](https://img.shields.io/badge/Gitee-cosmo--edge-C71D23?style=flat-square&logo=gitee)](https://gitee.com/cosmo-wander-ai/cosmo-edge)
 
-[Quick Start](#quick-start) | [Features](#key-features) | [Validation](#validation) | [Docs](#documentation) | [Hardware](#cosmoedge-ready-devices)
+[Official Website](https://www.cosmowander.ai/) | [Online Docs](https://www.cosmowander.ai/docs/) | [Quick Start](#quick-start) | [Features](#key-features) | [Validation](#validation) | [Benchmarks](https://www.cosmowander.ai/docs/benchmarks/scenario-bench/v1.0/) | [Hardware](#cosmoedge-ready-devices)
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,10 +12,12 @@
 [![Release](https://img.shields.io/badge/release-v1.0.0-green?style=flat-square)](https://github.com/cosmo-wander-ai/cosmo-edge/releases)
 [![Stress Test](https://img.shields.io/badge/stress%20test-200%20video%20samples-brightgreen?style=flat-square)](#验证与性能)
 [![Pipelines](https://img.shields.io/badge/pipelines-26%20validated-brightgreen?style=flat-square)](#验证与性能)
+[![Website](https://img.shields.io/badge/website-cosmowander.ai-3B82F6?style=flat-square)](https://www.cosmowander.ai/zh/)
+[![Docs](https://img.shields.io/badge/docs-online-2563EB?style=flat-square)](https://www.cosmowander.ai/docs/)
 [![GitHub](https://img.shields.io/badge/GitHub-cosmo--edge-181717?style=flat-square&logo=github)](https://github.com/cosmo-wander-ai/cosmo-edge)
 [![Gitee](https://img.shields.io/badge/Gitee-cosmo--edge-C71D23?style=flat-square&logo=gitee)](https://gitee.com/cosmo-wander-ai/cosmo-edge)
 
-[快速开始](#快速开始) | [核心特性](#核心特性) | [验证与性能](#验证与性能) | [文档](#文档) | [硬件](#cosmoedge-ready-设备)
+[官网](https://www.cosmowander.ai/zh/) | [在线文档](https://www.cosmowander.ai/docs/) | [快速开始](#快速开始) | [核心特性](#核心特性) | [验证与性能](#验证与性能) | [Benchmark](https://www.cosmowander.ai/docs/benchmarks/scenario-bench/v1.0/) | [硬件](#cosmoedge-ready-设备)
 
 [English](README.md) | 简体中文
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,15 @@
 {
   "name": "cosmo-edge-docs",
   "private": true,
+  "description": "CosmoEdge documentation site for the open-source C++ edge AI engine.",
+  "homepage": "https://www.cosmowander.ai/docs/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cosmo-wander-ai/cosmo-edge.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cosmo-wander-ai/cosmo-edge/issues"
+  },
   "type": "module",
   "scripts": {
     "docs:dev": "vitepress dev docs",


### PR DESCRIPTION
## Summary

- Add official website and online docs links to English and Chinese README files.
- Point the issue template documentation link to the production docs site.
- Add homepage, repository, bugs, and description metadata to the docs package.
- Sync GitHub About metadata with the official website and discovery topics.

## Verification

- npm run docs:build
