### PR TITLE
chore(workflow): harden change validation gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,6 +44,34 @@ body:
         Build path: x86 Docker / Sophon package / other
     validations:
       required: true
+  - type: input
+    id: baseline
+    attributes:
+      label: Baseline commit
+      description: Commit or tag used to establish whether this is a regression.
+      placeholder: Commit SHA, tag, or unknown with an explanation
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundaries
+      description: State what is in scope and explicitly out of scope for this issue.
+      placeholder: |
+        In scope:
+        Out of scope:
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risk tags and affected paths
+      description: Identify runtime, thread, memory, API, media, frontend, device, packaging, or compatibility risks.
+      placeholder: |
+        Risk tags:
+        Affected paths:
+    validations:
+      required: true
   - type: textarea
     id: steps
     attributes:
@@ -65,6 +93,23 @@ body:
     id: actual
     attributes:
       label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: initial_analysis
+    attributes:
+      label: Initial root-cause analysis
+      description: Optional at issue creation; update it before implementation when the root cause becomes known.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance checks
+      description: List objective checks that must pass before this issue can be closed.
+      placeholder: |
+        - [ ] Parent baseline recorded
+        - [ ] Focused regression test passes
+        - [ ] Required build and device checks pass
+        - [ ] Temporary data and rollback state audited
     validations:
       required: true
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,36 @@
 
 Describe the change and why it is needed.
 
+## Related issue
+
+Replace this line with a closing reference when the PR completes the issue, for example `Closes #<issue-number>`.
+
+## Root cause
+
+Describe the concrete failure path or reason for the change.
+
+## Scope
+
+### In scope
+
+-
+
+### Out of scope
+
+-
+
+## Risk tags
+
+- [ ] Runtime / lifecycle
+- [ ] Thread / memory safety
+- [ ] API / authentication / network
+- [ ] Media / streaming
+- [ ] Model / inference / flow
+- [ ] Frontend console
+- [ ] Build / package / deployment
+- [ ] Compatibility / migration
+- [ ] None of the above
+
 ## Type of change
 
 - [ ] Bug fix
@@ -22,13 +52,41 @@ Describe the change and why it is needed.
 - [ ] Build / deployment
 - [ ] Documentation
 
+## Candidate identity
+
+- Base commit: `<sha>`
+- Candidate commit: `<sha>`
+- Candidate tree: `<tree-sha>`
+- Package SHA-256: `<sha256 or N/A>`
+- Test binary SHA-256: `<sha256 or N/A>`
+
+State whether the candidate was amended, rebased, merged, or otherwise changed after the evidence below was collected.
+
 ## Verification
 
-List the commands or manual checks you ran.
+### Parent baseline
+
+Record `PASS`, `FAIL`, or `BLOCKED`, plus the exact command and environment used to establish regression attribution.
 
 ```text
 
 ```
+
+### Candidate checks
+
+List exact commands, test filters, case/assertion counts, and results.
+
+```text
+
+```
+
+### Risk-based evidence
+
+- API/network:
+- Media/streaming:
+- Sophon/device:
+- Frontend/UI:
+- Package/deployment:
 
 ## Documentation impact
 
@@ -57,6 +115,17 @@ List the commands or manual checks you ran.
 - [ ] Documentation was updated if behavior changed.
 - [ ] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
 - [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
+
+## Acceptance and cleanup
+
+- Candidate-bound acceptance: `<验证通过 candidate-commit package-sha256, or N/A>`
+- Device test filter: `<filter or N/A>`
+- Device backup state: `<retained/restored/N/A>`
+- Temporary-data cleanup: `<complete/N/A>`
+- Final Git status: `<clean or explanation>`
+- [ ] Evidence was collected from the candidate commit listed above.
+- [ ] Any source change after validation invalidated and restarted the required checks.
+- [ ] No temporary credentials, media, models, device exports, or generated packages are included.
 
 ## Notes for reviewers
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,6 +12,117 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── Non-blocking workflow policy audit ─────────────────────────────
+  # This remains informational until the team agrees to enforce it in
+  # the repository ruleset.
+  policy-audit:
+    name: policy-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Audit issue, scope, candidate, and risk evidence
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -uo pipefail
+
+          warnings=()
+          add_warning() {
+            warnings+=("$1")
+            echo "::warning::$1"
+          }
+
+          changed_paths=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          changed_lines=$(git diff --numstat "$BASE_SHA" "$HEAD_SHA" | awk '
+            BEGIN { total = 0 }
+            {
+              if ($1 ~ /^[0-9]+$/) total += $1
+              if ($2 ~ /^[0-9]+$/) total += $2
+            }
+            END { print total }
+          ')
+
+          shopt -s nocasematch
+          if (( changed_lines > 50 )) && \
+             [[ ! "$PR_BODY" =~ (close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+ ]]; then
+            add_warning "Changes over 50 lines must use a closing keyword to reference an agreed issue."
+          fi
+          shopt -u nocasematch
+
+          if [[ "$PR_DRAFT" != "true" ]]; then
+            for heading in \
+              "## Related issue" \
+              "## Root cause" \
+              "## Scope" \
+              "## Candidate identity" \
+              "## Verification" \
+              "## Acceptance and cleanup"; do
+              if ! grep -Fqi "$heading" <<< "$PR_BODY"; then
+                add_warning "PR body is missing required heading: $heading"
+              fi
+            done
+
+            candidate=$(sed -nE \
+              's/^[[:space:]-]*Candidate commit:[[:space:]]*`?([0-9a-fA-F]{7,40})`?.*/\1/p' \
+              <<< "$PR_BODY" | head -n 1)
+            if [[ -z "$candidate" ]]; then
+              add_warning "PR body does not record a candidate commit."
+            elif [[ "$HEAD_SHA" != "$candidate"* ]]; then
+              add_warning "Recorded candidate commit does not match the current PR HEAD."
+            fi
+          fi
+
+          risk_notes=()
+          if grep -Eq '^(src/api/|src/network/)' <<< "$changed_paths"; then
+            risk_notes+=("API/network changes require authentication, invalid-input, error-response, and lifecycle evidence.")
+          fi
+          if grep -Eq '^(src/media/|src/service/media/|src/web/.*(whep|flv|bigScreen))' <<< "$changed_paths"; then
+            risk_notes+=("Media changes require ownership, first-frame, switching, overlay, and sustained-playback evidence.")
+          fi
+          if grep -Eq '^(src/infer/|src/nn/|src/flow/)' <<< "$changed_paths"; then
+            risk_notes+=("Inference, NN, or flow changes require Sophon package and focused device evidence.")
+          fi
+          if grep -Eq '^src/web/' <<< "$changed_paths"; then
+            risk_notes+=("Frontend changes require the Docker production build and affected UI evidence.")
+          fi
+          if grep -Eq '(^|/)(CMakeLists[.]txt|docker-compose[.]sophon[.]yml)$|^(cmake/|data/resource/|scripts/build)' <<< "$changed_paths"; then
+            risk_notes+=("Build, resource, or package changes require final package checksum and compatibility evidence.")
+          fi
+
+          {
+            echo "## Workflow policy audit"
+            echo
+            echo "This job is informational and does not block merging."
+            echo
+            echo "- Changed lines: $changed_lines"
+            echo "- Candidate HEAD: \`$HEAD_SHA\`"
+            echo
+            if (( ${#warnings[@]} == 0 )); then
+              echo "No policy gaps detected."
+            else
+              echo "### Policy gaps"
+              for warning in "${warnings[@]}"; do
+                echo "- $warning"
+              done
+            fi
+            if (( ${#risk_notes[@]} > 0 )); then
+              echo
+              echo "### Risk-based evidence reminders"
+              for note in "${risk_notes[@]}"; do
+                echo "- $note"
+              done
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit 0
+
   # ── C++ format check via clang-format ──────────────────────────────
   # Only checks files changed in the PR (not the entire codebase)
   format-check:

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -24,6 +24,7 @@ MODE=""
 STAGED_ONLY=false
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
+REQUIRED_CLANG_FORMAT_MAJOR=18
 
 # ── Parse arguments ─────────────────────────────────────────────────
 usage() {
@@ -57,15 +58,6 @@ if [[ -z "$MODE" ]]; then
     usage
 fi
 
-# ── Verify clang-format is available ────────────────────────────────
-if ! command -v "$CLANG_FORMAT" &> /dev/null; then
-    echo -e "${RED}Error: clang-format not found. Install it or set CLANG_FORMAT env var.${NC}"
-    exit 1
-fi
-
-VERSION=$("$CLANG_FORMAT" --version 2>&1)
-echo -e "${CYAN}Using: ${VERSION}${NC}"
-
 # ── Collect files ───────────────────────────────────────────────────
 collect_files() {
     if [[ "$STAGED_ONLY" == true ]]; then
@@ -92,6 +84,27 @@ TOTAL=${#FILES[@]}
 if [[ $TOTAL -eq 0 ]]; then
     echo -e "${YELLOW}No files to check.${NC}"
     exit 0
+fi
+
+# ── Verify clang-format is available ────────────────────────────────
+if ! command -v "$CLANG_FORMAT" &> /dev/null; then
+    echo -e "${RED}Error: clang-format not found. Install it or set CLANG_FORMAT env var.${NC}"
+    exit 1
+fi
+
+VERSION=$("$CLANG_FORMAT" --version 2>&1)
+echo -e "${CYAN}Using: ${VERSION}${NC}"
+
+if [[ ! "$VERSION" =~ version[[:space:]]+([0-9]+)([.]|$) ]]; then
+    echo -e "${RED}Error: unable to determine the clang-format major version.${NC}"
+    exit 1
+fi
+
+CLANG_FORMAT_MAJOR="${BASH_REMATCH[1]}"
+if [[ "$CLANG_FORMAT_MAJOR" -ne "$REQUIRED_CLANG_FORMAT_MAJOR" ]]; then
+    echo -e "${RED}Error: clang-format ${REQUIRED_CLANG_FORMAT_MAJOR} is required; found major version ${CLANG_FORMAT_MAJOR}.${NC}"
+    echo -e "${CYAN}Install clang-format-${REQUIRED_CLANG_FORMAT_MAJOR} or set CLANG_FORMAT=clang-format-${REQUIRED_CLANG_FORMAT_MAJOR}.${NC}"
+    exit 1
 fi
 
 echo -e "${CYAN}Scanning ${BOLD}${TOTAL}${NC}${CYAN} files...${NC}"


### PR DESCRIPTION
## Summary

Harden the repository change-validation workflow without changing product code, device state, or the GitHub Ruleset.

## Related issue

Closes #37

## Root cause

Large or cross-module changes can reach acceptance before the regression scope, baseline attribution, candidate identity, and evidence requirements are fixed. Local and CI clang-format versions can also diverge until commit time.

## Scope

### In scope

- Require clang-format 18 when C++ files are actually checked.
- Extend bug reports and PRs with baseline, scope, risk, candidate, verification, acceptance, and cleanup evidence.
- Add an informational PR policy audit.

### Out of scope

- Product source or test behavior.
- Tracked `AGENTS.md` or `.codex/` content.
- Sophon build, package, deployment, or device state.
- GitHub Ruleset and bypass actors.
- Blocking policy enforcement before team agreement.

## Risk tags

- [ ] Runtime / lifecycle
- [ ] Thread / memory safety
- [ ] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [x] Build / deployment
- [ ] Refactor
- [ ] Test

## Area

- [ ] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [x] Build / deployment
- [x] Documentation

## Candidate identity

- Base commit: `6d3448fcde960041561310c04deca35e67e74f97`
- Candidate commit: `138d74bb8ca3b5a0f92b63243b2cf60948584eee`
- Candidate tree: `e30840ff5aafd4e845cee405f1eb9acb0f224053`
- Package SHA-256: `N/A`
- Test binary SHA-256: `N/A`

The candidate was not amended, rebased, merged, or otherwise changed after evidence collection.

## Verification

### Parent baseline

`PASS` — `origin/main@6d3448fc` was fetched immediately before push; the candidate is one commit ahead with no base divergence.

### Candidate checks

```text
bash -n scripts/format_check.sh
python3/PyYAML parse of pr-checks.yml and bug_report.yml
bash -n of the policy-audit run block
./scripts/format_check.sh --staged --check  # no C++ files
./scripts/static_analysis.sh --staged --cppcheck  # no C++ files
git diff --cached --check
sensitive-value scan of all four changed files
```

The negative version test confirmed that host clang-format 14 is rejected when C++ files are present. The issue placeholder audit confirmed that `Closes #<issue-number>` cannot satisfy the real issue-reference check. The policy audit reports annotations and exits zero.

### Risk-based evidence

- API/network: N/A
- Media/streaming: N/A
- Sophon/device: N/A
- Frontend/UI: N/A
- Package/deployment: Workflow-only change; no package content changed.

## Documentation impact

- [x] Documentation was updated.
- [ ] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: User approved the exact staged diff; commit `138d74bb8ca3b5a0f92b63243b2cf60948584eee` contains that unchanged tree. Package is N/A.
- Device test filter: `N/A`
- Device backup state: `N/A`
- Temporary-data cleanup: `complete`
- Final Git status: `clean`
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

`policy-audit` is intentionally informational and is not added to the Ruleset. Ruleset and bypass changes remain pending team discussion.