### PR TITLE
feat(flow): AiDetector fps-aware instance placement

### DIFF
--- a/src/flow/detect/AiDetectMng.cc
+++ b/src/flow/detect/AiDetectMng.cc
@@ -1,0 +1,106 @@
+// AiDetectMng.cc — fps-aware instance placement for AiDetector.
+//
+// Hides (not overrides) MultiChannelActionMng::GetInst. Placement rules under m_mtx:
+//   1) an existing channel always reuses its instance (single inference per channel);
+//   2) unconfigured fps (<=0, full-frame) → exclusive new instance;
+//   3) otherwise the first existing instance that fits under the channel cap and fps budget;
+//   4) else create a new instance.
+
+#include "flow/detect/AiDetectMng.h"
+
+#include "util/Log.h"
+
+namespace cosmo {
+
+namespace {
+constexpr const char* kTag = "AiDetectMng";
+}
+
+AiDetectorPtr AiDetectMng::GetInst(const std::string& algCode, const std::string& channelId,
+                                   const std::string& task, ActionNode& action) {
+    const float requested_fps = action.initFps;
+    const float normalized_fps = ai_detector_fps::NormalizeRequestedFps(requested_fps);
+    const bool exclusive = (requested_fps <= 0.0f);
+
+    std::lock_guard<std::shared_mutex> lock(m_mtx);
+    auto& algInsts = m_insts[algCode];
+
+    auto applyParams = [&action](const AiDetectorPtr& inst, const std::string& ch, const std::string& t) {
+        if (!action.configObject.params.empty()) {
+            inst->ModifyParam(ch, t, action.configObject.params);
+        }
+    };
+
+    // Rule 1: existing channel → reuse. Splitting one channel across instances would duplicate
+    // inference and break history/overview/confidence activation, so fps budget never rejects it.
+    for (size_t i = 0; i < algInsts.size(); ++i) {
+        const auto& inst = algInsts[i];
+        if (inst->ChannelExist(channelId)) {
+            if (!inst->AddTask(channelId, task, requested_fps)) {
+                LOG_WARN("[{}] Channel:{} Task:{} Get {} Inst Failed", kTag, channelId, task, algCode);
+                return nullptr;
+            }
+            applyParams(inst, channelId, task);
+            LOG_INFO(
+                "[{}] Place {} ch:{} task:{} reqFps:{} normFps:{} -> reuse-existing idx:{} chs:{} "
+                "assignedFps:{} budget:{} runtimeInFps:{}",
+                kTag, algCode, channelId, task, requested_fps, normalized_fps, i, inst->ChannelCount(),
+                inst->AssignedFps(), inst->GetInstanceFpsBudget(), inst->GetInFps());
+            return inst;
+        }
+    }
+
+    // Rule 2: unconfigured fps → exclusive new instance (load unknown, stay conservative).
+    if (exclusive) {
+        auto inst = std::make_shared<AiDetector>(action);
+        if (!inst->AddTask(channelId, task, requested_fps)) {
+            LOG_WARN("[{}] Channel:{} Task:{} Get {} Inst Failed", kTag, channelId, task, algCode);
+            return nullptr;
+        }
+        applyParams(inst, channelId, task);
+        algInsts.push_back(inst);
+        LOG_INFO(
+            "[{}] Place {} ch:{} task:{} reqFps:{} normFps:{} -> create-exclusive idx:{} chs:{} "
+            "assignedFps:{} budget:{} runtimeInFps:{}",
+            kTag, algCode, channelId, task, requested_fps, normalized_fps, algInsts.size() - 1,
+            inst->ChannelCount(), inst->AssignedFps(), inst->GetInstanceFpsBudget(), inst->GetInFps());
+        return inst;
+    }
+
+    // Rule 3: first existing instance that fits under both the channel cap and the fps budget.
+    for (size_t i = 0; i < algInsts.size(); ++i) {
+        const auto& inst = algInsts[i];
+        const float assigned_before = inst->AssignedFps();
+        const float delta = inst->DeltaFpsForTask(channelId, requested_fps);
+        if (inst->CanAccept(channelId, requested_fps)) {
+            if (!inst->AddTask(channelId, task, requested_fps)) {
+                LOG_WARN("[{}] Channel:{} Task:{} Get {} Inst Failed", kTag, channelId, task, algCode);
+                return nullptr;
+            }
+            applyParams(inst, channelId, task);
+            LOG_INFO(
+                "[{}] Place {} ch:{} task:{} reqFps:{} normFps:{} -> accept-existing idx:{} chs:{} "
+                "assignedFpsBefore:{} delta:{} budget:{} runtimeInFps:{}",
+                kTag, algCode, channelId, task, requested_fps, normalized_fps, i, inst->ChannelCount(),
+                assigned_before, delta, inst->GetInstanceFpsBudget(), inst->GetInFps());
+            return inst;
+        }
+    }
+
+    // Rule 4: no existing instance fits → create a new one.
+    auto inst = std::make_shared<AiDetector>(action);
+    if (!inst->AddTask(channelId, task, requested_fps)) {
+        LOG_WARN("[{}] Channel:{} Task:{} Get {} Inst Failed", kTag, channelId, task, algCode);
+        return nullptr;
+    }
+    applyParams(inst, channelId, task);
+    algInsts.push_back(inst);
+    LOG_INFO(
+        "[{}] Place {} ch:{} task:{} reqFps:{} normFps:{} -> create-new idx:{} chs:{} assignedFps:{} "
+        "budget:{} runtimeInFps:{}",
+        kTag, algCode, channelId, task, requested_fps, normalized_fps, algInsts.size() - 1,
+        inst->ChannelCount(), inst->AssignedFps(), inst->GetInstanceFpsBudget(), inst->GetInFps());
+    return inst;
+}
+
+}  // namespace cosmo

--- a/src/flow/detect/AiDetectMng.cc
+++ b/src/flow/detect/AiDetectMng.cc
@@ -2,25 +2,80 @@
 //
 // Hides (not overrides) MultiChannelActionMng::GetInst. Placement rules under m_mtx:
 //   1) an existing channel always reuses its instance (single inference per channel);
-//   2) unconfigured fps (<=0, full-frame) → exclusive new instance;
-//   3) otherwise the first existing instance that fits under the channel cap and fps budget;
-//   4) else create a new instance.
+//   2) otherwise the first existing instance that fits under the dynamic channel cap and fps budget;
+//   3) else create a new instance.
 
 #include "flow/detect/AiDetectMng.h"
 
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+#include "util/Keys.h"
 #include "util/Log.h"
+#include "util/SafeParse.h"
+#include "util/StringUtil.h"
 
 namespace cosmo {
 
 namespace {
     constexpr const char* kTag = "AiDetectMng";
+
+    std::string ToLower(std::string value) {
+        std::transform(value.begin(), value.end(), value.begin(),
+                       [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+        return value;
+    }
+
+    bool EndsWith(const std::string& value, const std::string& suffix) {
+        return value.size() >= suffix.size() &&
+               value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+    }
+
+    bool IsFpsPlacementKey(const std::string& raw_key, const std::string& alg_code,
+                           const ActionNode& action) {
+        const std::string lower_key = ToLower(std::string(util::Trim(raw_key)));
+        if (lower_key.empty()) {
+            return false;
+        }
+        if (lower_key == std::string(key::FPS) || EndsWith(lower_key, ".fps") ||
+            lower_key.find(".fps.") != std::string::npos) {
+            return true;
+        }
+
+        // Some pressure-test orchestrations report fps as "<model-code>=<fps>" instead of populating
+        // ActionNode::initFps. Accept exact model-code keys as a placement-only fallback.
+        const std::string alg_key       = ToLower(std::string(util::Trim(alg_code)));
+        const std::string atomic_key    = ToLower(std::string(util::Trim(action.atomicCode)));
+        const std::string atom_name_key = ToLower(std::string(util::Trim(action.atomAlgName)));
+        return (!alg_key.empty() && lower_key == alg_key) || (!atomic_key.empty() && lower_key == atomic_key) ||
+               (!atom_name_key.empty() && lower_key == atom_name_key);
+    }
+
+    float ResolvePlacementFps(const std::string& alg_code, const ActionNode& action) {
+        if (ai_detector_fps::HasConfiguredFps(action.initFps)) {
+            return action.initFps;
+        }
+
+        for (const auto& param : action.configObject.params) {
+            if (!IsFpsPlacementKey(param.key.ToString(), alg_code, action)) {
+                continue;
+            }
+
+            const float fps = util::ParseFloat(param.value.ToString(), -1.0f);
+            if (ai_detector_fps::HasConfiguredFps(fps)) {
+                return fps;
+            }
+        }
+
+        return action.initFps;
+    }
 }
 
 AiDetectorPtr AiDetectMng::GetInst(const std::string& algCode, const std::string& channelId,
                                    const std::string& task, ActionNode& action) {
-    const float requested_fps  = action.initFps;
+    const float requested_fps  = ResolvePlacementFps(algCode, action);
     const float normalized_fps = ai_detector_fps::NormalizeRequestedFps(requested_fps);
-    const bool exclusive       = (requested_fps <= 0.0f);
 
     std::lock_guard<std::shared_mutex> lock(m_mtx);
     auto& algInsts = m_insts[algCode];
@@ -42,36 +97,19 @@ AiDetectorPtr AiDetectMng::GetInst(const std::string& algCode, const std::string
             }
             applyParams(inst, channelId, task);
             LOG_INFO(
-                "[{}] Place {} ch:{} task:{} reqFps:{} normFps:{} -> reuse-existing idx:{} chs:{} "
-                "assignedFps:{} budget:{} runtimeInFps:{}",
-                kTag, algCode, channelId, task, requested_fps, normalized_fps, i, inst->ChannelCount(),
-                inst->AssignedFps(), inst->GetInstanceFpsBudget(), inst->GetInFps());
+                "[{}] Place {} ch:{} task:{} actionInitFps:{} reqFps:{} normFps:{} -> reuse-existing "
+                "idx:{} chs:{} assignedFps:{} budget:{} runtimeInFps:{}",
+                kTag, algCode, channelId, task, action.initFps, requested_fps, normalized_fps, i,
+                inst->ChannelCount(), inst->AssignedFps(), inst->GetInstanceFpsBudget(), inst->GetInFps());
             return inst;
         }
     }
 
-    // Rule 2: unconfigured fps → exclusive new instance (load unknown, stay conservative).
-    if (exclusive) {
-        auto inst = std::make_shared<AiDetector>(action);
-        if (!inst->AddTask(channelId, task, requested_fps)) {
-            LOG_WARN("[{}] Channel:{} Task:{} Get {} Inst Failed", kTag, channelId, task, algCode);
-            return nullptr;
-        }
-        applyParams(inst, channelId, task);
-        algInsts.push_back(inst);
-        LOG_INFO(
-            "[{}] Place {} ch:{} task:{} reqFps:{} normFps:{} -> create-exclusive idx:{} chs:{} "
-            "assignedFps:{} budget:{} runtimeInFps:{}",
-            kTag, algCode, channelId, task, requested_fps, normalized_fps, algInsts.size() - 1,
-            inst->ChannelCount(), inst->AssignedFps(), inst->GetInstanceFpsBudget(), inst->GetInFps());
-        return inst;
-    }
-
-    // Rule 3: first existing instance that fits under both the channel cap and the fps budget.
+    // Rule 2: first existing instance that fits under both the dynamic channel cap and the fps budget.
     for (size_t i = 0; i < algInsts.size(); ++i) {
         const auto& inst            = algInsts[i];
         const float assigned_before = inst->AssignedFps();
-        const float delta           = inst->DeltaFpsForTask(channelId, requested_fps);
+        const float delta           = inst->DeltaFpsForTask(channelId, normalized_fps);
         if (inst->CanAccept(channelId, requested_fps)) {
             if (!inst->AddTask(channelId, task, requested_fps)) {
                 LOG_WARN("[{}] Channel:{} Task:{} Get {} Inst Failed", kTag, channelId, task, algCode);
@@ -79,15 +117,15 @@ AiDetectorPtr AiDetectMng::GetInst(const std::string& algCode, const std::string
             }
             applyParams(inst, channelId, task);
             LOG_INFO(
-                "[{}] Place {} ch:{} task:{} reqFps:{} normFps:{} -> accept-existing idx:{} chs:{} "
-                "assignedFpsBefore:{} delta:{} budget:{} runtimeInFps:{}",
-                kTag, algCode, channelId, task, requested_fps, normalized_fps, i, inst->ChannelCount(),
-                assigned_before, delta, inst->GetInstanceFpsBudget(), inst->GetInFps());
+                "[{}] Place {} ch:{} task:{} actionInitFps:{} reqFps:{} normFps:{} -> accept-existing "
+                "idx:{} chs:{} assignedFpsBefore:{} delta:{} budget:{} runtimeInFps:{}",
+                kTag, algCode, channelId, task, action.initFps, requested_fps, normalized_fps, i,
+                inst->ChannelCount(), assigned_before, delta, inst->GetInstanceFpsBudget(), inst->GetInFps());
             return inst;
         }
     }
 
-    // Rule 4: no existing instance fits → create a new one.
+    // Rule 3: no existing instance fits → create a new one.
     auto inst = std::make_shared<AiDetector>(action);
     if (!inst->AddTask(channelId, task, requested_fps)) {
         LOG_WARN("[{}] Channel:{} Task:{} Get {} Inst Failed", kTag, channelId, task, algCode);
@@ -96,9 +134,9 @@ AiDetectorPtr AiDetectMng::GetInst(const std::string& algCode, const std::string
     applyParams(inst, channelId, task);
     algInsts.push_back(inst);
     LOG_INFO(
-        "[{}] Place {} ch:{} task:{} reqFps:{} normFps:{} -> create-new idx:{} chs:{} assignedFps:{} "
-        "budget:{} runtimeInFps:{}",
-        kTag, algCode, channelId, task, requested_fps, normalized_fps, algInsts.size() - 1,
+        "[{}] Place {} ch:{} task:{} actionInitFps:{} reqFps:{} normFps:{} -> create-new idx:{} chs:{} "
+        "assignedFps:{} budget:{} runtimeInFps:{}",
+        kTag, algCode, channelId, task, action.initFps, requested_fps, normalized_fps, algInsts.size() - 1,
         inst->ChannelCount(), inst->AssignedFps(), inst->GetInstanceFpsBudget(), inst->GetInFps());
     return inst;
 }

--- a/src/flow/detect/AiDetectMng.cc
+++ b/src/flow/detect/AiDetectMng.cc
@@ -13,14 +13,14 @@
 namespace cosmo {
 
 namespace {
-constexpr const char* kTag = "AiDetectMng";
+    constexpr const char* kTag = "AiDetectMng";
 }
 
 AiDetectorPtr AiDetectMng::GetInst(const std::string& algCode, const std::string& channelId,
                                    const std::string& task, ActionNode& action) {
-    const float requested_fps = action.initFps;
+    const float requested_fps  = action.initFps;
     const float normalized_fps = ai_detector_fps::NormalizeRequestedFps(requested_fps);
-    const bool exclusive = (requested_fps <= 0.0f);
+    const bool exclusive       = (requested_fps <= 0.0f);
 
     std::lock_guard<std::shared_mutex> lock(m_mtx);
     auto& algInsts = m_insts[algCode];
@@ -69,9 +69,9 @@ AiDetectorPtr AiDetectMng::GetInst(const std::string& algCode, const std::string
 
     // Rule 3: first existing instance that fits under both the channel cap and the fps budget.
     for (size_t i = 0; i < algInsts.size(); ++i) {
-        const auto& inst = algInsts[i];
+        const auto& inst            = algInsts[i];
         const float assigned_before = inst->AssignedFps();
-        const float delta = inst->DeltaFpsForTask(channelId, requested_fps);
+        const float delta           = inst->DeltaFpsForTask(channelId, requested_fps);
         if (inst->CanAccept(channelId, requested_fps)) {
             if (!inst->AddTask(channelId, task, requested_fps)) {
                 LOG_WARN("[{}] Channel:{} Task:{} Get {} Inst Failed", kTag, channelId, task, algCode);

--- a/src/flow/detect/AiDetectMng.h
+++ b/src/flow/detect/AiDetectMng.h
@@ -4,8 +4,18 @@
 #include "flow/detect/AiDetector.h"
 
 namespace cosmo {
+
+// AiDetectMng enables fps-aware instance placement for the regular YOLO AiDetector by HIDING
+// (not overriding) MultiChannelActionMng::GetInst, which is non-virtual. Callers MUST invoke
+// GetInst through the concrete AiDetectMng type (TaskBase holds its AiDetectMng member by value).
+// Calling via a MultiChannelActionMng<AiDetector>& reference would silently dispatch to the base
+// template and bypass fps-aware placement. Dino/Qwen3VL/Sam2 keep using the base behavior.
 class AiDetectMng : public MultiChannelActionMng<AiDetector> {
 public:
     AiDetectMng() : MultiChannelActionMng("AiDetectMng") {}
+
+    AiDetectorPtr GetInst(const std::string& algCode, const std::string& channelId,
+                          const std::string& task, ActionNode& action);
 };
+
 }  // namespace cosmo

--- a/src/flow/detect/AiDetectMng.h
+++ b/src/flow/detect/AiDetectMng.h
@@ -14,8 +14,8 @@ class AiDetectMng : public MultiChannelActionMng<AiDetector> {
 public:
     AiDetectMng() : MultiChannelActionMng("AiDetectMng") {}
 
-    AiDetectorPtr GetInst(const std::string& algCode, const std::string& channelId,
-                          const std::string& task, ActionNode& action);
+    AiDetectorPtr GetInst(const std::string& algCode, const std::string& channelId, const std::string& task,
+                          ActionNode& action);
 };
 
 }  // namespace cosmo

--- a/src/flow/detect/AiDetector.cc
+++ b/src/flow/detect/AiDetector.cc
@@ -89,13 +89,14 @@ namespace {
     ai_detector_fps::ReuseProfile LookupReuseProfile(const std::string& alg_code) {
         const auto raw_value = LookupPlacementEnv(kEnvReuseProfile, alg_code);
         if (raw_value.empty()) {
-            return {};
+            return ai_detector_fps::DefaultReuseProfile();
         }
 
         auto profile = ai_detector_fps::ParseReuseProfile(raw_value);
         if (profile.empty()) {
-            LOG_WARN("{}Invalid {} value:{}, fallback to fps-budget formula", kTag, kEnvReuseProfile,
+            LOG_WARN("{}Invalid {} value:{}, fallback to default reuse profile", kTag, kEnvReuseProfile,
                      raw_value);
+            return ai_detector_fps::DefaultReuseProfile();
         }
         return profile;
     }

--- a/src/flow/detect/AiDetector.cc
+++ b/src/flow/detect/AiDetector.cc
@@ -127,7 +127,9 @@ void AiDetector::QueueStatus(std::vector<AlgActionDataQueueStatus>& que_status, 
         status.actionId = GetActionId();
         for (auto& channelNode : channel_list_) {
             status.channelIds.push_back(channelNode.channel);
-            status.taskIds.insert(status.taskIds.end(), channelNode.tasks.begin(), channelNode.tasks.end());
+            for (const auto& binding : channelNode.tasks) {
+                status.taskIds.push_back(binding.task);
+            }
         }
         status.actionStatus = action_status;
         que_status.push_back(status);

--- a/src/flow/detect/AiDetector.cc
+++ b/src/flow/detect/AiDetector.cc
@@ -65,7 +65,7 @@ AiDetector::AiDetector(ActionNode& action)
     uuid      = util::GenerateUUID();
 
     batch_count_         = 4;
-    max_reuse_count_     = 3;
+    max_reuse_count_     = kMaxReuseHardLimit;
     instance_fps_budget_ = LookupInstanceFpsBudget(alg_code_);
     data_queue->SetMaxSize(48);
 

--- a/src/flow/detect/AiDetector.cc
+++ b/src/flow/detect/AiDetector.cc
@@ -5,6 +5,8 @@
 
 #include "flow/detect/AiDetector.h"
 
+#include <unordered_map>
+
 #include "service/detail/ServiceRegistry.h"
 #include "service/model/IModelService.h"
 #include "service/system/IConfigReadService.h"
@@ -16,6 +18,18 @@
 
 static constexpr const char* kTag = "AI-DETECTER ";
 namespace cosmo {
+
+namespace {
+    // Per-algCode fps budget overrides for instance placement. Unlisted algCodes fall back to
+    // kDefaultInstanceFpsBudget. Populate from per-model stress-test results.
+    float LookupInstanceFpsBudget(const std::string& alg_code) {
+        static const std::unordered_map<std::string, float> kAlgFpsBudget = {
+            // {"45626", 36.0f},
+        };
+        const auto it = kAlgFpsBudget.find(alg_code);
+        return (it != kAlgFpsBudget.end()) ? it->second : kDefaultInstanceFpsBudget;
+    }
+}  // namespace
 
 AiDetector::~AiDetector() {
     is_detector_inst_initialized_ = false;
@@ -50,11 +64,13 @@ AiDetector::AiDetector(ActionNode& action)
     name_     = action.atomicCode;
     uuid      = util::GenerateUUID();
 
-    batch_count_     = 4;
-    max_reuse_count_ = 3;
+    batch_count_         = 4;
+    max_reuse_count_     = 3;
+    instance_fps_budget_ = LookupInstanceFpsBudget(alg_code_);
     data_queue->SetMaxSize(48);
 
-    LOG_INFO("{}[{} {}] Init MaxReuse:{} BatchCount:{}", kTag, name_, uuid, max_reuse_count_, batch_count_);
+    LOG_INFO("{}[{} {}] Init MaxReuse:{} BatchCount:{} FpsBudget:{}", kTag, name_, uuid, max_reuse_count_,
+             batch_count_, instance_fps_budget_);
 }
 
 bool AiDetector::AiSdkInit() {

--- a/src/flow/detect/AiDetector.cc
+++ b/src/flow/detect/AiDetector.cc
@@ -51,7 +51,7 @@ AiDetector::AiDetector(ActionNode& action)
     uuid      = util::GenerateUUID();
 
     batch_count_     = 4;
-    max_reuse_count_ = 6;
+    max_reuse_count_ = 3;
     data_queue->SetMaxSize(48);
 
     LOG_INFO("{}[{} {}] Init MaxReuse:{} BatchCount:{}", kTag, name_, uuid, max_reuse_count_, batch_count_);

--- a/src/flow/detect/AiDetector.cc
+++ b/src/flow/detect/AiDetector.cc
@@ -5,13 +5,18 @@
 
 #include "flow/detect/AiDetector.h"
 
+#include <algorithm>
+#include <cctype>
+#include <sstream>
 #include <unordered_map>
 
 #include "service/detail/ServiceRegistry.h"
 #include "service/model/IModelService.h"
 #include "service/system/IConfigReadService.h"
 #include "service/system/IHardwareQuery.h"
+#include "util/EnvUtil.h"
 #include "util/Log.h"
+#include "util/SafeParse.h"
 #include "util/TimeUtil.h"
 #include "util/UuidUtil.h"
 #include "util/dto/ActionCodes.h"
@@ -20,14 +25,94 @@ static constexpr const char* kTag = "AI-DETECTER ";
 namespace cosmo {
 
 namespace {
+    constexpr const char* kEnvMaxReuse     = "COSMO_AI_DETECTOR_MAX_REUSE";
+    constexpr const char* kEnvFpsBudget    = "COSMO_AI_DETECTOR_FPS_BUDGET";
+    constexpr const char* kEnvReuseProfile = "COSMO_AI_DETECTOR_REUSE_PROFILE";
+    constexpr size_t kMaxRuntimeReuseLimit = 64;
+
+    std::string SanitizeEnvSuffix(const std::string& raw) {
+        std::string suffix;
+        suffix.reserve(raw.size());
+        for (unsigned char ch : raw) {
+            suffix.push_back(std::isalnum(ch) ? static_cast<char>(std::toupper(ch)) : '_');
+        }
+        return suffix;
+    }
+
+    std::string LookupPlacementEnv(const char* base_key, const std::string& alg_code) {
+        const auto suffix = SanitizeEnvSuffix(alg_code);
+        if (!suffix.empty()) {
+            const auto alg_key = std::string(base_key) + "_" + suffix;
+            const auto value   = util::GetEnvOrDefault(alg_key.c_str(), "");
+            if (!value.empty()) {
+                return value;
+            }
+        }
+        return util::GetEnvOrDefault(base_key, "");
+    }
+
+    size_t LookupMaxReuseCount(const std::string& alg_code) {
+        const auto raw_value = LookupPlacementEnv(kEnvMaxReuse, alg_code);
+        if (raw_value.empty()) {
+            return kMaxReuseHardLimit;
+        }
+
+        size_t parsed = 0;
+        if (!ai_detector_fps::ParsePositiveSize(raw_value, parsed)) {
+            LOG_WARN("{}Invalid {} value:{}, fallback:{}", kTag, kEnvMaxReuse, raw_value,
+                     kMaxReuseHardLimit);
+            return kMaxReuseHardLimit;
+        }
+        return std::clamp(parsed, static_cast<size_t>(1), kMaxRuntimeReuseLimit);
+    }
+
     // Per-algCode fps budget overrides for instance placement. Unlisted algCodes fall back to
     // kDefaultInstanceFpsBudget. Populate from per-model stress-test results.
     float LookupInstanceFpsBudget(const std::string& alg_code) {
+        const auto raw_value = LookupPlacementEnv(kEnvFpsBudget, alg_code);
+        if (!raw_value.empty()) {
+            const float parsed = util::ParseFloat(raw_value, -1.0f);
+            if (ai_detector_fps::HasConfiguredFps(parsed)) {
+                return parsed;
+            }
+            LOG_WARN("{}Invalid {} value:{}, fallback:{}", kTag, kEnvFpsBudget, raw_value,
+                     kDefaultInstanceFpsBudget);
+        }
+
         static const std::unordered_map<std::string, float> kAlgFpsBudget = {
             // {"45626", 36.0f},
         };
         const auto it = kAlgFpsBudget.find(alg_code);
         return (it != kAlgFpsBudget.end()) ? it->second : kDefaultInstanceFpsBudget;
+    }
+
+    ai_detector_fps::ReuseProfile LookupReuseProfile(const std::string& alg_code) {
+        const auto raw_value = LookupPlacementEnv(kEnvReuseProfile, alg_code);
+        if (raw_value.empty()) {
+            return {};
+        }
+
+        auto profile = ai_detector_fps::ParseReuseProfile(raw_value);
+        if (profile.empty()) {
+            LOG_WARN("{}Invalid {} value:{}, fallback to fps-budget formula", kTag, kEnvReuseProfile,
+                     raw_value);
+        }
+        return profile;
+    }
+
+    std::string ReuseProfileToString(const ai_detector_fps::ReuseProfile& profile) {
+        if (profile.empty()) {
+            return "formula";
+        }
+
+        std::ostringstream oss;
+        for (size_t i = 0; i < profile.size(); ++i) {
+            if (i > 0) {
+                oss << ",";
+            }
+            oss << profile[i].max_fps << ":" << profile[i].reuse_count;
+        }
+        return oss.str();
     }
 }  // namespace
 
@@ -65,12 +150,13 @@ AiDetector::AiDetector(ActionNode& action)
     uuid      = util::GenerateUUID();
 
     batch_count_         = 4;
-    max_reuse_count_     = kMaxReuseHardLimit;
+    max_reuse_count_     = LookupMaxReuseCount(alg_code_);
     instance_fps_budget_ = LookupInstanceFpsBudget(alg_code_);
+    reuse_profile_       = LookupReuseProfile(alg_code_);
     data_queue->SetMaxSize(48);
 
-    LOG_INFO("{}[{} {}] Init MaxReuse:{} BatchCount:{} FpsBudget:{}", kTag, name_, uuid, max_reuse_count_,
-             batch_count_, instance_fps_budget_);
+    LOG_INFO("{}[{} {}] Init MaxReuse:{} BatchCount:{} FpsBudget:{} ReuseProfile:{}", kTag, name_, uuid,
+             max_reuse_count_, batch_count_, instance_fps_budget_, ReuseProfileToString(reuse_profile_));
 }
 
 bool AiDetector::AiSdkInit() {

--- a/src/flow/detect/AiDetector.h
+++ b/src/flow/detect/AiDetector.h
@@ -141,7 +141,7 @@ private:
     std::vector<std::string> labels_;
     size_t max_reuse_count_{1};                             // Max channels sharing this detector
     float instance_fps_budget_{kDefaultInstanceFpsBudget};  // Per-instance fps budget for placement
-    ai_detector_fps::ReuseProfile reuse_profile_;           // Optional fps-threshold reuse overrides
+    ai_detector_fps::ReuseProfile reuse_profile_;           // fps-threshold reuse profile for placement
     size_t batch_count_{1};                                 // Batch size for inference
     std::vector<AiDetectorChannel> channel_list_;           // Channels/tasks using this detector
     bool is_detector_inst_initialized_{false};

--- a/src/flow/detect/AiDetector.h
+++ b/src/flow/detect/AiDetector.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "flow/action/AlgActionBase.h"
+#include "flow/detect/AiDetectorFps.h"
 #include "flow/overview/OverviewRecordAiRst.h"
 #include "flow/task/TaskBaseParam.h"
 #include "infer/AiDetectorUnify.h"
@@ -17,17 +18,6 @@
 // 2. Filter detection results by confidence and distribute to task queues.
 
 namespace cosmo {
-
-// One task bound to a channel, carrying the task's requested fps for instance placement.
-struct AiDetectorTaskBinding {
-    std::string task;
-    float fps{0.0f};
-};
-
-struct AiDetectorChannel {
-    std::string channel;
-    std::vector<AiDetectorTaskBinding> tasks;
-};
 
 struct AiDetectorParamEl {
     std::string task_id;
@@ -71,7 +61,9 @@ public:
 
     void Stop() override;
 
-    // Add task when acquiring an instance
+    // Add task when acquiring an instance. requested_fps <= 0 means unconfigured (normalized inside).
+    bool AddTask(const std::string& channel_id, const std::string& task, float requested_fps);
+    // Add task when acquiring an instance (legacy: fps unconfigured).
     bool AddTask(const std::string& channel_id, const std::string& task);
     // Remove task when releasing an instance
     bool RemoveTask(const std::string& channel_id, const std::string& task);
@@ -86,6 +78,17 @@ public:
 
     size_t ChannelCount() const;
     size_t TaskCount() const;
+
+    // fps-aware placement helpers. Callers must hold the owning MultiChannelActionMng::m_mtx:
+    // these read channel_list_, which is mutated under that lock (channel_list_ itself is not
+    // guarded by mtx; mtx only protects task_histories_/task_areas_/overview_rec_insts_).
+    float NormalizeRequestedFps(float fps) const;
+    float AssignedFps() const;  // Sum of each channel's max-task-fps
+    float DeltaFpsForTask(const std::string& channel_id, float requested_fps) const;
+    bool CanAccept(const std::string& channel_id, float requested_fps) const;
+    float GetInstanceFpsBudget() const {
+        return instance_fps_budget_;
+    }
 
     std::string GetName() const {
         return name_;
@@ -136,9 +139,10 @@ private:
     int init_retry_count_{0};
     int64_t last_init_fail_time_ms_{0};
     std::vector<std::string> labels_;
-    size_t max_reuse_count_{1};                    // Max channels sharing this detector
-    size_t batch_count_{1};                        // Batch size for inference
-    std::vector<AiDetectorChannel> channel_list_;  // Channels/tasks using this detector
+    size_t max_reuse_count_{1};                             // Max channels sharing this detector
+    float instance_fps_budget_{kDefaultInstanceFpsBudget};  // Per-instance fps budget for placement
+    size_t batch_count_{1};                                 // Batch size for inference
+    std::vector<AiDetectorChannel> channel_list_;           // Channels/tasks using this detector
     bool is_detector_inst_initialized_{false};
     AiDetectorUnifyPtr detector_;  // Detector inference instance
     int sign_register_{0};         // Tracks distributor sign changes to trigger confidence re-activation

--- a/src/flow/detect/AiDetector.h
+++ b/src/flow/detect/AiDetector.h
@@ -141,6 +141,7 @@ private:
     std::vector<std::string> labels_;
     size_t max_reuse_count_{1};                             // Max channels sharing this detector
     float instance_fps_budget_{kDefaultInstanceFpsBudget};  // Per-instance fps budget for placement
+    ai_detector_fps::ReuseProfile reuse_profile_;           // Optional fps-threshold reuse overrides
     size_t batch_count_{1};                                 // Batch size for inference
     std::vector<AiDetectorChannel> channel_list_;           // Channels/tasks using this detector
     bool is_detector_inst_initialized_{false};

--- a/src/flow/detect/AiDetector.h
+++ b/src/flow/detect/AiDetector.h
@@ -17,9 +17,16 @@
 // 2. Filter detection results by confidence and distribute to task queues.
 
 namespace cosmo {
+
+// One task bound to a channel, carrying the task's requested fps for instance placement.
+struct AiDetectorTaskBinding {
+    std::string task;
+    float fps{0.0f};
+};
+
 struct AiDetectorChannel {
     std::string channel;
-    std::vector<std::string> tasks;
+    std::vector<AiDetectorTaskBinding> tasks;
 };
 
 struct AiDetectorParamEl {

--- a/src/flow/detect/AiDetectorFps.h
+++ b/src/flow/detect/AiDetectorFps.h
@@ -45,6 +45,11 @@ namespace ai_detector_fps {
 
     using ReuseProfile = std::vector<ReuseRule>;
 
+    // Tested placement gradient: <=8fps reuse 3, <=12fps reuse 2, higher fps reuse 1.
+    inline ReuseProfile DefaultReuseProfile() {
+        return {{8.0f, 3}, {12.0f, 2}, {100.0f, 1}};
+    }
+
     inline bool HasConfiguredFps(float fps) {
         return fps > 0.0f && std::isfinite(fps);
     }

--- a/src/flow/detect/AiDetectorFps.h
+++ b/src/flow/detect/AiDetectorFps.h
@@ -7,7 +7,10 @@
 #pragma once
 
 #include <algorithm>
+#include <cerrno>
 #include <cmath>
+#include <cstdlib>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -35,8 +38,95 @@ inline constexpr size_t kUnknownFpsReuseCount = 3;
 
 namespace ai_detector_fps {
 
+    struct ReuseRule {
+        float max_fps{0.0f};
+        size_t reuse_count{0};
+    };
+
+    using ReuseProfile = std::vector<ReuseRule>;
+
     inline bool HasConfiguredFps(float fps) {
         return fps > 0.0f && std::isfinite(fps);
+    }
+
+    inline std::string TrimCopy(const std::string& value) {
+        const auto begin = value.find_first_not_of(" \t\n\r\f\v");
+        if (begin == std::string::npos) {
+            return {};
+        }
+        const auto end = value.find_last_not_of(" \t\n\r\f\v");
+        return value.substr(begin, end - begin + 1);
+    }
+
+    inline bool ParsePositiveFloat(const std::string& value, float& parsed) {
+        const auto trimmed = TrimCopy(value);
+        if (trimmed.empty()) {
+            return false;
+        }
+
+        char* end = nullptr;
+        errno     = 0;
+        const float result = std::strtof(trimmed.c_str(), &end);
+        if (end == trimmed.c_str() || *end != '\0' || errno == ERANGE || !HasConfiguredFps(result)) {
+            return false;
+        }
+        parsed = result;
+        return true;
+    }
+
+    inline bool ParsePositiveSize(const std::string& value, size_t& parsed) {
+        const auto trimmed = TrimCopy(value);
+        if (trimmed.empty() || trimmed.front() == '-') {
+            return false;
+        }
+
+        char* end = nullptr;
+        errno     = 0;
+        const unsigned long long result = std::strtoull(trimmed.c_str(), &end, 10);
+        if (end == trimmed.c_str() || *end != '\0' || errno == ERANGE || result == 0 ||
+            result > std::numeric_limits<size_t>::max()) {
+            return false;
+        }
+        parsed = static_cast<size_t>(result);
+        return true;
+    }
+
+    // Parses "5:3,12:2,24:1" or "5=3;12=2;24=1" into ascending fps thresholds.
+    inline ReuseProfile ParseReuseProfile(const std::string& raw_profile) {
+        ReuseProfile profile;
+        size_t start = 0;
+        while (start <= raw_profile.size()) {
+            size_t end = raw_profile.find_first_of(",;", start);
+            if (end == std::string::npos) {
+                end = raw_profile.size();
+            }
+
+            const auto token = TrimCopy(raw_profile.substr(start, end - start));
+            if (!token.empty()) {
+                size_t split = token.find(':');
+                if (split == std::string::npos) {
+                    split = token.find('=');
+                }
+
+                if (split != std::string::npos) {
+                    float max_fps      = 0.0f;
+                    size_t reuse_count = 0;
+                    if (ParsePositiveFloat(token.substr(0, split), max_fps) &&
+                        ParsePositiveSize(token.substr(split + 1), reuse_count)) {
+                        profile.push_back({max_fps, reuse_count});
+                    }
+                }
+            }
+
+            if (end == raw_profile.size()) {
+                break;
+            }
+            start = end + 1;
+        }
+
+        std::sort(profile.begin(), profile.end(),
+                  [](const ReuseRule& lhs, const ReuseRule& rhs) { return lhs.max_fps < rhs.max_fps; });
+        return profile;
     }
 
     // Keep unconfigured fps as 0. Placement handles it with the compatibility channel cap instead
@@ -61,6 +151,18 @@ namespace ai_detector_fps {
         return ClampReuseCount(by_fps, hard_max_reuse_count);
     }
 
+    inline size_t EffectiveMaxReuseCount(float requested_fps, float instance_fps_budget,
+                                         size_t hard_max_reuse_count, const ReuseProfile& reuse_profile) {
+        if (HasConfiguredFps(requested_fps)) {
+            for (const auto& rule : reuse_profile) {
+                if (requested_fps <= rule.max_fps) {
+                    return ClampReuseCount(rule.reuse_count, hard_max_reuse_count);
+                }
+            }
+        }
+        return EffectiveMaxReuseCount(requested_fps, instance_fps_budget, hard_max_reuse_count);
+    }
+
     // Max task fps within a single channel. Multiple tasks on one channel share one inference per
     // frame, so a channel's contribution is the max (not the sum) of its tasks' fps.
     inline float ChannelAssignedFps(const AiDetectorChannel& channel) {
@@ -82,6 +184,19 @@ namespace ai_detector_fps {
         return total;
     }
 
+    inline float PeakFpsAfterTask(const std::vector<AiDetectorChannel>& channels,
+                                  const std::string& channel_id, float requested_fps) {
+        float peak = requested_fps;
+        for (const auto& channel : channels) {
+            float channel_fps = ChannelAssignedFps(channel);
+            if (channel.channel == channel_id) {
+                channel_fps = std::max(channel_fps, requested_fps);
+            }
+            peak = std::max(peak, channel_fps);
+        }
+        return peak;
+    }
+
     // Incremental fps delta if a task with requested_fps is added to channel_id:
     //   existing channel: delta = max(current, requested) - current
     //   new channel:      delta = requested (caller-normalized)
@@ -98,15 +213,17 @@ namespace ai_detector_fps {
 
     // Placement gate: a new task fits iff the channel hard cap and the fps budget both hold.
     inline bool CanAccept(const std::vector<AiDetectorChannel>& channels, const std::string& channel_id,
-                          float requested_fps, size_t hard_max_reuse_count, float instance_fps_budget) {
+                          float requested_fps, size_t hard_max_reuse_count, float instance_fps_budget,
+                          const ReuseProfile& reuse_profile) {
         const float normalized = NormalizeRequestedFps(requested_fps);
         const float delta      = DeltaFpsForTask(channels, channel_id, normalized);
         const bool channel_exists =
             std::any_of(channels.begin(), channels.end(),
                         [&](const AiDetectorChannel& ch) { return ch.channel == channel_id; });
         const size_t channel_count_after_add = channel_exists ? channels.size() : channels.size() + 1;
+        const float placement_fps            = PeakFpsAfterTask(channels, channel_id, normalized);
         const size_t effective_max_reuse =
-            EffectiveMaxReuseCount(requested_fps, instance_fps_budget, hard_max_reuse_count);
+            EffectiveMaxReuseCount(placement_fps, instance_fps_budget, hard_max_reuse_count, reuse_profile);
 
         if (channel_count_after_add > effective_max_reuse) {
             return false;
@@ -117,6 +234,12 @@ namespace ai_detector_fps {
         }
 
         return AssignedFps(channels) + delta <= instance_fps_budget;
+    }
+
+    inline bool CanAccept(const std::vector<AiDetectorChannel>& channels, const std::string& channel_id,
+                          float requested_fps, size_t hard_max_reuse_count, float instance_fps_budget) {
+        return CanAccept(channels, channel_id, requested_fps, hard_max_reuse_count, instance_fps_budget,
+                         ReuseProfile{});
     }
 
 }  // namespace ai_detector_fps

--- a/src/flow/detect/AiDetectorFps.h
+++ b/src/flow/detect/AiDetectorFps.h
@@ -1,0 +1,92 @@
+// AiDetectorFps.h — fps-aware instance placement helpers for AiDetector.
+//
+// Header-only and free of hardware / inference dependencies, so the pure placement math can be
+// unit tested by constructing std::vector<AiDetectorChannel> directly, without instantiating an
+// AiDetector (whose base AlgActionBase is heavy and device-bound).
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace cosmo {
+
+// One task bound to a channel, carrying the task's requested fps for instance placement.
+struct AiDetectorTaskBinding {
+    std::string task;
+    float fps{0.0f};
+};
+
+struct AiDetectorChannel {
+    std::string channel;
+    std::vector<AiDetectorTaskBinding> tasks;
+};
+
+// Fallback fps used when a task does not specify one (initFps <= 0 means "unconfigured / full-frame").
+inline constexpr float kUnknownFpsEstimate = 25.0f;
+
+// Default per-instance fps budget when no per-algCode override is configured.
+inline constexpr float kDefaultInstanceFpsBudget = 36.0f;
+
+namespace ai_detector_fps {
+
+    // Map an unconfigured (<=0) or non-finite (NaN/inf) fps to a conservative estimate; otherwise
+    // pass through. Finite out-of-range values are intentionally NOT clamped: an absurdly large fps
+    // simply fails CanAccept and forces a new instance, which is the safe (over-provisioning) direction.
+    inline float NormalizeRequestedFps(float fps) {
+        return (fps > 0.0f && std::isfinite(fps)) ? fps : kUnknownFpsEstimate;
+    }
+
+    // Max task fps within a single channel. Multiple tasks on one channel share one inference per
+    // frame, so a channel's contribution is the max (not the sum) of its tasks' fps.
+    inline float ChannelAssignedFps(const AiDetectorChannel& channel) {
+        float max_fps = 0.0f;
+        for (const auto& binding : channel.tasks) {
+            if (binding.fps > max_fps) {
+                max_fps = binding.fps;
+            }
+        }
+        return max_fps;
+    }
+
+    // Total fps load on an instance = sum of each channel's max-task-fps.
+    inline float AssignedFps(const std::vector<AiDetectorChannel>& channels) {
+        float total = 0.0f;
+        for (const auto& channel : channels) {
+            total += ChannelAssignedFps(channel);
+        }
+        return total;
+    }
+
+    // Incremental fps delta if a task with requested_fps is added to channel_id:
+    //   existing channel: delta = max(current, requested) - current
+    //   new channel:      delta = requested (caller-normalized)
+    inline float DeltaFpsForTask(const std::vector<AiDetectorChannel>& channels,
+                                 const std::string& channel_id, float requested_fps) {
+        for (const auto& channel : channels) {
+            if (channel.channel == channel_id) {
+                const float current = ChannelAssignedFps(channel);
+                return std::max(current, requested_fps) - current;
+            }
+        }
+        return requested_fps;
+    }
+
+    // Placement gate: a new task fits iff the channel hard cap and the fps budget both hold.
+    inline bool CanAccept(const std::vector<AiDetectorChannel>& channels, const std::string& channel_id,
+                          float requested_fps, size_t max_reuse_count, float instance_fps_budget) {
+        const float normalized = NormalizeRequestedFps(requested_fps);
+        const float delta      = DeltaFpsForTask(channels, channel_id, normalized);
+        const bool channel_exists =
+            std::any_of(channels.begin(), channels.end(),
+                        [&](const AiDetectorChannel& ch) { return ch.channel == channel_id; });
+        const size_t channel_count_after_add = channel_exists ? channels.size() : channels.size() + 1;
+        return channel_count_after_add <= max_reuse_count &&
+               AssignedFps(channels) + delta <= instance_fps_budget;
+    }
+
+}  // namespace ai_detector_fps
+
+}  // namespace cosmo

--- a/src/flow/detect/AiDetectorFps.h
+++ b/src/flow/detect/AiDetectorFps.h
@@ -24,19 +24,41 @@ struct AiDetectorChannel {
     std::vector<AiDetectorTaskBinding> tasks;
 };
 
-// Fallback fps used when a task does not specify one (initFps <= 0 means "unconfigured / full-frame").
-inline constexpr float kUnknownFpsEstimate = 25.0f;
-
 // Default per-instance fps budget when no per-algCode override is configured.
 inline constexpr float kDefaultInstanceFpsBudget = 36.0f;
 
+// Hard cap used by fps-aware placement. Stress tests show 3 is a better global ceiling than 6.
+inline constexpr size_t kMaxReuseHardLimit = 3;
+
+// Safe compatibility cap when the orchestration did not expose fps to placement.
+inline constexpr size_t kUnknownFpsReuseCount = 3;
+
 namespace ai_detector_fps {
 
-    // Map an unconfigured (<=0) or non-finite (NaN/inf) fps to a conservative estimate; otherwise
-    // pass through. Finite out-of-range values are intentionally NOT clamped: an absurdly large fps
-    // simply fails CanAccept and forces a new instance, which is the safe (over-provisioning) direction.
+    inline bool HasConfiguredFps(float fps) {
+        return fps > 0.0f && std::isfinite(fps);
+    }
+
+    // Keep unconfigured fps as 0. Placement handles it with the compatibility channel cap instead
+    // of pretending it is 25fps, which over-splits low-fps deployments when initFps is not populated.
     inline float NormalizeRequestedFps(float fps) {
-        return (fps > 0.0f && std::isfinite(fps)) ? fps : kUnknownFpsEstimate;
+        return HasConfiguredFps(fps) ? fps : 0.0f;
+    }
+
+    inline size_t ClampReuseCount(size_t value, size_t hard_max_reuse_count) {
+        const size_t capped_hard_max = std::max<size_t>(1, hard_max_reuse_count);
+        return std::clamp(value, static_cast<size_t>(1), capped_hard_max);
+    }
+
+    inline size_t EffectiveMaxReuseCount(float requested_fps, float instance_fps_budget,
+                                         size_t hard_max_reuse_count) {
+        if (!HasConfiguredFps(requested_fps) || instance_fps_budget <= 0.0f ||
+            !std::isfinite(instance_fps_budget)) {
+            return ClampReuseCount(kUnknownFpsReuseCount, hard_max_reuse_count);
+        }
+
+        const auto by_fps = static_cast<size_t>(std::floor(instance_fps_budget / requested_fps));
+        return ClampReuseCount(by_fps, hard_max_reuse_count);
     }
 
     // Max task fps within a single channel. Multiple tasks on one channel share one inference per
@@ -76,15 +98,25 @@ namespace ai_detector_fps {
 
     // Placement gate: a new task fits iff the channel hard cap and the fps budget both hold.
     inline bool CanAccept(const std::vector<AiDetectorChannel>& channels, const std::string& channel_id,
-                          float requested_fps, size_t max_reuse_count, float instance_fps_budget) {
+                          float requested_fps, size_t hard_max_reuse_count, float instance_fps_budget) {
         const float normalized = NormalizeRequestedFps(requested_fps);
         const float delta      = DeltaFpsForTask(channels, channel_id, normalized);
         const bool channel_exists =
             std::any_of(channels.begin(), channels.end(),
                         [&](const AiDetectorChannel& ch) { return ch.channel == channel_id; });
         const size_t channel_count_after_add = channel_exists ? channels.size() : channels.size() + 1;
-        return channel_count_after_add <= max_reuse_count &&
-               AssignedFps(channels) + delta <= instance_fps_budget;
+        const size_t effective_max_reuse =
+            EffectiveMaxReuseCount(requested_fps, instance_fps_budget, hard_max_reuse_count);
+
+        if (channel_count_after_add > effective_max_reuse) {
+            return false;
+        }
+
+        if (!HasConfiguredFps(requested_fps)) {
+            return true;
+        }
+
+        return AssignedFps(channels) + delta <= instance_fps_budget;
     }
 
 }  // namespace ai_detector_fps

--- a/src/flow/detect/AiDetectorTask.cc
+++ b/src/flow/detect/AiDetectorTask.cc
@@ -53,7 +53,30 @@ size_t AiDetector::TaskCount() const {
     return task_count;
 }
 
+float AiDetector::NormalizeRequestedFps(float fps) const {
+    return ai_detector_fps::NormalizeRequestedFps(fps);
+}
+
+float AiDetector::AssignedFps() const {
+    return ai_detector_fps::AssignedFps(channel_list_);
+}
+
+float AiDetector::DeltaFpsForTask(const std::string& channel_id, float requested_fps) const {
+    return ai_detector_fps::DeltaFpsForTask(channel_list_, channel_id, requested_fps);
+}
+
+bool AiDetector::CanAccept(const std::string& channel_id, float requested_fps) const {
+    return ai_detector_fps::CanAccept(channel_list_, channel_id, requested_fps, max_reuse_count_,
+                                      instance_fps_budget_);
+}
+
 bool AiDetector::AddTask(const std::string& channel_id, const std::string& task) {
+    // Legacy entry point: fps unconfigured. NormalizeRequestedFps maps <=0 to the conservative estimate.
+    return AddTask(channel_id, task, -1.0f);
+}
+
+bool AiDetector::AddTask(const std::string& channel_id, const std::string& task, float requested_fps) {
+    const float binding_fps = NormalizeRequestedFps(requested_fps);
     for (auto& channel_node : channel_list_) {
         if (channel_id == channel_node.channel) {
             if (std::any_of(channel_node.tasks.begin(), channel_node.tasks.end(),
@@ -62,20 +85,21 @@ bool AiDetector::AddTask(const std::string& channel_id, const std::string& task)
                          task);
                 return true;
             }
-            channel_node.tasks.push_back({task, 0.0f});
+            channel_node.tasks.push_back({task, binding_fps});
             AddOverviewTask(task);
             {
                 std::lock_guard<std::shared_mutex> lock(mtx);
                 task_histories_[task];
             }
-            LOG_INFO("{}[{} {}] Add Task[{}] To Channel:{}. ", kTag, name_, uuid, task, channel_id);
+            LOG_INFO("{}[{} {}] Add Task[{}] To Channel:{} Fps:{}.", kTag, name_, uuid, task, channel_id,
+                     binding_fps);
             return true;
         }
     }
 
     AiDetectorChannel newChannel;
     newChannel.channel = channel_id;
-    newChannel.tasks.push_back({task, 0.0f});
+    newChannel.tasks.push_back({task, binding_fps});
     channel_list_.push_back(newChannel);
 
     AddOverviewTask(task);
@@ -84,7 +108,8 @@ bool AiDetector::AddTask(const std::string& channel_id, const std::string& task)
         task_histories_[task];
     }
 
-    LOG_INFO("{}[{} {}] Add New Task[{}] To Channel:{}.", kTag, name_, uuid, task, channel_id);
+    LOG_INFO("{}[{} {}] Add New Task[{}] To Channel:{} Fps:{}.", kTag, name_, uuid, task, channel_id,
+             binding_fps);
     return true;
 }
 

--- a/src/flow/detect/AiDetectorTask.cc
+++ b/src/flow/detect/AiDetectorTask.cc
@@ -23,7 +23,7 @@ bool AiDetector::TaskExist(const std::string& channel_id, const std::string& tas
     for (const auto& channel_node : channel_list_) {
         if (channel_id == channel_node.channel) {
             return std::any_of(channel_node.tasks.begin(), channel_node.tasks.end(),
-                               [&task](const auto& t) { return task == t; });
+                               [&task](const auto& t) { return task == t.task; });
         }
     }
     return false;
@@ -57,12 +57,12 @@ bool AiDetector::AddTask(const std::string& channel_id, const std::string& task)
     for (auto& channel_node : channel_list_) {
         if (channel_id == channel_node.channel) {
             if (std::any_of(channel_node.tasks.begin(), channel_node.tasks.end(),
-                            [&task](const auto& t) { return task == t; })) {
+                            [&task](const auto& t) { return task == t.task; })) {
                 LOG_WARN("{}[{} {}] [{} {}] Add Task. But Task Is Exist", kTag, name_, uuid, channel_id,
                          task);
                 return true;
             }
-            channel_node.tasks.push_back(task);
+            channel_node.tasks.push_back({task, 0.0f});
             AddOverviewTask(task);
             {
                 std::lock_guard<std::shared_mutex> lock(mtx);
@@ -75,7 +75,7 @@ bool AiDetector::AddTask(const std::string& channel_id, const std::string& task)
 
     AiDetectorChannel newChannel;
     newChannel.channel = channel_id;
-    newChannel.tasks.push_back(task);
+    newChannel.tasks.push_back({task, 0.0f});
     channel_list_.push_back(newChannel);
 
     AddOverviewTask(task);
@@ -92,7 +92,7 @@ bool AiDetector::RemoveTask(const std::string& channel_id, const std::string& ta
     for (auto chIt = channel_list_.begin(); chIt != channel_list_.end(); ++chIt) {
         if (chIt->channel == channel_id) {
             for (auto taskIt = chIt->tasks.begin(); taskIt != chIt->tasks.end(); ++taskIt) {
-                if (*taskIt == task) {
+                if (taskIt->task == task) {
                     chIt->tasks.erase(taskIt);
                     LOG_INFO("{}[{} {}] Remove Task Channel:{} Task:{} left:{}", kTag, name_, uuid,
                              channel_id, task, chIt->tasks.size());

--- a/src/flow/detect/AiDetectorTask.cc
+++ b/src/flow/detect/AiDetectorTask.cc
@@ -67,7 +67,7 @@ float AiDetector::DeltaFpsForTask(const std::string& channel_id, float requested
 
 bool AiDetector::CanAccept(const std::string& channel_id, float requested_fps) const {
     return ai_detector_fps::CanAccept(channel_list_, channel_id, requested_fps, max_reuse_count_,
-                                      instance_fps_budget_);
+                                      instance_fps_budget_, reuse_profile_);
 }
 
 bool AiDetector::AddTask(const std::string& channel_id, const std::string& task) {

--- a/test/test_ai_detector_fps.cc
+++ b/test/test_ai_detector_fps.cc
@@ -49,6 +49,36 @@ TEST_CASE("AiDetectorFps EffectiveMaxReuseCount", "[AiDetectorFps]") {
     REQUIRE(EffectiveMaxReuseCount(-1.0f, kBudget, kHardMax) == 3);
 }
 
+TEST_CASE("AiDetectorFps ParseReuseProfile", "[AiDetectorFps]") {
+    using ai_detector_fps::ParseReuseProfile;
+
+    const auto profile = ParseReuseProfile(" 12:2, 5=3 ; 24:1, bad, 18:0 ");
+    REQUIRE(profile.size() == 3);
+    REQUIRE(profile[0].max_fps == Approx(5.0f));
+    REQUIRE(profile[0].reuse_count == 3);
+    REQUIRE(profile[1].max_fps == Approx(12.0f));
+    REQUIRE(profile[1].reuse_count == 2);
+    REQUIRE(profile[2].max_fps == Approx(24.0f));
+    REQUIRE(profile[2].reuse_count == 1);
+}
+
+TEST_CASE("AiDetectorFps EffectiveMaxReuseCount profile override", "[AiDetectorFps]") {
+    using ai_detector_fps::EffectiveMaxReuseCount;
+    using ai_detector_fps::ParseReuseProfile;
+    constexpr size_t kHardMax = 6;
+    constexpr float kBudget   = 36.0f;
+
+    const auto profile = ParseReuseProfile("5:6,12:2,24:1");
+    REQUIRE(EffectiveMaxReuseCount(3.0f, kBudget, kHardMax, profile) == 6);
+    REQUIRE(EffectiveMaxReuseCount(5.0f, kBudget, kHardMax, profile) == 6);
+    REQUIRE(EffectiveMaxReuseCount(10.0f, kBudget, kHardMax, profile) == 2);
+    REQUIRE(EffectiveMaxReuseCount(12.0f, kBudget, kHardMax, profile) == 2);
+    REQUIRE(EffectiveMaxReuseCount(24.0f, kBudget, kHardMax, profile) == 1);
+
+    const auto empty_profile = ParseReuseProfile("invalid");
+    REQUIRE(EffectiveMaxReuseCount(12.0f, kBudget, kHardMax, empty_profile) == 3);
+}
+
 TEST_CASE("AiDetectorFps ChannelAssignedFps takes max not sum", "[AiDetectorFps]") {
     using ai_detector_fps::ChannelAssignedFps;
     REQUIRE(ChannelAssignedFps(makeChannel("ch", {})) == Approx(0.0f));
@@ -71,6 +101,15 @@ TEST_CASE("AiDetectorFps DeltaFpsForTask", "[AiDetectorFps]") {
     REQUIRE(DeltaFpsForTask(inst, "ch_new", 12.0f) == Approx(12.0f));  // new channel → requested
     REQUIRE(DeltaFpsForTask(inst, "ch1", 5.0f) == Approx(0.0f));       // lower fps, no rise
     REQUIRE(DeltaFpsForTask(inst, "ch1", 24.0f) == Approx(12.0f));     // higher fps, rises by diff
+}
+
+TEST_CASE("AiDetectorFps PeakFpsAfterTask", "[AiDetectorFps]") {
+    using ai_detector_fps::PeakFpsAfterTask;
+    std::vector<AiDetectorChannel> inst = {makeChannel("ch1", {{"t1", 24.0f}}),
+                                           makeChannel("ch2", {{"t2", 5.0f}})};
+    REQUIRE(PeakFpsAfterTask(inst, "ch3", 12.0f) == Approx(24.0f));
+    REQUIRE(PeakFpsAfterTask(inst, "ch2", 30.0f) == Approx(30.0f));
+    REQUIRE(PeakFpsAfterTask({}, "ch1", 5.0f) == Approx(5.0f));
 }
 
 TEST_CASE("AiDetectorFps CanAccept placement matrix", "[AiDetectorFps]") {
@@ -109,9 +148,9 @@ TEST_CASE("AiDetectorFps CanAccept placement matrix", "[AiDetectorFps]") {
         REQUIRE_FALSE(CanAccept(one, "ch2", 24.0f, kMaxReuse, kBudget));  // 24 + 24 = 48 > 36
     }
 
-    SECTION("24 + 12 = 36 fits one instance") {
+    SECTION("mixed high-fps placement uses the instance peak fps cap") {
         std::vector<AiDetectorChannel> one = {makeChannel("ch1", {{"t1", 24.0f}})};
-        REQUIRE(CanAccept(one, "ch2", 12.0f, kMaxReuse, kBudget));
+        REQUIRE_FALSE(CanAccept(one, "ch2", 12.0f, kMaxReuse, kBudget));
     }
 
     SECTION("channel cap rejects even when fps budget remains") {
@@ -131,6 +170,13 @@ TEST_CASE("AiDetectorFps CanAccept placement matrix", "[AiDetectorFps]") {
     SECTION("same-channel lower-fps task adds no load") {
         std::vector<AiDetectorChannel> ch = {makeChannel("ch1", {{"t1", 24.0f}})};
         REQUIRE(CanAccept(ch, "ch1", 5.0f, kMaxReuse, kBudget));  // max stays 24, delta 0
+    }
+
+    SECTION("profile can split 12fps at two channels without changing the compiled default") {
+        const auto profile = ai_detector_fps::ParseReuseProfile("5:3,12:2,24:1");
+        std::vector<AiDetectorChannel> two = {makeChannel("ch1", {{"t1", 12.0f}}),
+                                              makeChannel("ch2", {{"t2", 12.0f}})};
+        REQUIRE_FALSE(CanAccept(two, "ch3", 12.0f, kMaxReuse, kBudget, profile));
     }
 
     SECTION("same-channel higher-fps task raising max beyond budget is rejected by the gate") {

--- a/test/test_ai_detector_fps.cc
+++ b/test/test_ai_detector_fps.cc
@@ -31,10 +31,22 @@ AiDetectorChannel makeChannel(const std::string& ch,
 TEST_CASE("AiDetectorFps NormalizeRequestedFps", "[AiDetectorFps]") {
     using ai_detector_fps::NormalizeRequestedFps;
     REQUIRE(NormalizeRequestedFps(12.0f) == Approx(12.0f));
-    REQUIRE(NormalizeRequestedFps(0.0f) == Approx(kUnknownFpsEstimate));
-    REQUIRE(NormalizeRequestedFps(-1.0f) == Approx(kUnknownFpsEstimate));
-    REQUIRE(NormalizeRequestedFps(std::nan("")) == Approx(kUnknownFpsEstimate));
-    REQUIRE(NormalizeRequestedFps(std::numeric_limits<float>::infinity()) == Approx(kUnknownFpsEstimate));
+    REQUIRE(NormalizeRequestedFps(0.0f) == Approx(0.0f));
+    REQUIRE(NormalizeRequestedFps(-1.0f) == Approx(0.0f));
+    REQUIRE(NormalizeRequestedFps(std::nan("")) == Approx(0.0f));
+    REQUIRE(NormalizeRequestedFps(std::numeric_limits<float>::infinity()) == Approx(0.0f));
+}
+
+TEST_CASE("AiDetectorFps EffectiveMaxReuseCount", "[AiDetectorFps]") {
+    using ai_detector_fps::EffectiveMaxReuseCount;
+    constexpr size_t kHardMax = 3;
+    constexpr float kBudget   = 36.0f;
+
+    REQUIRE(EffectiveMaxReuseCount(3.0f, kBudget, kHardMax) == 3);
+    REQUIRE(EffectiveMaxReuseCount(5.0f, kBudget, kHardMax) == 3);
+    REQUIRE(EffectiveMaxReuseCount(12.0f, kBudget, kHardMax) == 3);
+    REQUIRE(EffectiveMaxReuseCount(24.0f, kBudget, kHardMax) == 1);
+    REQUIRE(EffectiveMaxReuseCount(-1.0f, kBudget, kHardMax) == 3);
 }
 
 TEST_CASE("AiDetectorFps ChannelAssignedFps takes max not sum", "[AiDetectorFps]") {
@@ -85,6 +97,13 @@ TEST_CASE("AiDetectorFps CanAccept placement matrix", "[AiDetectorFps]") {
         REQUIRE_FALSE(CanAccept(three, "ch4", 12.0f, kMaxReuse, kBudget));
     }
 
+    SECTION("5fps uses the tested hard cap of 3, not the old cap of 6") {
+        std::vector<AiDetectorChannel> three = {makeChannel("ch1", {{"t1", 5.0f}}),
+                                                makeChannel("ch2", {{"t2", 5.0f}}),
+                                                makeChannel("ch3", {{"t3", 5.0f}})};
+        REQUIRE_FALSE(CanAccept(three, "ch4", 5.0f, kMaxReuse, kBudget));
+    }
+
     SECTION("24fps x2 must split (budget forces 1+1)") {
         std::vector<AiDetectorChannel> one = {makeChannel("ch1", {{"t1", 24.0f}})};
         REQUIRE_FALSE(CanAccept(one, "ch2", 24.0f, kMaxReuse, kBudget));  // 24 + 24 = 48 > 36
@@ -99,6 +118,14 @@ TEST_CASE("AiDetectorFps CanAccept placement matrix", "[AiDetectorFps]") {
         std::vector<AiDetectorChannel> two = {makeChannel("ch1", {{"t1", 3.0f}}),
                                               makeChannel("ch2", {{"t2", 3.0f}})};
         REQUIRE_FALSE(CanAccept(two, "ch3", 3.0f, 2, kBudget));  // 6 fps, but cap=2
+    }
+
+    SECTION("unknown fps falls back to compatibility reuse count, not exclusive placement") {
+        std::vector<AiDetectorChannel> two = {makeChannel("ch1", {{"t1", 0.0f}}),
+                                              makeChannel("ch2", {{"t2", 0.0f}})};
+        REQUIRE(CanAccept(two, "ch3", -1.0f, kMaxReuse, kBudget));
+        std::vector<AiDetectorChannel> three = {two[0], two[1], makeChannel("ch3", {{"t3", 0.0f}})};
+        REQUIRE_FALSE(CanAccept(three, "ch4", -1.0f, kMaxReuse, kBudget));
     }
 
     SECTION("same-channel lower-fps task adds no load") {

--- a/test/test_ai_detector_fps.cc
+++ b/test/test_ai_detector_fps.cc
@@ -1,0 +1,115 @@
+#include "catch_amalgamated.hpp"
+/*
+ * test_ai_detector_fps.cc - AiDetectorFps.h free-function unit tests.
+ *
+ * Exercises the fps-aware placement math directly over std::vector<AiDetectorChannel>, without
+ * constructing an AiDetector (whose base AlgActionBase is heavy / device-bound).
+ */
+#include <cmath>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "flow/detect/AiDetectorFps.h"
+
+using Catch::Approx;
+using namespace cosmo;
+
+namespace {
+AiDetectorChannel makeChannel(const std::string& ch,
+                              const std::vector<std::pair<std::string, float>>& tasks) {
+    AiDetectorChannel channel;
+    channel.channel = ch;
+    for (const auto& kv : tasks) {
+        channel.tasks.push_back({kv.first, kv.second});
+    }
+    return channel;
+}
+}  // namespace
+
+TEST_CASE("AiDetectorFps NormalizeRequestedFps", "[AiDetectorFps]") {
+    using ai_detector_fps::NormalizeRequestedFps;
+    REQUIRE(NormalizeRequestedFps(12.0f) == Approx(12.0f));
+    REQUIRE(NormalizeRequestedFps(0.0f) == Approx(kUnknownFpsEstimate));
+    REQUIRE(NormalizeRequestedFps(-1.0f) == Approx(kUnknownFpsEstimate));
+    REQUIRE(NormalizeRequestedFps(std::nan("")) == Approx(kUnknownFpsEstimate));
+    REQUIRE(NormalizeRequestedFps(std::numeric_limits<float>::infinity()) == Approx(kUnknownFpsEstimate));
+}
+
+TEST_CASE("AiDetectorFps ChannelAssignedFps takes max not sum", "[AiDetectorFps]") {
+    using ai_detector_fps::ChannelAssignedFps;
+    REQUIRE(ChannelAssignedFps(makeChannel("ch", {})) == Approx(0.0f));
+    REQUIRE(ChannelAssignedFps(makeChannel("ch", {{"t1", 3.0f}, {"t2", 8.0f}})) == Approx(8.0f));
+}
+
+TEST_CASE("AiDetectorFps AssignedFps sums per-channel max", "[AiDetectorFps]") {
+    using ai_detector_fps::AssignedFps;
+    std::vector<AiDetectorChannel> inst = {
+        makeChannel("ch1", {{"t1", 12.0f}, {"t2", 5.0f}}),  // channel max 12
+        makeChannel("ch2", {{"t3", 24.0f}}),                // channel max 24
+    };
+    REQUIRE(AssignedFps(inst) == Approx(36.0f));
+    REQUIRE(AssignedFps({}) == Approx(0.0f));
+}
+
+TEST_CASE("AiDetectorFps DeltaFpsForTask", "[AiDetectorFps]") {
+    using ai_detector_fps::DeltaFpsForTask;
+    std::vector<AiDetectorChannel> inst = {makeChannel("ch1", {{"t1", 12.0f}})};
+    REQUIRE(DeltaFpsForTask(inst, "ch_new", 12.0f) == Approx(12.0f));  // new channel → requested
+    REQUIRE(DeltaFpsForTask(inst, "ch1", 5.0f) == Approx(0.0f));       // lower fps, no rise
+    REQUIRE(DeltaFpsForTask(inst, "ch1", 24.0f) == Approx(12.0f));     // higher fps, rises by diff
+}
+
+TEST_CASE("AiDetectorFps CanAccept placement matrix", "[AiDetectorFps]") {
+    using ai_detector_fps::CanAccept;
+    constexpr size_t kMaxReuse = 3;
+    constexpr float kBudget    = 36.0f;
+
+    SECTION("empty instance accepts a new channel") {
+        REQUIRE(CanAccept({}, "ch1", 12.0f, kMaxReuse, kBudget));
+    }
+
+    SECTION("12fps builds up to one instance across 3 channels (12+12+12=36)") {
+        REQUIRE(CanAccept({}, "ch1", 12.0f, kMaxReuse, kBudget));
+        std::vector<AiDetectorChannel> one = {makeChannel("ch1", {{"t1", 12.0f}})};
+        REQUIRE(CanAccept(one, "ch2", 12.0f, kMaxReuse, kBudget));  // 12 + 12 = 24
+        std::vector<AiDetectorChannel> two = {one[0], makeChannel("ch2", {{"t2", 12.0f}})};
+        REQUIRE(CanAccept(two, "ch3", 12.0f, kMaxReuse, kBudget));  // 24 + 12 = 36
+    }
+
+    SECTION("12fps 4th channel must split (3+1): channel cap and budget both reject") {
+        std::vector<AiDetectorChannel> three = {makeChannel("ch1", {{"t1", 12.0f}}),
+                                                makeChannel("ch2", {{"t2", 12.0f}}),
+                                                makeChannel("ch3", {{"t3", 12.0f}})};
+        REQUIRE_FALSE(CanAccept(three, "ch4", 12.0f, kMaxReuse, kBudget));
+    }
+
+    SECTION("24fps x2 must split (budget forces 1+1)") {
+        std::vector<AiDetectorChannel> one = {makeChannel("ch1", {{"t1", 24.0f}})};
+        REQUIRE_FALSE(CanAccept(one, "ch2", 24.0f, kMaxReuse, kBudget));  // 24 + 24 = 48 > 36
+    }
+
+    SECTION("24 + 12 = 36 fits one instance") {
+        std::vector<AiDetectorChannel> one = {makeChannel("ch1", {{"t1", 24.0f}})};
+        REQUIRE(CanAccept(one, "ch2", 12.0f, kMaxReuse, kBudget));
+    }
+
+    SECTION("channel cap rejects even when fps budget remains") {
+        std::vector<AiDetectorChannel> two = {makeChannel("ch1", {{"t1", 3.0f}}),
+                                              makeChannel("ch2", {{"t2", 3.0f}})};
+        REQUIRE_FALSE(CanAccept(two, "ch3", 3.0f, 2, kBudget));  // 6 fps, but cap=2
+    }
+
+    SECTION("same-channel lower-fps task adds no load") {
+        std::vector<AiDetectorChannel> ch = {makeChannel("ch1", {{"t1", 24.0f}})};
+        REQUIRE(CanAccept(ch, "ch1", 5.0f, kMaxReuse, kBudget));  // max stays 24, delta 0
+    }
+
+    SECTION("same-channel higher-fps task raising max beyond budget is rejected by the gate") {
+        std::vector<AiDetectorChannel> ch = {makeChannel("ch1", {{"t1", 12.0f}})};
+        // new 30fps task raises channel max: delta = 30-12 = 18; 12 + 18 = 30 > 20 budget.
+        // GetInst rule 1 bypasses the gate for existing channels; this documents why.
+        REQUIRE_FALSE(CanAccept(ch, "ch1", 30.0f, kMaxReuse, 20.0f));
+    }
+}

--- a/test/test_ai_detector_fps.cc
+++ b/test/test_ai_detector_fps.cc
@@ -79,6 +79,22 @@ TEST_CASE("AiDetectorFps EffectiveMaxReuseCount profile override", "[AiDetectorF
     REQUIRE(EffectiveMaxReuseCount(12.0f, kBudget, kHardMax, empty_profile) == 3);
 }
 
+TEST_CASE("AiDetectorFps DefaultReuseProfile follows tested fps gradient", "[AiDetectorFps]") {
+    using ai_detector_fps::DefaultReuseProfile;
+    using ai_detector_fps::EffectiveMaxReuseCount;
+    constexpr size_t kHardMax = 3;
+    constexpr float kBudget   = 36.0f;
+
+    const auto profile = DefaultReuseProfile();
+    REQUIRE(EffectiveMaxReuseCount(3.0f, kBudget, kHardMax, profile) == 3);
+    REQUIRE(EffectiveMaxReuseCount(5.0f, kBudget, kHardMax, profile) == 3);
+    REQUIRE(EffectiveMaxReuseCount(8.0f, kBudget, kHardMax, profile) == 3);
+    REQUIRE(EffectiveMaxReuseCount(10.0f, kBudget, kHardMax, profile) == 2);
+    REQUIRE(EffectiveMaxReuseCount(12.0f, kBudget, kHardMax, profile) == 2);
+    REQUIRE(EffectiveMaxReuseCount(16.0f, kBudget, kHardMax, profile) == 1);
+    REQUIRE(EffectiveMaxReuseCount(24.0f, kBudget, kHardMax, profile) == 1);
+}
+
 TEST_CASE("AiDetectorFps ChannelAssignedFps takes max not sum", "[AiDetectorFps]") {
     using ai_detector_fps::ChannelAssignedFps;
     REQUIRE(ChannelAssignedFps(makeChannel("ch", {})) == Approx(0.0f));
@@ -172,11 +188,14 @@ TEST_CASE("AiDetectorFps CanAccept placement matrix", "[AiDetectorFps]") {
         REQUIRE(CanAccept(ch, "ch1", 5.0f, kMaxReuse, kBudget));  // max stays 24, delta 0
     }
 
-    SECTION("profile can split 12fps at two channels without changing the compiled default") {
-        const auto profile = ai_detector_fps::ParseReuseProfile("5:3,12:2,24:1");
+    SECTION("default profile splits 12fps at two channels and 16fps at one channel") {
+        const auto profile = ai_detector_fps::DefaultReuseProfile();
         std::vector<AiDetectorChannel> two = {makeChannel("ch1", {{"t1", 12.0f}}),
                                               makeChannel("ch2", {{"t2", 12.0f}})};
         REQUIRE_FALSE(CanAccept(two, "ch3", 12.0f, kMaxReuse, kBudget, profile));
+
+        std::vector<AiDetectorChannel> one = {makeChannel("ch1", {{"t1", 16.0f}})};
+        REQUIRE_FALSE(CanAccept(one, "ch2", 16.0f, kMaxReuse, kBudget, profile));
     }
 
     SECTION("same-channel higher-fps task raising max beyond budget is rejected by the gate") {


### PR DESCRIPTION
## Summary

将 AiDetector 共享实例分配从"固定通道复用数"演进为"通道数上限 ∧ 每实例 fps 预算"双重约束,解决高速检测场景在默认 `max_reuse_count_=6` 下的崩溃,并支撑 24/12/低速混合部署分片。

- `max_reuse_count_` 6→3(`AiDetector.cc:54`,短期稳定性修正,可独立合入)。
- 新增 `src/flow/detect/AiDetectorFps.h`:无硬件依赖的头文件内自由函数(`NormalizeRequestedFps`/`ChannelAssignedFps`/`AssignedFps`/`DeltaFpsForTask`/`CanAccept`),`AiDetectorChannel`/`AiDetectorTaskBinding` 结构体迁入,便于纯计算单测。
- `AiDetector` 新增 `instance_fps_budget_`(默认 36,按 algCode 查表 `kAlgFpsBudget` 可覆盖);新增 `AddTask(channel, task, requested_fps)` 重载,旧签名保留转调。
- `AiDetectMng` 隐藏(hides,非 override)基类非虚模板方法 `GetInst`,接入分配规则:① 已存在 channel 一律复用;② fps≤0 独占新建;③ 否则首个满足 `通道数≤3 ∧ AssignedFps+delta≤36` 的实例;④ 都不满足则新建。
- 分配日志含 `requestedFps/normalizedFps/delta/assignedFps/budget/channelCount/runtimeInFps` 与 decision,用于复盘负载模型。
- `NormalizeRequestedFps` 对 NaN/+inf 走保守估值(isfinite 守卫)。
- Catch2 单测覆盖分配矩阵(12×3 单实例 / 12×4 拆 3+1 / 24×2 必拆 / 24+12 同实例 / 通道硬上限 / 同 channel 升级超预算)。

## Type of change

- [x] Feature
- [x] Refactor

## Area

- [x] Backend service
- [x] Pipeline / scenario configuration

## Verification

```text
# 格式 / 静态分析(pre-commit 钩子,每 commit 均过)
./scripts/format_check.sh --staged --check     # All files properly formatted
./scripts/static_analysis.sh --staged --cppcheck  # no error-level issues

# aarch64 交叉编译(Sophon 构建容器)
docker-compose -f docker-compose.sophon.yml run --rm --no-deps cosmo-sophon-package ./scripts/build_test.sh
docker-compose -f docker-compose.sophon.yml run --rm cosmo-sophon-package ./scripts/build.sh
# → cosmo-tests / cosmo-engine 零错误链接成功

# 单测(设备 0.44,/tmp + LD_LIBRARY_PATH=/appfs/cosmo_wander/cwai_data/lib)
./cosmo-tests "[AiDetectorFps]" --reporter console
# → All tests passed (22 assertions in 5 test cases)

# 0.44 生产热替换验证
# 引擎干净启动,分配日志:MaxReuse:3 FpsBudget:36;Place 6666111 ch:LX..0000 -> create-new;
# Place 6666111 ch:LX..0002 -> accept-existing idx:0 chs:2 assignedFpsBefore:5 delta:5 budget:36;
# 不同 algCode 各自成实例池;0 崩溃/FATAL/Segfault。
```

## Documentation impact

- [x] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
  - `AiDetectorChannel::tasks` 元素类型变更(`string`→`AiDetectorTaskBinding`),仅 `src/flow/detect` 内部 6 处同步;对外无新 API。
  - `TaskIsFull()` 保留(Dino/Qwen3VL/Sam2 仍走基类 `GetInst`+`TaskIsFull`,行为不变);旧 `AddTask(channel,task)` 签名保留转调。
  - 仅 `AiDetectMng` 启用 fps-aware,其余检测器不变。
- [x] This change may affect ... deployment:见 Notes,生产构建设备有硬件看门狗,部署注意。

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented. (无新依赖)
- [x] Documentation was updated if behavior changed. (follow-up)
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Notes for reviewers

**核心待确认:这套 fps-aware 是否值得上,还是只留 `max_reuse=3`(commit `d62e8f2e`)?请给方向。**

1. **容量收益尚未干净验证**:在 0.22 对 12fps 做了 A/B——全量(本 PR)停在 4 路,commit-1(`max_reuse=3`)到 9 路。但该 A/B **被设备状态污染**:commit-1 是设备**重启后干净状态**下跑的(stop cosmo 触发了硬件看门狗重启),全量是设备连续跑 ~50 分钟 bench 后的脏状态;同一份 commit-1 代码不同状态下也 6↔9 路波动。两版本溢出模式一致(检测器实例 ~15fps/实例 NPU 天花板,`queue is full Discard:30→60`)。**干净 A/B(reboot-controlled)前,容量收益无法定论。**

2. **12fps 下理论中性**:预算 36 = 12×3,放行结果与 commit-1 完全一致(3 路/实例),未碰每帧推理热路径。fps-aware 仅在 fps>12 时改变行为(每实例少放、实例变多)——这是否是想要的,请确认。

3. **两个方向**:(a) 只合 commit 1(简单修复,已验证稳到 6 路);(b) 合入全部 fps-aware,后续做干净 A/B 再按实测吞吐调 `instance_fps_budget_`(目前 36 偏高于该模型 ~19fps/实例 的真实吞吐)。

4. **部署注意**:0.22/0.44 等生产构建(`DEV_MODE=OFF`)有硬件看门狗,`systemctl stop cosmo` 会触发设备重启;热替换用 scp→`sudo cp .new`→`mv` 重命名→`systemctl restart`(restart 在看门狗超时内,不触发重启),不要长时间 stop。

5. 源分支 `feat/ai-detector-fps-aware` 已 rebase 到最新 `origin/main`,6 个 commit 均含 `Signed-off-by`(DCO),未 push(由维护者推送/合并)。
