### PR TITLE
feat(model): protect preset models — no export/delete, factory restore

### DIFF
--- a/src/api/MessageModelHandler.cc
+++ b/src/api/MessageModelHandler.cc
@@ -59,7 +59,7 @@ Model::MsgGetConfigSend MessageModelHandler::Handle(Model::MsgGetConfigRecv&& da
                                                     std::error_condition& errc) const {
     Model::MsgGetConfigSend retData{};
     errc = model_service_.GetModelConfig(data.modelCode, retData.resData.configJson,
-                                         retData.resData.isExportable);
+                                         retData.resData.isExportable, retData.resData.defaultConfigJson);
     return retData;
 }
 

--- a/src/api/MessageModelHandler.cc
+++ b/src/api/MessageModelHandler.cc
@@ -58,7 +58,8 @@ Model::MsgUploadTempSend MessageModelHandler::Handle(Model::MsgUploadTempRecv&& 
 Model::MsgGetConfigSend MessageModelHandler::Handle(Model::MsgGetConfigRecv&& data,
                                                     std::error_condition& errc) const {
     Model::MsgGetConfigSend retData{};
-    errc = model_service_.GetModelConfig(data.modelCode, retData.resData.configJson);
+    errc = model_service_.GetModelConfig(data.modelCode, retData.resData.configJson,
+                                         retData.resData.isExportable);
     return retData;
 }
 

--- a/src/service/model/IModelService.h
+++ b/src/service/model/IModelService.h
@@ -89,10 +89,12 @@ public:
     // ── Model Configuration ──
 
     /// Get the JSON configuration of a model.
-    /// @param modelCode  Model code identifier.
-    /// @param configJson [out] Configuration JSON string.
+    /// @param modelCode    Model code identifier.
+    /// @param configJson   [out] Configuration JSON string.
+    /// @param isExportable [out] Whether the model may be exported (false for preset models).
     /// @return ErrorEnum::kSuccess on success.
-    virtual cosmo::util::ErrorEnum GetModelConfig(const std::string& modelCode, std::string& configJson) = 0;
+    virtual cosmo::util::ErrorEnum GetModelConfig(const std::string& modelCode, std::string& configJson,
+                                                  bool& isExportable) = 0;
 
     /// Save a model's JSON configuration.
     /// @param modelCode  Model code identifier.

--- a/src/service/model/IModelService.h
+++ b/src/service/model/IModelService.h
@@ -89,12 +89,13 @@ public:
     // ── Model Configuration ──
 
     /// Get the JSON configuration of a model.
-    /// @param modelCode    Model code identifier.
-    /// @param configJson   [out] Configuration JSON string.
-    /// @param isExportable [out] Whether the model may be exported (false for preset models).
+    /// @param modelCode         Model code identifier.
+    /// @param configJson        [out] Configuration JSON string.
+    /// @param isExportable      [out] Whether the model may be exported (false for preset models).
+    /// @param defaultConfigJson [out] Factory config snapshot for "restore defaults"; empty if absent.
     /// @return ErrorEnum::kSuccess on success.
     virtual cosmo::util::ErrorEnum GetModelConfig(const std::string& modelCode, std::string& configJson,
-                                                  bool& isExportable) = 0;
+                                                  bool& isExportable, std::string& defaultConfigJson) = 0;
 
     /// Save a model's JSON configuration.
     /// @param modelCode  Model code identifier.

--- a/src/service/model/dto/ModelDto.cc
+++ b/src/service/model/dto/ModelDto.cc
@@ -325,10 +325,12 @@ void to_json(nlohmann::json& j, const MsgUploadTempSend::ResData& v) {
 
 void from_json(const nlohmann::json& j, MsgGetConfigSend::ResData& v) {
     JSON_OPT(j, v, configJson);
+    JSON_OPT(j, v, isExportable);
 }
 
 void to_json(nlohmann::json& j, const MsgGetConfigSend::ResData& v) {
-    j["configJson"] = v.configJson;
+    j["configJson"]   = v.configJson;
+    j["isExportable"] = v.isExportable;
 }
 
 }  // namespace cosmo::Model

--- a/src/service/model/dto/ModelDto.cc
+++ b/src/service/model/dto/ModelDto.cc
@@ -272,6 +272,7 @@ void from_json(const nlohmann::json& j, MsgModel& v) {
     JSON_OPT(j, v, inputDim);
     JSON_OPT(j, v, outputCount);
     JSON_OPT(j, v, outputDim);
+    JSON_OPT(j, v, isExportable);
 }
 
 void to_json(nlohmann::json& j, const MsgModel& v) {
@@ -293,6 +294,7 @@ void to_json(nlohmann::json& j, const MsgModel& v) {
     j["inputDim"]       = v.inputDim;
     j["outputCount"]    = v.outputCount;
     j["outputDim"]      = v.outputDim;
+    j["isExportable"]   = v.isExportable;
 }
 
 void from_json(const nlohmann::json& j, MsgPageSend::ResData& v) {
@@ -326,11 +328,13 @@ void to_json(nlohmann::json& j, const MsgUploadTempSend::ResData& v) {
 void from_json(const nlohmann::json& j, MsgGetConfigSend::ResData& v) {
     JSON_OPT(j, v, configJson);
     JSON_OPT(j, v, isExportable);
+    JSON_OPT(j, v, defaultConfigJson);
 }
 
 void to_json(nlohmann::json& j, const MsgGetConfigSend::ResData& v) {
-    j["configJson"]   = v.configJson;
-    j["isExportable"] = v.isExportable;
+    j["configJson"]        = v.configJson;
+    j["isExportable"]      = v.isExportable;
+    j["defaultConfigJson"] = v.defaultConfigJson;
 }
 
 }  // namespace cosmo::Model

--- a/src/service/model/dto/ModelDto.h
+++ b/src/service/model/dto/ModelDto.h
@@ -155,6 +155,7 @@ namespace Model {
     struct MsgGetConfigSend : public MsgSendHead {
         struct ResData {
             std::string configJson;
+            bool isExportable{true};  // false for preset (encrypted, device-bound) models
             friend void to_json(nlohmann::json& j, const ResData& v);
             friend void from_json(const nlohmann::json& j, ResData& v);
         } resData;

--- a/src/service/model/dto/ModelDto.h
+++ b/src/service/model/dto/ModelDto.h
@@ -50,6 +50,8 @@ namespace Model {
         std::string inputDim{"1"};
         int outputCount{1};
         std::string outputDim{"5"};
+        bool isExportable{
+            true};  // false for preset (encrypted, device-bound) models — gates export/delete/update
         friend void to_json(nlohmann::json& j, const MsgModel& v);
         friend void from_json(const nlohmann::json& j, MsgModel& v);
     };
@@ -155,7 +157,8 @@ namespace Model {
     struct MsgGetConfigSend : public MsgSendHead {
         struct ResData {
             std::string configJson;
-            bool isExportable{true};  // false for preset (encrypted, device-bound) models
+            bool isExportable{true};        // false for preset (encrypted, device-bound) models
+            std::string defaultConfigJson;  // factory snapshot for "restore defaults"; empty if absent
             friend void to_json(nlohmann::json& j, const ResData& v);
             friend void from_json(const nlohmann::json& j, ResData& v);
         } resData;

--- a/src/service/model/impl/ModelImportExporter.cc
+++ b/src/service/model/impl/ModelImportExporter.cc
@@ -56,6 +56,14 @@ util::ErrorEnum ModelImportExporter::ExportModelConfig(const std::string& modelC
         LOG_WARN("Model directory not found for modelCode: {}", modelCode);
         return util::ErrorEnum::FileNotExist;
     }
+
+    // Preset (built-in) models are encrypted and device-bound — they cannot be
+    // used on other machines, so refuse to export them.
+    if (cosmo::path::IsWithinRoot(cosmo::path::GetPresetModelPath(), model_dir_path)) {
+        LOG_WARN("Reject export of preset (built-in) model {}: device-bound encryption", modelCode);
+        return util::ErrorEnum::DefaultCantBeExport;
+    }
+
     const std::string models_dir = fs::path(model_dir_path).parent_path().string();
 
     // Clean model name for filename

--- a/src/service/model/impl/ModelServiceCrud.cc
+++ b/src/service/model/impl/ModelServiceCrud.cc
@@ -14,7 +14,6 @@
 #include <fstream>
 #include <regex>
 #include <sstream>
-#include <unordered_set>
 
 #include "nlohmann/json.hpp"
 #include "service/algorithm/IAlgorithmQuery.h"
@@ -142,7 +141,7 @@ void ModelServiceImpl::NotifyAlgorithmsChanged(const std::string& modelCode, boo
 // ──────────────────────────────────────────────
 
 cosmo::util::ErrorEnum ModelServiceImpl::GetModelConfig(const std::string& modelCode, std::string& configJson,
-                                                        bool& isExportable) {
+                                                        bool& isExportable, std::string& defaultConfigJson) {
     std::string model_dir_path = FindModelDir(modelCode);
     if (model_dir_path.empty()) {
         LOG_WARN("Model directory not found for modelCode: {}", modelCode);
@@ -153,7 +152,8 @@ cosmo::util::ErrorEnum ModelServiceImpl::GetModelConfig(const std::string& model
     // so they must not be exported.
     isExportable = !cosmo::path::IsWithinRoot(cosmo::path::GetPresetModelPath(), model_dir_path);
 
-    std::string config_path = (std::filesystem::path(model_dir_path) / "config.json").string();
+    const std::filesystem::path model_dir(model_dir_path);
+    const std::string config_path = (model_dir / "config.json").string();
 
     std::ifstream file(config_path);
     if (!file.is_open()) {
@@ -165,6 +165,17 @@ cosmo::util::ErrorEnum ModelServiceImpl::GetModelConfig(const std::string& model
     buffer << file.rdbuf();
     configJson = buffer.str();
     file.close();
+
+    // Factory config snapshot (for "restore defaults"); empty when absent (e.g. user models or
+    // preset models before Init snapshots them) — caller must handle empty gracefully.
+    defaultConfigJson.clear();
+    std::ifstream dfile((model_dir / "config.default.json").string());
+    if (dfile.is_open()) {
+        std::stringstream dbuf;
+        dbuf << dfile.rdbuf();
+        defaultConfigJson = dbuf.str();
+        dfile.close();
+    }
 
     LOG_INFO("Successfully read config.json for modelCode: {}", modelCode);
     return cosmo::util::ErrorEnum::Success;
@@ -241,20 +252,16 @@ cosmo::util::ErrorEnum ModelServiceImpl::DeleteModel(const std::string& modelCod
         return cosmo::util::ErrorEnum::InvalidParam;
     }
 
-    // Built-in models cannot be deleted (face lib / uniform lib dependency)
-    static const std::unordered_set<std::string> kBuiltinModels = {
-        "1000001", "1000005", "1000010", "1000012", "1000016",  // Face
-        "1001003", "1001007", "1001008"                         // Body
-    };
-    if (kBuiltinModels.count(modelCode)) {
-        LOG_WARN("Cannot delete built-in model: {}", modelCode);
-        return cosmo::util::ErrorEnum::DefaultCantBeDelete;
-    }
-
     std::string model_dir_path = FindModelDir(modelCode);
     if (model_dir_path.empty()) {
         LOG_WARN("Model directory not found for modelCode: {}", modelCode);
         return cosmo::util::ErrorEnum::FileNotExist;
+    }
+
+    // Preset (built-in) models are encrypted / device-bound and must not be deleted.
+    if (cosmo::path::IsWithinRoot(cosmo::path::GetPresetModelPath(), model_dir_path)) {
+        LOG_WARN("Cannot delete preset (built-in) model: {}", modelCode);
+        return cosmo::util::ErrorEnum::DefaultCantBeDelete;
     }
 
     namespace fs = std::filesystem;
@@ -285,16 +292,6 @@ cosmo::util::ErrorEnum ModelServiceImpl::UpdateModel(const std::string& modelCod
     if (modelCode.empty()) {
         LOG_WARN("{}", "modelCode is empty in update request");
         return cosmo::util::ErrorEnum::InvalidParam;
-    }
-
-    // Built-in models cannot be modified (face lib / uniform lib dependency)
-    static const std::unordered_set<std::string> kBuiltinModels = {
-        "1000001", "1000005", "1000010", "1000012", "1000016",  // Face
-        "1001003", "1001007", "1001008"                         // Body
-    };
-    if (kBuiltinModels.count(modelCode)) {
-        LOG_WARN("Cannot update built-in model: {}", modelCode);
-        return cosmo::util::ErrorEnum::DefaultCantBeUpdate;
     }
 
     std::string model_dir_path = FindModelDir(modelCode);

--- a/src/service/model/impl/ModelServiceCrud.cc
+++ b/src/service/model/impl/ModelServiceCrud.cc
@@ -25,6 +25,7 @@
 #include "util/Exec.h"
 #include "util/JsonFileUtil.h"
 #include "util/JsonStructUtil.h"
+#include "util/PathUtil.h"
 #include "util/StringUtil.h"
 #include "util/TimeUtil.h"
 
@@ -140,13 +141,17 @@ void ModelServiceImpl::NotifyAlgorithmsChanged(const std::string& modelCode, boo
 // Config CRUD
 // ──────────────────────────────────────────────
 
-cosmo::util::ErrorEnum ModelServiceImpl::GetModelConfig(const std::string& modelCode,
-                                                        std::string& configJson) {
+cosmo::util::ErrorEnum ModelServiceImpl::GetModelConfig(const std::string& modelCode, std::string& configJson,
+                                                        bool& isExportable) {
     std::string model_dir_path = FindModelDir(modelCode);
     if (model_dir_path.empty()) {
         LOG_WARN("Model directory not found for modelCode: {}", modelCode);
         return cosmo::util::ErrorEnum::FileNotExist;
     }
+
+    // Preset (built-in) models live under the preset path and are encrypted / device-bound,
+    // so they must not be exported.
+    isExportable = !cosmo::path::IsWithinRoot(cosmo::path::GetPresetModelPath(), model_dir_path);
 
     std::string config_path = (std::filesystem::path(model_dir_path) / "config.json").string();
 

--- a/src/service/model/impl/ModelServiceImpl.cc
+++ b/src/service/model/impl/ModelServiceImpl.cc
@@ -102,15 +102,26 @@ void ModelServiceImpl::Init() {
         [this](const std::string& code, const std::string& path) { SetModelPathMapping(code, path); });
 
     // Scan models directory to build path mappings at startup
-    namespace fs = std::filesystem;
+    namespace fs                  = std::filesystem;
+    const std::string preset_root = cosmo::path::GetPresetModelPath();
     for (const auto& modelsDir : GetModelSearchPaths()) {
+        const bool is_preset_dir = cosmo::path::IsWithinRoot(preset_root, modelsDir);
         std::error_code ec;
         for (const auto& dirEntry : fs::directory_iterator(modelsDir, ec)) {
             if (!dirEntry.is_directory())
                 continue;
-            auto cfg = detail::ModelConfigParser::Parse((dirEntry.path() / "config.json").string());
+            const fs::path cfg_path = dirEntry.path() / "config.json";
+            auto cfg                = detail::ModelConfigParser::Parse(cfg_path.string());
             if (cfg.valid && !cfg.algorithm_code.empty() && GetModelPathMapping(cfg.algorithm_code).empty()) {
                 SetModelPathMapping(cfg.algorithm_code, dirEntry.path().string());
+            }
+            // Preset models: snapshot the factory config so "restore defaults" can revert user edits.
+            if (is_preset_dir) {
+                const fs::path default_cfg = dirEntry.path() / "config.default.json";
+                std::error_code cp_ec;
+                if (!fs::exists(default_cfg, cp_ec)) {
+                    fs::copy_file(cfg_path, default_cfg, fs::copy_options::skip_existing, cp_ec);
+                }
             }
         }
         if (ec) {

--- a/src/service/model/impl/ModelServiceImpl.h
+++ b/src/service/model/impl/ModelServiceImpl.h
@@ -42,7 +42,7 @@ public:
 
     // ---- Config CRUD ----
     cosmo::util::ErrorEnum GetModelConfig(const std::string& modelCode, std::string& configJson,
-                                          bool& isExportable) override;
+                                          bool& isExportable, std::string& defaultConfigJson) override;
     cosmo::util::ErrorEnum SaveModelConfig(const std::string& modelCode,
                                            const std::string& configJson) override;
 

--- a/src/service/model/impl/ModelServiceImpl.h
+++ b/src/service/model/impl/ModelServiceImpl.h
@@ -41,7 +41,8 @@ public:
                                           std::string& persistentPath) override;
 
     // ---- Config CRUD ----
-    cosmo::util::ErrorEnum GetModelConfig(const std::string& modelCode, std::string& configJson) override;
+    cosmo::util::ErrorEnum GetModelConfig(const std::string& modelCode, std::string& configJson,
+                                          bool& isExportable) override;
     cosmo::util::ErrorEnum SaveModelConfig(const std::string& modelCode,
                                            const std::string& configJson) override;
 

--- a/src/service/model/impl/ModelServiceImpl_Query.cc
+++ b/src/service/model/impl/ModelServiceImpl_Query.cc
@@ -27,7 +27,9 @@ void ModelServiceImpl::QueryModels(const std::string& modelName, const std::stri
     std::vector<cosmo::Model::MsgModel> all_models;
     std::unordered_set<std::string> seenModelCodes;
 
-    for (const auto& models_dir : GetModelSearchPaths()) {
+    const std::vector<std::string> search_paths = GetModelSearchPaths();
+    const std::string& preset_path              = search_paths.back();
+    for (const auto& models_dir : search_paths) {
         std::error_code ec;
         for (const auto& dirEntry : fs::directory_iterator(models_dir, ec)) {
             if (!dirEntry.is_directory())
@@ -65,6 +67,10 @@ void ModelServiceImpl::QueryModels(const std::string& modelName, const std::stri
             }
 
             model.gpuCode = cosmo::util::kEngineType;
+
+            // Preset (built-in) models live under the preset search path and are
+            // encrypted / read-only — not deletable / updatable / exportable.
+            model.isExportable = (models_dir != preset_path);
 
             // Convert parsed labels to MsgModelLabel and serialize to JSON string
             std::vector<cosmo::Model::MsgModelLabel> model_labels;

--- a/src/util/ErrorCode.cc
+++ b/src/util/ErrorCode.cc
@@ -125,6 +125,7 @@ std::string ErrorCategory::message(int code) const {
         CaseStr(TimeTemplateCountLimit, "时间模板数量超过上限");
         CaseStr(DefaultCantBeDelete, "默认不可删除");
         CaseStr(DefaultCantBeUpdate, "默认不可修改");
+        CaseStr(DefaultCantBeExport, "默认不可导出");
         CaseStr(CameraNotExist, "相机不存在");
         CaseStr(CameraNotOnline, "相机不在线");
         CaseStr(CameraCountLimit, "相机数量达到上限");
@@ -228,7 +229,9 @@ std::string ErrorCategory::message(int code) const {
     return {};
 }
 
-#define CaseName(X) case cosmo::util::ErrorEnum::X: return #X
+#define CaseName(X)                                                                                          \
+    case cosmo::util::ErrorEnum::X:                                                                          \
+        return #X
 
 std::string ErrorEnumName(ErrorEnum code) {
     switch (code) {
@@ -315,6 +318,7 @@ std::string ErrorEnumName(ErrorEnum code) {
         CaseName(TimeTemplateCountLimit);
         CaseName(DefaultCantBeDelete);
         CaseName(DefaultCantBeUpdate);
+        CaseName(DefaultCantBeExport);
         CaseName(CameraNotExist);
         CaseName(CameraNotOnline);
         CaseName(CameraCountLimit);

--- a/src/util/ErrorCode.h
+++ b/src/util/ErrorCode.h
@@ -96,6 +96,7 @@ enum class ErrorEnum : uint32_t {
     TimeTemplateCountLimit,  // Time template count exceeds limit
     DefaultCantBeDelete,     // Default cannot be deleted
     DefaultCantBeUpdate,     // Default cannot be modified
+    DefaultCantBeExport,     // Default cannot be exported (preset/encrypted model)
     CameraNotExist,          // Camera does not exist
     CameraNotOnline,         // Camera is not online
     CameraCountLimit,        // Camera count reached the limit

--- a/src/util/PathUtil.cc
+++ b/src/util/PathUtil.cc
@@ -300,6 +300,12 @@ std::string GetModelPath() {
     return p;
 }
 
+std::string GetPresetModelPath() {
+    auto p = PresetModelPath();
+    EnsureDir(p);
+    return p;
+}
+
 std::vector<std::string> GetModelSearchPaths() {
     auto mp = ModelPath();
     auto pp = PresetModelPath();

--- a/src/util/PathUtil.h
+++ b/src/util/PathUtil.h
@@ -112,6 +112,11 @@ std::string GetTemporaryDirPath();
 /// Primary user model storage directory.
 std::string GetModelPath();
 
+/// Preset (built-in, device-bound) model storage directory. Models here ship
+/// with the product and are encrypted — they must not be exported to other
+/// machines. Counterpart to GetModelPath(); GetModelSearchPaths() returns both.
+std::string GetPresetModelPath();
+
 /// All directories to search for model files (user + preset).
 std::vector<std::string> GetModelSearchPaths();
 

--- a/src/web/src/i18n/locales/en-US.js
+++ b/src/web/src/i18n/locales/en-US.js
@@ -545,6 +545,7 @@ export default {
     exportFailed: 'Export failed',
     exportNetworkError: 'Export failed due to network error',
     saveFailedCannotExport: 'Failed to save config, unable to export',
+    presetModelNotExportable: 'Preset model cannot be exported',
     defaultRestored: 'Default config restored',
     addFailed: 'Add failed',
     uploading: 'Uploading',

--- a/src/web/src/i18n/locales/en-US.js
+++ b/src/web/src/i18n/locales/en-US.js
@@ -546,6 +546,7 @@ export default {
     exportNetworkError: 'Export failed due to network error',
     saveFailedCannotExport: 'Failed to save config, unable to export',
     presetModelNotExportable: 'Preset model cannot be exported',
+    noDefaultConfig: 'No factory config available to restore',
     defaultRestored: 'Default config restored',
     addFailed: 'Add failed',
     uploading: 'Uploading',

--- a/src/web/src/i18n/locales/zh-CN.js
+++ b/src/web/src/i18n/locales/zh-CN.js
@@ -545,6 +545,7 @@ export default {
     exportFailed: '导出失败',
     exportNetworkError: '导出失败，网络错误',
     saveFailedCannotExport: '保存配置失败，无法导出',
+    presetModelNotExportable: '预置模型不可导出',
     defaultRestored: '已恢复默认配置',
     addFailed: '添加失败',
     uploading: '上传中',

--- a/src/web/src/i18n/locales/zh-CN.js
+++ b/src/web/src/i18n/locales/zh-CN.js
@@ -546,6 +546,7 @@ export default {
     exportNetworkError: '导出失败，网络错误',
     saveFailedCannotExport: '保存配置失败，无法导出',
     presetModelNotExportable: '预置模型不可导出',
+    noDefaultConfig: '该模型无出厂配置，无法恢复默认',
     defaultRestored: '已恢复默认配置',
     addFailed: '添加失败',
     uploading: '上传中',

--- a/src/web/src/views/gam/countManagement/atomicModel/index.vue
+++ b/src/web/src/views/gam/countManagement/atomicModel/index.vue
@@ -236,8 +236,8 @@
       </div>
 
       <template #footer>
-        <el-button v-if="!defaultModels.includes(detailModel.modelCode)" @click="editFromDetail">{{ t('action.editModel') }}</el-button>
-        <el-button v-if="!defaultModels.includes(detailModel.modelCode)" type="danger" plain @click="deleteFromDetail">{{ t('action.delete') }}</el-button>
+        <el-button @click="editFromDetail">{{ t('action.editModel') }}</el-button>
+        <el-button v-if="detailModel.isExportable" type="danger" plain @click="deleteFromDetail">{{ t('action.delete') }}</el-button>
         <el-button type="primary" @click="modelDetailDialogVisible = false">{{ t('action.close') }}</el-button>
       </template>
     </el-dialog>
@@ -600,17 +600,6 @@ const addModelForm = reactive({
   normalizationMode: '0-1',
   colorChannel: 'rgb'
 })
-
-const defaultModels = ref([
-  '1000001',
-  '1000005',
-  '1000010',
-  '1000012',
-  '1000016',
-  '1001003',
-  '1001007',
-  '1001008'
-])
 
 const modelTypeGroups = computed(() => [
   {

--- a/src/web/src/views/gam/countManagement/modelConfig/index.vue
+++ b/src/web/src/views/gam/countManagement/modelConfig/index.vue
@@ -71,6 +71,7 @@ const modelType = ref('')
 const chipType = ref('')
 const version = ref('')
 const isExportable = ref(true)
+const defaultConfigJson = ref('')
 const showOther = ref(false)
 const flowData = ref({})
 const paramsConfig = ref({})
@@ -200,8 +201,17 @@ const handleReset = () => {
   proxy.$confirm(t('validate.confirmResetDefault'), t('common.notice'), {
     type: 'warning'
   }).then(() => {
-    if (raw.value) hydrate(raw.value)
-    proxy.$message.success(t('common.defaultRestored'))
+    const text = defaultConfigJson.value
+    if (!text) {
+      proxy.$message.warning(t('common.noDefaultConfig'))
+      return
+    }
+    try {
+      hydrate(JSON.parse(text))
+      proxy.$message.success(t('common.defaultRestored'))
+    } catch {
+      proxy.$message.error(t('validate.editFailed'))
+    }
   })
 }
 
@@ -215,6 +225,7 @@ const queryModelConfig = () => {
     const { resData } = res || {}
     const text = resData?.configJson || '{}'
     isExportable.value = resData?.isExportable !== false
+    defaultConfigJson.value = resData?.defaultConfigJson || ''
     let cfg = {}
     try {
       cfg = JSON.parse(text)

--- a/src/web/src/views/gam/countManagement/modelConfig/index.vue
+++ b/src/web/src/views/gam/countManagement/modelConfig/index.vue
@@ -14,7 +14,11 @@
       </div>
       <div class="actions">
         <el-button type="primary" size="small" @click="handleSave">{{ t('action.save') }}</el-button>
-        <el-button size="small" @click="handleExport">{{ t('action.export') }}</el-button>
+        <el-tooltip :content="t('common.presetModelNotExportable')" :disabled="isExportable" placement="top">
+          <span>
+            <el-button size="small" :disabled="!isExportable" @click="handleExport">{{ t('action.export') }}</el-button>
+          </span>
+        </el-tooltip>
         <el-button size="small" @click="handleReset">{{ t('action.restoreDefault') }}</el-button>
         <el-button size="small" @click="goBack">{{ t('action.goBack') }}</el-button>
       </div>
@@ -66,6 +70,7 @@ const modelCode = ref('')
 const modelType = ref('')
 const chipType = ref('')
 const version = ref('')
+const isExportable = ref(true)
 const showOther = ref(false)
 const flowData = ref({})
 const paramsConfig = ref({})
@@ -209,6 +214,7 @@ const queryModelConfig = () => {
   proxy.$API.getModelConfig({ modelCode: routeModelCode }).then((res) => {
     const { resData } = res || {}
     const text = resData?.configJson || '{}'
+    isExportable.value = resData?.isExportable !== false
     let cfg = {}
     try {
       cfg = JSON.parse(text)

--- a/test/mock/MockModelService.h
+++ b/test/mock/MockModelService.h
@@ -28,7 +28,7 @@ public:
                                       const std::string&, const std::string&, const std::string&,
                                       std::string&),
                override);
-    MAKE_MOCK2(GetModelConfig, cosmo::util::ErrorEnum(const std::string&, std::string&), override);
+    MAKE_MOCK3(GetModelConfig, cosmo::util::ErrorEnum(const std::string&, std::string&, bool&), override);
     MAKE_MOCK2(SaveModelConfig, cosmo::util::ErrorEnum(const std::string&, const std::string&), override);
     MAKE_MOCK0(GetModelComponents, std::vector<cosmo::Model::MsgModelComponent>(), override);
     MAKE_MOCK1(DeleteModel, cosmo::util::ErrorEnum(const std::string&), override);

--- a/test/mock/MockModelService.h
+++ b/test/mock/MockModelService.h
@@ -28,7 +28,8 @@ public:
                                       const std::string&, const std::string&, const std::string&,
                                       std::string&),
                override);
-    MAKE_MOCK3(GetModelConfig, cosmo::util::ErrorEnum(const std::string&, std::string&, bool&), override);
+    MAKE_MOCK4(GetModelConfig, cosmo::util::ErrorEnum(const std::string&, std::string&, bool&, std::string&),
+               override);
     MAKE_MOCK2(SaveModelConfig, cosmo::util::ErrorEnum(const std::string&, const std::string&), override);
     MAKE_MOCK0(GetModelComponents, std::vector<cosmo::Model::MsgModelComponent>(), override);
     MAKE_MOCK1(DeleteModel, cosmo::util::ErrorEnum(const std::string&), override);

--- a/test/test_message_model_handler.cc
+++ b/test/test_message_model_handler.cc
@@ -83,7 +83,7 @@ TEST_CASE("ModelHandler: GetModelConfig", "[model-handler]") {
     MockServiceRegistry mocks;
     auto handler = MakeHandler(mocks);
 
-    REQUIRE_CALL(mocks.modelSvc, GetModelConfig("model-1", _, _))
+    REQUIRE_CALL(mocks.modelSvc, GetModelConfig("model-1", _, _, _))
         .SIDE_EFFECT(_2 = "{\"key\":\"value\"}")
         .SIDE_EFFECT(_3 = true)
         .RETURN(cosmo::util::ErrorEnum::Success);

--- a/test/test_message_model_handler.cc
+++ b/test/test_message_model_handler.cc
@@ -83,8 +83,9 @@ TEST_CASE("ModelHandler: GetModelConfig", "[model-handler]") {
     MockServiceRegistry mocks;
     auto handler = MakeHandler(mocks);
 
-    REQUIRE_CALL(mocks.modelSvc, GetModelConfig("model-1", _))
+    REQUIRE_CALL(mocks.modelSvc, GetModelConfig("model-1", _, _))
         .SIDE_EFFECT(_2 = "{\"key\":\"value\"}")
+        .SIDE_EFFECT(_3 = true)
         .RETURN(cosmo::util::ErrorEnum::Success);
 
     Model::MsgGetConfigRecv data{};

--- a/test/test_model_import_exporter.cc
+++ b/test/test_model_import_exporter.cc
@@ -31,10 +31,11 @@ TEST_CASE("ModelImportExporter Tests", "[model]") {
     ModelImportExporter importExporter;
 
     std::string testRoot = "/tmp/cosmo_test_models";
-    cosmo::path::OverrideRootPathForTest(testRoot, testRoot);
+    // Separate user (udata) and preset (adata) roots so export-path checks don't flag test models.
+    cosmo::path::OverrideRootPathForTest(testRoot + "/udata", testRoot + "/adata");
 
-    std::string testModelDir    = testRoot + "/resource/models";
-    std::string testTemplateDir = testRoot + "/resource/model_template";
+    std::string testModelDir    = cosmo::path::GetModelPath();          // udata/resource/models (user)
+    std::string testTemplateDir = cosmo::path::GetModelTemplatePath();  // adata/resource/model_template
     fs::create_directories(testModelDir);
     fs::create_directories(testTemplateDir);
 

--- a/test/test_model_import_exporter.cc
+++ b/test/test_model_import_exporter.cc
@@ -31,11 +31,10 @@ TEST_CASE("ModelImportExporter Tests", "[model]") {
     ModelImportExporter importExporter;
 
     std::string testRoot = "/tmp/cosmo_test_models";
-    // Separate user (udata) and preset (adata) roots so export-path checks don't flag test models.
-    cosmo::path::OverrideRootPathForTest(testRoot + "/udata", testRoot + "/adata");
+    cosmo::path::OverrideRootPathForTest(testRoot, testRoot);
 
-    std::string testModelDir    = cosmo::path::GetModelPath();          // udata/resource/models (user)
-    std::string testTemplateDir = cosmo::path::GetModelTemplatePath();  // adata/resource/model_template
+    std::string testModelDir    = testRoot + "/resource/models";
+    std::string testTemplateDir = testRoot + "/resource/model_template";
     fs::create_directories(testModelDir);
     fs::create_directories(testTemplateDir);
 
@@ -55,7 +54,7 @@ TEST_CASE("ModelImportExporter Tests", "[model]") {
                                   if (code == "1234567")
                                       return testModelDir + "/1234567";
                                   if (code == "test_export_model")
-                                      return testModelDir + "/test_export_model";
+                                      return testRoot + "/export_target/test_export_model";
                                   return std::string("");
                               },
                               [&]() { return std::string("1234567"); }, [&](const nlohmann::json&) {},
@@ -389,7 +388,7 @@ TEST_CASE("ModelImportExporter Tests", "[model]") {
     }
 
     SECTION("2.4 ExportModelConfig：验证 tar.gz 创建") {
-        std::string exportModelDir = testModelDir + "/test_export_model";
+        std::string exportModelDir = testRoot + "/export_target/test_export_model";
         fs::create_directories(exportModelDir);
         std::ofstream outCfg(exportModelDir + "/config.json");
         outCfg << "{\"modelCode\": \"test_export_model\", \"algorithmVersion\": \"1.0.0\"}";

--- a/test/test_model_service_impl.cc
+++ b/test/test_model_service_impl.cc
@@ -120,11 +120,7 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
         }
 
         SECTION("UpdateModel 流程") {
-            // 预置（内置）模型不可更新 —— 在预置目录造一个
-            CreateTestModelOnDisk(testPresetDir, "preset_upd_001", "PresetUpdModel");
-            REQUIRE(sut.UpdateModel("preset_upd_001", "new_name", 4, "desc") ==
-                    cosmo::util::ErrorEnum::DefaultCantBeUpdate);
-
+            // UpdateModel 允许修改（含预置模型，config 改动可逆），这里验证用户模型可改
             ALLOW_CALL(mocks.algSvc, GetAlgorithmsByModelId("test_model_001"))
                 .RETURN(std::vector<std::string>{});
             ALLOW_CALL(mocks.cameraSvc, NotifyAlgorithmsChanged(trompeloeil::_, true));
@@ -134,9 +130,6 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
             // 验证修改
             auto info = sut.GetModelInfo("test_model_001");
             REQUIRE(info.name == "NewTestName");
-
-            // 清理预置目录，避免残留污染后续 SECTION
-            std::filesystem::remove_all(testPresetDir);
         }
 
         SECTION("GetModelConfig / SaveModelConfig 流程") {

--- a/test/test_model_service_impl.cc
+++ b/test/test_model_service_impl.cc
@@ -47,10 +47,13 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
 
     cosmo::test::MockServiceRegistry mocks;
     // Redirect path roots to test directory
-    cosmo::path::OverrideRootPathForTest(testBaseDir, testBaseDir);
-    // GetModelPath() -> testBaseDir/resource/models
-    // GetModelTemplatePath() -> testBaseDir/resource/model_template
+    // Separate user (data) and preset (app) roots so preset-path checks are testable.
+    cosmo::path::OverrideRootPathForTest(testBaseDir + "/udata", testBaseDir + "/adata");
+    // GetModelPath()         -> udata/resource/models  (user models: exportable/deletable)
+    // GetPresetModelPath()   -> adata/resource/models  (preset models: protected)
+    // GetModelTemplatePath() -> adata/resource/model_template
     auto testModelsDir      = cosmo::path::GetModelPath();
+    auto testPresetDir      = cosmo::path::GetPresetModelPath();
     auto testTemplatePath   = cosmo::path::GetModelTemplatePath();
     auto testComponentsPath = cosmo::path::GetModelComponentsJsonPath();
     ModelServiceImpl sut;
@@ -96,11 +99,14 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
         REQUIRE(results.size() == 1);
         REQUIRE(results[0].id == "test_model_001");
 
-        SECTION("DeleteModel 非法参数与内置模型") {
+        SECTION("DeleteModel 非法参数与预置模型") {
             REQUIRE(sut.DeleteModel("") == cosmo::util::ErrorEnum::InvalidParam);
-            REQUIRE(sut.DeleteModel("1000001") == cosmo::util::ErrorEnum::DefaultCantBeDelete);
 
-            // 可以删除我们创建的 test_model_001
+            // 预置（内置）模型不可删除 —— 在预置目录造一个
+            CreateTestModelOnDisk(testPresetDir, "preset_del_001", "PresetDelModel");
+            REQUIRE(sut.DeleteModel("preset_del_001") == cosmo::util::ErrorEnum::DefaultCantBeDelete);
+
+            // 可以删除我们创建的用户模型 test_model_001
             ALLOW_CALL(mocks.algSvc, GetAlgorithmsByModelId("test_model_001"))
                 .RETURN(std::vector<std::string>{});
             ALLOW_CALL(mocks.cameraSvc, NotifyAlgorithmsChanged(trompeloeil::_, false));
@@ -108,11 +114,15 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
             REQUIRE(std::filesystem::exists(testModelsDir + "/" +
                                             std::string(cosmo::util::kPlatformDirPrefix) +
                                             "test_model_001_TestModel_V1.0.0") == false);
+
+            // 清理预置目录，避免残留污染后续 QueryModels 等 SECTION
+            std::filesystem::remove_all(testPresetDir);
         }
 
         SECTION("UpdateModel 流程") {
-            // 不能更新内置模型
-            REQUIRE(sut.UpdateModel("1000001", "new_name", 4, "desc") ==
+            // 预置（内置）模型不可更新 —— 在预置目录造一个
+            CreateTestModelOnDisk(testPresetDir, "preset_upd_001", "PresetUpdModel");
+            REQUIRE(sut.UpdateModel("preset_upd_001", "new_name", 4, "desc") ==
                     cosmo::util::ErrorEnum::DefaultCantBeUpdate);
 
             ALLOW_CALL(mocks.algSvc, GetAlgorithmsByModelId("test_model_001"))
@@ -124,12 +134,16 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
             // 验证修改
             auto info = sut.GetModelInfo("test_model_001");
             REQUIRE(info.name == "NewTestName");
+
+            // 清理预置目录，避免残留污染后续 SECTION
+            std::filesystem::remove_all(testPresetDir);
         }
 
         SECTION("GetModelConfig / SaveModelConfig 流程") {
             std::string cfgJson;
+            std::string defaultCfgJson;
             bool isExportable{false};
-            REQUIRE(sut.GetModelConfig("test_model_001", cfgJson, isExportable) ==
+            REQUIRE(sut.GetModelConfig("test_model_001", cfgJson, isExportable, defaultCfgJson) ==
                     cosmo::util::ErrorEnum::Success);
             REQUIRE(cfgJson.find("TestModel") != std::string::npos);
 
@@ -146,7 +160,7 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
             REQUIRE(sut.SaveModelConfig("test_model_001", newJson) == cosmo::util::ErrorEnum::Success);
 
             std::string updatedJson;
-            REQUIRE(sut.GetModelConfig("test_model_001", updatedJson, isExportable) ==
+            REQUIRE(sut.GetModelConfig("test_model_001", updatedJson, isExportable, defaultCfgJson) ==
                     cosmo::util::ErrorEnum::Success);
             REQUIRE(updatedJson.find("SavedModel") != std::string::npos);
         }

--- a/test/test_model_service_impl.cc
+++ b/test/test_model_service_impl.cc
@@ -128,7 +128,9 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
 
         SECTION("GetModelConfig / SaveModelConfig 流程") {
             std::string cfgJson;
-            REQUIRE(sut.GetModelConfig("test_model_001", cfgJson) == cosmo::util::ErrorEnum::Success);
+            bool isExportable{false};
+            REQUIRE(sut.GetModelConfig("test_model_001", cfgJson, isExportable) ==
+                    cosmo::util::ErrorEnum::Success);
             REQUIRE(cfgJson.find("TestModel") != std::string::npos);
 
             ALLOW_CALL(mocks.algSvc, GetAlgorithmsByModelId("test_model_001"))
@@ -144,7 +146,8 @@ TEST_CASE("ModelServiceImpl: 模型服务核心逻辑", "[model-service]") {
             REQUIRE(sut.SaveModelConfig("test_model_001", newJson) == cosmo::util::ErrorEnum::Success);
 
             std::string updatedJson;
-            REQUIRE(sut.GetModelConfig("test_model_001", updatedJson) == cosmo::util::ErrorEnum::Success);
+            REQUIRE(sut.GetModelConfig("test_model_001", updatedJson, isExportable) ==
+                    cosmo::util::ErrorEnum::Success);
             REQUIRE(updatedJson.find("SavedModel") != std::string::npos);
         }
 


### PR DESCRIPTION
## 背景

预置模型在部署时针对设备加密（设备绑定），导出到其他设备无法使用；加密权重没有副本，**删除不可逆**（删除依赖它们的人脸/人体库模型还会让入库等功能崩溃）。手动添加的模型不加密，不受此限制。

之前删除/更新的保护是前后端**硬编码的 8 个 code 列表**（`kBuiltinModels` / `defaultModels`），新增预置模型要改代码。

## 方案：按路径判断 + 保护分级

预置模型都在固定预置目录（`PresetModelPath`），用户模型在另一目录——按路径区分，新增预置模型自动受控，去掉硬编码。

| 操作 | 预置模型 | 用户模型 | 理由 |
|---|---|---|---|
| 导出 | ❌ 禁止 | ✅ | 加密设备绑定，导出无用 |
| 删除 | ❌ 禁止 | ✅ | 加密权重无副本，删除不可逆 |
| 修改 config | ✅ 允许 | ✅ | 只改 config.json，不动加密权重，可逆 |
| 恢复默认 | ✅ 从出厂快照 | ⚠️ 无快照则提示 | |

## 改动

**后端**
- `cosmo::path::GetPresetModelPath()`：新增 accessor，对称 `GetModelPath()`。
- `ExportModelConfig` / `DeleteModel`：拿到模型目录后用 `IsWithinRoot(GetPresetModelPath())` 判断，命中返回 `DefaultCantBeExport` / `DefaultCantBeDelete`；移除硬编码 `kBuiltinModels`。
- `UpdateModel`：移除硬编码保护（改 config 可逆，保留允许）。
- `ModelServiceImpl::Init`：扫描预置目录时为每个模型快照 `config.json → config.default.json`（`copy_file` + `skip_existing`，老预置模型首次启动自动补上，不覆盖已有出厂值）。
- `getModelConfig`：新增返回 `defaultConfigJson`（出厂快照；空则前端降级提示）。
- `MsgModel` 新增 `isExportable`，`QueryModels` 按搜索路径归属填充。

**前端**
- 详情页（`modelConfig`）：导出按钮按 `isExportable` 禁用；"恢复默认"改为从 `defaultConfigJson` 恢复（不再恢复到"打开页面时的状态"），无快照时提示。
- 列表页（`atomicModel`）：移除 `defaultModels` 硬编码，删除按钮按 `isExportable` 禁用，编辑按钮恢复显示。
- i18n：新增 `presetModelNotExportable` / `noDefaultConfig`（中英）。

## 验证
- ✅ 前端 `i18n:check` 5 项通过
- ✅ C++ `format_check --staged --check` 全 clean
- ✅ Sophon aarch64 交叉编译（192.168.0.169 docker）零 error，出包成功
- ⚠️ `cosmo-tests` 未构建（`build.sh` 默认 `BUILD_TESTS=OFF`）；测试改动已同步签名

🤖 Generated with [Claude Code](https://claude.com/claude-code)
