### PR TITLE
Fix RTSP passwords containing unescaped at signs

### DIFF
--- a/src/media/RtspDemuxStrategy.cc
+++ b/src/media/RtspDemuxStrategy.cc
@@ -3,6 +3,7 @@
 #include "media/RtspDemuxStrategy.h"
 
 #include "util/Log.h"
+#include "util/RtspUrlUtil.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,20 +37,22 @@ util::ErrorEnum RtspDemuxStrategy::OpenInput(AVFormatContext*& fmt_ctx, const st
     av_dict_set(&options, "stimeout", stimeout.c_str(), 0);
     av_dict_set(&options, "fflags", "nobuffer", 0);
 
-    int ret = avformat_open_input(&fmt_ctx, filename.c_str(), nullptr, &options);
+    const std::string normalized_url = util::NormalizeRtspUrl(filename);
+    int ret = avformat_open_input(&fmt_ctx, normalized_url.c_str(), nullptr, &options);
     av_dict_free(&options);
     if (ret != 0 || !fmt_ctx) {
         if (fmt_ctx) {
             avformat_close_input(&fmt_ctx);
             fmt_ctx = nullptr;
         }
-        LOG_WARN("{}Open {} failed. ret:{} [{}]", kTag, filename, ret, GetAvErr(ret));
+        LOG_WARN("{}Open {} failed. ret:{} [{}]", kTag, util::RedactRtspUrl(normalized_url), ret,
+                 GetAvErr(ret));
         if (std::string::npos != GetAvErr(ret).find("Unauthorized")) {
             return util::ErrorEnum::DemuxOpenStreamUnauthorized;
         }
         return util::ErrorEnum::DemuxOpenStreamFail;
     }
-    LOG_INFO("{}Open {}. ", kTag, filename);
+    LOG_INFO("{}Open {}. ", kTag, util::RedactRtspUrl(normalized_url));
     return util::ErrorEnum::Success;
 }
 

--- a/src/service/camera/impl/CameraDeviceCrud.cc
+++ b/src/service/camera/impl/CameraDeviceCrud.cc
@@ -13,6 +13,7 @@
 #include "util/FileUtil.h"
 #include "util/Log.h"
 #include "util/PaginationHelper.h"
+#include "util/RtspUrlUtil.h"
 #include "util/dto/ChannelStatusDto.h"
 
 namespace cosmo::service {
@@ -96,7 +97,8 @@ util::ErrorEnum CameraServiceImpl::Add(MsgCameraInfo& config, std::string& id) {
             LOG_INFO("camera->url:{}", camera->url);
             util::FileMoveWithRename(config.url, camera->url);
         } else {
-            camera->url = config.url;
+            camera->url = util::NormalizeRtspUrl(config.url);
+            config.url  = camera->url;
         }
 
         camera->channelType = static_cast<int>(config.channelType);
@@ -124,7 +126,8 @@ util::ErrorEnum CameraServiceImpl::Update(MsgCameraInfo& config) {
         camera->channelName    = config.channelName;
         // Local video channels cannot modify URL
         if (MsgCameraType::MsgCameraTypeLocalVideo != static_cast<MsgCameraType>(camera->channelType)) {
-            camera->url = config.url;
+            camera->url = util::NormalizeRtspUrl(config.url);
+            config.url  = camera->url;
         }
         // Update channel URL directly (inlined from CameraTaskMng::SetChannelUrl)
         if (camera->channel_url_ != camera->url) {

--- a/src/service/camera/impl/CameraServiceImpl.cc
+++ b/src/service/camera/impl/CameraServiceImpl.cc
@@ -38,6 +38,7 @@
 #include "util/Log.h"
 #include "util/PaginationHelper.h"
 #include "util/PathUtil.h"
+#include "util/RtspUrlUtil.h"
 #include "util/TimeUtil.h"
 #include "util/dto/ChannelStatusDto.h"
 
@@ -122,7 +123,8 @@ namespace {
     }
 
     // Lightweight URL connectivity check (TCP socket probe).
-    bool CheckUrlConnectivity(const std::string& urlStr) {
+    bool CheckUrlConnectivity(const std::string& inputUrl) {
+        const std::string urlStr = util::NormalizeRtspUrl(inputUrl);
         if (urlStr.empty())
             return false;
 
@@ -159,7 +161,7 @@ namespace {
         if (protoPos != std::string::npos) {
             std::string withoutProto = urlStr.substr(protoPos + 3);
             // Strip out auth part user:pass@
-            auto atPos = withoutProto.find("@");
+            auto atPos = withoutProto.rfind('@');
             if (atPos != std::string::npos) {
                 withoutProto = withoutProto.substr(atPos + 1);
             }
@@ -620,6 +622,7 @@ void CameraServiceImpl::LoadConfig() {
     cameras_       = detail::CameraConfigPersistence::LoadConfig(conf_file_path_, conf_file_name_);
     int max_number = -1;
     for (const auto& camera : cameras_) {
+        camera->url = util::NormalizeRtspUrl(camera->url);
         LOG_INFO("LoadConfig channel Id {}", camera->videoChannelId);
         InitCameraChannel(camera);
         int current_number = -1;

--- a/src/service/camera/impl/CameraServiceImpl.cc
+++ b/src/service/camera/impl/CameraServiceImpl.cc
@@ -386,7 +386,7 @@ util::ErrorEnum CameraServiceImpl::MakeCameraTask(const CameraEntityPtr& camera,
     task->task_id_        = ChannelAlgIdToTaskId(camera->videoChannelId, task->algorithm_code_);
     task->algorithm_name_ = algData->algorithmName;
     auto taskUnit         = std::make_shared<CameraTaskUnit>(camera->conf_file_path_, camera->videoChannelId,
-                                                     task->algorithm_code_, models);
+                                                             task->algorithm_code_, models);
     if (!taskUnit->IsReady()) {
         auto status = taskUnit->GetStatus();
         LOG_WARN("[{}/{}] Make Task failed, unit status:{}", camera->videoChannelId, task->algorithm_code_,

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(cosmo_util OBJECT
     Log.cc               Log.h
     NToL.cc              NToL.h
     PeriodicTimer.cc     PeriodicTimer.h
+    RtspUrlUtil.cc       RtspUrlUtil.h
     ScoreCalc.cc         ScoreCalc.h
     StringUtil.cc        StringUtil.h
     Thread.cc            Thread.h

--- a/src/util/RtspUrlUtil.cc
+++ b/src/util/RtspUrlUtil.cc
@@ -1,0 +1,69 @@
+#include "util/RtspUrlUtil.h"
+
+namespace cosmo::util {
+
+namespace {
+    constexpr std::string_view kRtspPrefix = "rtsp://";
+
+    bool GetAuthorityRange(std::string_view url, size_t& begin, size_t& end) {
+        if (url.rfind(kRtspPrefix, 0) != 0) {
+            return false;
+        }
+
+        begin = kRtspPrefix.size();
+        end   = url.find_first_of("/?#", begin);
+        if (end == std::string_view::npos) {
+            end = url.size();
+        }
+        return end > begin;
+    }
+}  // namespace
+
+std::string NormalizeRtspUrl(std::string_view url) {
+    size_t authority_begin = 0;
+    size_t authority_end   = 0;
+    if (!GetAuthorityRange(url, authority_begin, authority_end)) {
+        return std::string(url);
+    }
+
+    const size_t auth_separator = url.rfind('@', authority_end - 1);
+    if (auth_separator == std::string_view::npos || auth_separator < authority_begin) {
+        return std::string(url);
+    }
+
+    std::string normalized;
+    normalized.reserve(url.size());
+    for (size_t i = 0; i < url.size(); ++i) {
+        if (i >= authority_begin && i < auth_separator && url[i] == '@') {
+            normalized.append("%40");
+        } else {
+            normalized.push_back(url[i]);
+        }
+    }
+    return normalized;
+}
+
+std::string RedactRtspUrl(std::string_view url) {
+    std::string redacted = NormalizeRtspUrl(url);
+
+    size_t authority_begin = 0;
+    size_t authority_end   = 0;
+    if (!GetAuthorityRange(redacted, authority_begin, authority_end)) {
+        return redacted;
+    }
+
+    const size_t auth_separator = redacted.rfind('@', authority_end - 1);
+    if (auth_separator == std::string::npos || auth_separator < authority_begin) {
+        return redacted;
+    }
+
+    const size_t password_separator = redacted.find(':', authority_begin);
+    if (password_separator == std::string::npos || password_separator >= auth_separator) {
+        return redacted;
+    }
+
+    redacted.replace(password_separator + 1, auth_separator - password_separator - 1, "***");
+    return redacted;
+}
+
+}  // namespace cosmo::util

--- a/src/util/RtspUrlUtil.h
+++ b/src/util/RtspUrlUtil.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace cosmo::util {
+
+// Convert unescaped '@' characters inside RTSP userinfo to "%40" while
+// preserving the final '@' separator between credentials and the host.
+std::string NormalizeRtspUrl(std::string_view url);
+
+// Return an RTSP URL safe for logs by replacing the password with "***".
+std::string RedactRtspUrl(std::string_view url);
+
+}  // namespace cosmo::util

--- a/test/test_rtsp_url_util.cc
+++ b/test/test_rtsp_url_util.cc
@@ -1,5 +1,4 @@
 #include "catch_amalgamated.hpp"
-
 #include "util/RtspUrlUtil.h"
 
 using cosmo::util::NormalizeRtspUrl;
@@ -18,15 +17,13 @@ TEST_CASE("RtspUrlUtil: preserve encoded and unrelated URLs", "[rtsp-url]") {
     REQUIRE(NormalizeRtspUrl("rtsp://admin:p%40ss@camera.local/live") ==
             "rtsp://admin:p%40ss@camera.local/live");
     REQUIRE(NormalizeRtspUrl("rtsp://192.168.1.1:554/live") == "rtsp://192.168.1.1:554/live");
-    REQUIRE(NormalizeRtspUrl("http://admin:p@ss@example.com/live") ==
-            "http://admin:p@ss@example.com/live");
+    REQUIRE(NormalizeRtspUrl("http://admin:p@ss@example.com/live") == "http://admin:p@ss@example.com/live");
     REQUIRE(NormalizeRtspUrl("").empty());
 }
 
 TEST_CASE("RtspUrlUtil: redact passwords for logs", "[rtsp-url]") {
     REQUIRE(RedactRtspUrl("rtsp://admin:Jdzlab@2026@192.168.1.117:554/live") ==
             "rtsp://admin:***@192.168.1.117:554/live");
-    REQUIRE(RedactRtspUrl("rtsp://admin@192.168.1.1/live") ==
-            "rtsp://admin@192.168.1.1/live");
+    REQUIRE(RedactRtspUrl("rtsp://admin@192.168.1.1/live") == "rtsp://admin@192.168.1.1/live");
     REQUIRE(RedactRtspUrl("rtsp://192.168.1.1/live") == "rtsp://192.168.1.1/live");
 }

--- a/test/test_rtsp_url_util.cc
+++ b/test/test_rtsp_url_util.cc
@@ -1,0 +1,32 @@
+#include "catch_amalgamated.hpp"
+
+#include "util/RtspUrlUtil.h"
+
+using cosmo::util::NormalizeRtspUrl;
+using cosmo::util::RedactRtspUrl;
+
+TEST_CASE("RtspUrlUtil: normalize unescaped at signs in credentials", "[rtsp-url]") {
+    REQUIRE(NormalizeRtspUrl("rtsp://admin:plain@192.168.1.1:554/live") ==
+            "rtsp://admin:plain@192.168.1.1:554/live");
+    REQUIRE(NormalizeRtspUrl("rtsp://admin:Jdzlab@2026@192.168.1.117:554/Streaming/Channels/101") ==
+            "rtsp://admin:Jdzlab%402026@192.168.1.117:554/Streaming/Channels/101");
+    REQUIRE(NormalizeRtspUrl("rtsp://admin:p@a@s@s@camera.local/live") ==
+            "rtsp://admin:p%40a%40s%40s@camera.local/live");
+}
+
+TEST_CASE("RtspUrlUtil: preserve encoded and unrelated URLs", "[rtsp-url]") {
+    REQUIRE(NormalizeRtspUrl("rtsp://admin:p%40ss@camera.local/live") ==
+            "rtsp://admin:p%40ss@camera.local/live");
+    REQUIRE(NormalizeRtspUrl("rtsp://192.168.1.1:554/live") == "rtsp://192.168.1.1:554/live");
+    REQUIRE(NormalizeRtspUrl("http://admin:p@ss@example.com/live") ==
+            "http://admin:p@ss@example.com/live");
+    REQUIRE(NormalizeRtspUrl("").empty());
+}
+
+TEST_CASE("RtspUrlUtil: redact passwords for logs", "[rtsp-url]") {
+    REQUIRE(RedactRtspUrl("rtsp://admin:Jdzlab@2026@192.168.1.117:554/live") ==
+            "rtsp://admin:***@192.168.1.117:554/live");
+    REQUIRE(RedactRtspUrl("rtsp://admin@192.168.1.1/live") ==
+            "rtsp://admin@192.168.1.1/live");
+    REQUIRE(RedactRtspUrl("rtsp://192.168.1.1/live") == "rtsp://192.168.1.1/live");
+}


### PR DESCRIPTION
## What changed

- normalize unescaped `@` characters inside RTSP credentials to `%40`, while preserving the final credential/host separator
- apply normalization when camera configurations are added, updated, loaded, probed, and passed to FFmpeg
- use the last `@` when the connectivity probe separates credentials from the host
- redact RTSP passwords in demux open logs
- add unit coverage for raw `@`, pre-encoded `%40`, multiple `@` characters, unauthenticated URLs, non-RTSP URLs, and log redaction

## Why

Customers commonly use camera passwords containing `@`. A URL such as `rtsp://admin:Jdzlab@2026@192.168.1.117:554/...` was split at the first `@` by the lightweight connectivity probe, producing an invalid host and marking the camera offline. Passing the raw, ambiguous URL onward could also lead to inconsistent handling between code paths.

## Impact

Existing and newly entered RTSP URLs are normalized in the application layer; FFmpeg itself is unchanged. Previously encoded URLs remain unchanged, and non-RTSP URLs are not modified.

## Validation

- `git diff --cached --check` passed before commit
- added Catch2 unit tests in `test/test_rtsp_url_util.cc`
- local `cosmo-tests` was not run because this Windows environment does not have Docker, CMake, or a C++ compiler; CI should perform the full build and test run