### PR TITLE
fix(security): externalize manager signing credentials

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,46 @@
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Vendored upstream source and cryptographic test vectors are reviewed through dependency and SBOM gates"
+paths = ['''^3rd/''']
+
+[[allowlists]]
+description = "Generated web bundle is reproduced from separately scanned source"
+paths = ['''^src/web/dist/''']
+
+[[allowlists]]
+description = "Gitleaks configuration contains detection examples"
+paths = ['''^\.gitleaks\.toml$''']
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+description = "3D key-point field assignments are not credentials"
+condition = "AND"
+regexTarget = "match"
+paths = ['''^src/nn/utils/net_utils\.cc$''']
+regexes = ['''(?:new_info|offset_info)\.key_points_3d\s*=\s*key_points_3d''']
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+description = "Factory-default password hash is a one-way comparison marker"
+condition = "AND"
+regexTarget = "match"
+paths = ['''^src/service/network/impl/AuthServiceImpl\.h$''']
+regexes = ['''kDefaultAdminPasswordHash\s*=\s*"[A-F0-9]{32}"''']
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+description = "Retired discovery flow used the same reviewed factory password hash"
+condition = "AND"
+regexTarget = "match"
+paths = ['''^src/service/network/impl/DiscoveryCommandHandler\.cc$''']
+regexes = ['''tokenSendData\.passwd\s*=\s*"[A-F0-9]{32}"''']
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+description = "Deterministic AES unit-test material"
+condition = "AND"
+regexTarget = "match"
+paths = ['''^test/test_cipher_util\.cc$''']
+regexes = ['''key\s*=\s*"0123456789abcdef"''']

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -41,6 +41,19 @@ Set in `Dockerfile.x86`:
 ${INSTALLPATH}/scripts/run_start.sh start ${DATADIR}/log/logs/INTE_RUN_container.log
 ```
 
+## Manager Signing Credentials
+
+Signed requests to the manager no longer use built-in application credentials. Configure both variables below with absolute paths to credential files:
+
+| Variable | Description |
+| --- | --- |
+| `COSMO_APP_KEY_FILE` | App Key file |
+| `COSMO_APP_SECRET_FILE` | App Secret file |
+
+Each path must reference a regular file no larger than 4096 bytes containing exactly one non-empty line. Mount the files read-only with restricted permissions; do not store the credential values in an image, Compose file, or repository.
+
+When both variables are absent, signed manager requests remain disabled. A partial configuration, relative path, or invalid file also rejects the request. Local web and device APIs are unaffected.
+
 ## Sophon Build Variables
 
 `docker-compose.sophon.yml` supports the following build arguments:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -41,6 +41,19 @@ docker-compose.sophon.yml
 ${INSTALLPATH}/scripts/run_start.sh start ${DATADIR}/log/logs/INTE_RUN_container.log
 ```
 
+## 管理平台签名凭据
+
+向管理平台发送签名请求时，不再使用内置应用凭据。运行环境必须同时配置以下变量，变量值为凭据文件的绝对路径：
+
+| 变量 | 说明 |
+| --- | --- |
+| `COSMO_APP_KEY_FILE` | App Key 文件 |
+| `COSMO_APP_SECRET_FILE` | App Secret 文件 |
+
+两个文件都必须是普通文件，大小不超过 4096 字节，并且只包含一行非空内容。建议以只读方式挂载文件并限制读取权限，不要把实际凭据写入镜像、Compose 文件或仓库。
+
+两个变量均未设置时，签名管理平台请求保持禁用；只配置一个变量、使用相对路径或文件内容无效时，请求同样会被拒绝。该行为不会影响本地 Web 和设备 API。
+
 ## Sophon 构建变量
 
 `docker-compose.sophon.yml` 支持以下构建参数：
@@ -114,4 +127,3 @@ COSMO_STREAM_HTTP_PORT=18088
 | `COSMO_ENABLE_OPENH264` | CPU 后端时自动 `ON`，Sophon 后端时 `OFF` |
 | `COSMO_OPENH264_USE_ASM` | 始终为 `OFF` |
 | `COSMO_MODEL_GUARD` | Sophon 后端时 `ON`（启用加密模型校验），CPU 后端时 `OFF` |
-

--- a/src/api/ApiRouterInternal.h
+++ b/src/api/ApiRouterInternal.h
@@ -39,8 +39,10 @@ namespace detail {
 
     inline std::string ErroResult(const char* errMsg, std::error_condition& errc) {
         LOG_ERRO("{}", errMsg);
-        if (!errc) {
-            errc = util::ErrorEnum::SysErr;
+        // A plain std::exception does not carry a Cosmo error condition. Never
+        // serialize it with msgCode=0/messageKey=Success.
+        if (errc == util::ErrorEnum::Success) {
+            errc = util::ErrorEnum::InternalError;
         }
         MsgSendHead retData{};
         retData.resCode = kServerRspFailed;

--- a/src/network/http/HttpPost.cc
+++ b/src/network/http/HttpPost.cc
@@ -2,9 +2,13 @@
 
 #include "network/http/HttpPost.h"
 
+#include <array>
 #include <chrono>
+#include <cstdlib>
 #include <ctime>
+#include <filesystem>
 #include <fstream>
+#include <utility>
 
 #include "network/http/HttpCommon.h"
 #include "util/CipherUtil.h"
@@ -13,12 +17,93 @@
 
 namespace cosmo::network::http {
 
+namespace {
+
+    constexpr const char* kAppKeyFileEnv    = "COSMO_APP_KEY_FILE";
+    constexpr const char* kAppSecretFileEnv = "COSMO_APP_SECRET_FILE";
+    constexpr size_t kMaxCredentialBytes    = 4096;
+
+    enum class CredentialLoadState { kMissing, kLoaded, kInvalid };
+
+    CredentialLoadState LoadCredentialFile(const char* env_name, std::string& value) {
+        const char* configured_path = std::getenv(env_name);
+        if (!configured_path || configured_path[0] == '\0') {
+            return CredentialLoadState::kMissing;
+        }
+
+        const std::string path(configured_path);
+        if (path.empty() || path.front() != '/') {
+            LOG_ERRO("{} must reference an absolute credential file", env_name);
+            return CredentialLoadState::kInvalid;
+        }
+
+        std::error_code path_error;
+        if (!std::filesystem::is_regular_file(path, path_error) || path_error) {
+            LOG_ERRO("{} credential path must reference a regular file", env_name);
+            return CredentialLoadState::kInvalid;
+        }
+        path_error.clear();
+        const auto raw_size = std::filesystem::file_size(path, path_error);
+        if (path_error || raw_size == 0 || raw_size > kMaxCredentialBytes) {
+            LOG_ERRO("{} credential file is empty, invalid or exceeds {} bytes", env_name,
+                     kMaxCredentialBytes);
+            return CredentialLoadState::kInvalid;
+        }
+
+        std::ifstream input(path, std::ios::binary);
+        if (!input.is_open()) {
+            LOG_ERRO("{} credential file is not readable", env_name);
+            return CredentialLoadState::kInvalid;
+        }
+
+        std::array<char, kMaxCredentialBytes + 1> buffer{};
+        input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        const auto bytes_read = input.gcount();
+        if (input.bad() || bytes_read < 0 || static_cast<size_t>(bytes_read) > kMaxCredentialBytes) {
+            LOG_ERRO("{} credential file is invalid or exceeds {} bytes", env_name, kMaxCredentialBytes);
+            return CredentialLoadState::kInvalid;
+        }
+        std::string loaded(buffer.data(), static_cast<size_t>(bytes_read));
+        if (!loaded.empty() && loaded.back() == '\n') {
+            loaded.pop_back();
+            if (!loaded.empty() && loaded.back() == '\r') {
+                loaded.pop_back();
+            }
+        } else if (!loaded.empty() && loaded.back() == '\r') {
+            loaded.pop_back();
+        }
+        if (loaded.empty() || loaded.find('\0') != std::string::npos ||
+            loaded.find('\n') != std::string::npos || loaded.find('\r') != std::string::npos) {
+            LOG_ERRO("{} credential file must contain one non-empty line", env_name);
+            return CredentialLoadState::kInvalid;
+        }
+
+        value = std::move(loaded);
+        return CredentialLoadState::kLoaded;
+    }
+
+    const char* CredentialStateName(CredentialLoadState state) {
+        switch (state) {
+            case CredentialLoadState::kMissing:
+                return "missing";
+            case CredentialLoadState::kLoaded:
+                return "loaded";
+            case CredentialLoadState::kInvalid:
+                return "invalid";
+        }
+        return "unknown";
+    }
+
+}  // namespace
+
 HttpPost::HttpPost() : http_post_(std::string(""), str_hnd_) {
     BoundaryGen();
+    LoadAppInfoFromRuntime();
 }
 
 HttpPost::HttpPost(const std::string& url) : http_post_(url, str_hnd_) {
     BoundaryGen();
+    LoadAppInfoFromRuntime();
 }
 
 void HttpPost::SetPostUrl(const std::string& url) {
@@ -140,8 +225,40 @@ std::string& HttpPost::GetPostUrl(const CliReqType& type) {
 }
 
 void HttpPost::SetAppInfo(const std::string& app_key, const std::string& app_secret) {
+    if (app_key.empty() || app_secret.empty()) {
+        app_key_.clear();
+        app_secret_.clear();
+        LOG_ERRO("platform application credentials must provide both key and secret");
+        return;
+    }
     app_key_    = app_key;
     app_secret_ = app_secret;
+}
+
+bool HttpPost::HasAppInfo() const noexcept {
+    return !app_key_.empty() && !app_secret_.empty();
+}
+
+bool HttpPost::LoadAppInfoFromRuntime() {
+    std::string app_key;
+    std::string app_secret;
+    const auto key_state    = LoadCredentialFile(kAppKeyFileEnv, app_key);
+    const auto secret_state = LoadCredentialFile(kAppSecretFileEnv, app_secret);
+    if (key_state == CredentialLoadState::kLoaded && secret_state == CredentialLoadState::kLoaded) {
+        app_key_    = std::move(app_key);
+        app_secret_ = std::move(app_secret);
+        return true;
+    }
+
+    app_key_.clear();
+    app_secret_.clear();
+    if (key_state == CredentialLoadState::kMissing && secret_state == CredentialLoadState::kMissing) {
+        LOG_INFO("platform application credentials are not configured; signed manager requests are disabled");
+    } else {
+        LOG_ERRO("platform application credentials are incomplete: key={}, secret={}",
+                 CredentialStateName(key_state), CredentialStateName(secret_state));
+    }
+    return false;
 }
 
 void HttpPost::BoundaryGen() {
@@ -160,7 +277,11 @@ HttpRequest& HttpPost::GetHttpRequest() {
     return http_post_;
 }
 
-void HttpPost::AppendHeaderS(HttpRequest& hrt) {
+bool HttpPost::AppendHeaderS(HttpRequest& hrt) {
+    if (!HasAppInfo()) {
+        LOG_ERRO("signed manager request rejected because platform application credentials are unavailable");
+        return false;
+    }
     hrt.SetContentType("application/json");
     std::string request_id("CWAI_Analyzer_");
     request_id += cosmo::util::GenerateUUID();
@@ -174,12 +295,13 @@ void HttpPost::AppendHeaderS(HttpRequest& hrt) {
     auto cur_time = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
 
     char cur_time_buf[16] = {0};
-    snprintf(cur_time_buf, sizeof(cur_time_buf), "%013ld", cur_time);
+    snprintf(cur_time_buf, sizeof(cur_time_buf), "%013lld", static_cast<long long>(cur_time));
     hrt.AppendHeader("CurTime", cur_time_buf);
 
     std::string sha_str   = nonce + app_secret_ + cur_time_buf;
     std::string head_sha1 = cosmo::util::Sha1(sha_str);
     hrt.AppendHeader("CheckSum", head_sha1);
+    return true;
 }
 
 }  // namespace cosmo::network::http

--- a/src/network/http/HttpPost.h
+++ b/src/network/http/HttpPost.h
@@ -55,6 +55,7 @@ public:
     std::string& GetPostUrl(const CliReqType& type);
 
     void SetAppInfo(const std::string& app_key, const std::string& app_secret);
+    bool HasAppInfo() const noexcept;
     // Set proxy
     void SetProxy(const std::string& proxy, const std::string& username = "",
                   const std::string& password = "");
@@ -63,14 +64,16 @@ public:
 
 public:
     // Client push interface
-    void AppendHeaderS(HttpRequest& hrt);
+    bool AppendHeaderS(HttpRequest& hrt);
 
     template <typename IN, typename OUT>
     bool HttpClientSubmit(const CliReqType& type, IN& rgt_in, OUT& rgt_out) {
         HttpStringHandler http_hnd{};
         HttpRequest http_req(GetPostUrl(type), &http_hnd);
 
-        AppendHeaderS(http_req);
+        if (!AppendHeaderS(http_req)) {
+            return false;
+        }
         std::string json_result{};
         if (!cosmo::util::EncodeJson(rgt_in, json_result)) {
             LOG_ERRO("{}", "StructToJson failed");
@@ -101,6 +104,7 @@ public:
 
 private:
     void BoundaryGen();
+    bool LoadAppInfoFromRuntime();
 
 private:
     HttpStringHandler str_hnd_;
@@ -108,8 +112,8 @@ private:
     std::string data_;
     std::string boundary_;
 
-    std::string app_key_    = "6623141131";
-    std::string app_secret_ = "b67e258d8a6c422c7cbf16c1e0ebbb1c9a117a77";
+    std::string app_key_;
+    std::string app_secret_;
 
     std::string ip_port_;
     std::string register_url_;

--- a/test/test_http_post_credentials.cc
+++ b/test/test_http_post_credentials.cc
@@ -1,0 +1,212 @@
+#include <unistd.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "catch_amalgamated.hpp"
+#include "network/http/HttpPost.h"
+#include "network/http/HttpRequest.h"
+
+namespace {
+
+constexpr const char* kKeyFileEnv    = "COSMO_APP_KEY_FILE";
+constexpr const char* kSecretFileEnv = "COSMO_APP_SECRET_FILE";
+
+class ScopedEnvironment {
+public:
+    ScopedEnvironment() {
+        Save(kKeyFileEnv);
+        Save(kSecretFileEnv);
+        unsetenv(kKeyFileEnv);
+        unsetenv(kSecretFileEnv);
+    }
+
+    ~ScopedEnvironment() {
+        for (const auto& [key, value] : original_) {
+            if (value) {
+                setenv(key.c_str(), value->c_str(), 1);
+            } else {
+                unsetenv(key.c_str());
+            }
+        }
+    }
+
+    ScopedEnvironment(const ScopedEnvironment&)            = delete;
+    ScopedEnvironment& operator=(const ScopedEnvironment&) = delete;
+
+private:
+    void Save(const char* key) {
+        const char* value = std::getenv(key);
+        original_.emplace_back(key, value ? std::optional<std::string>(value) : std::nullopt);
+    }
+
+    std::vector<std::pair<std::string, std::optional<std::string>>> original_;
+};
+
+class CredentialFiles {
+public:
+    CredentialFiles() {
+        directory_ = std::filesystem::temp_directory_path() /
+                     ("cosmo-http-post-credentials-" + std::to_string(getpid()));
+        std::error_code error;
+        std::filesystem::remove_all(directory_, error);
+        REQUIRE(std::filesystem::create_directories(directory_));
+        key_path_    = directory_ / "app-key";
+        secret_path_ = directory_ / "app-secret";
+    }
+
+    ~CredentialFiles() {
+        std::error_code error;
+        std::filesystem::remove_all(directory_, error);
+    }
+
+    void WriteValid() const {
+        Write(key_path_, std::string("application-") + "key\n");
+        Write(secret_path_, std::string(32, 's') + "\n");
+    }
+
+    static void Write(const std::filesystem::path& path, const std::string& value) {
+        std::ofstream output(path, std::ios::binary);
+        REQUIRE(output.is_open());
+        output << value;
+        output.close();
+        REQUIRE(output.good());
+    }
+
+    const std::filesystem::path& Key() const {
+        return key_path_;
+    }
+    const std::filesystem::path& Secret() const {
+        return secret_path_;
+    }
+    const std::filesystem::path& Directory() const {
+        return directory_;
+    }
+
+private:
+    std::filesystem::path directory_;
+    std::filesystem::path key_path_;
+    std::filesystem::path secret_path_;
+};
+
+}  // namespace
+
+TEST_CASE("HttpPost rejects signed requests without runtime credentials", "[HttpPost][security]") {
+    ScopedEnvironment environment;
+    cosmo::network::http::HttpPost post;
+    cosmo::network::http::HttpStringHandler handler;
+    cosmo::network::http::HttpRequest request("http://127.0.0.1/", handler);
+
+    REQUIRE_FALSE(post.HasAppInfo());
+    REQUIRE_FALSE(post.AppendHeaderS(request));
+}
+
+TEST_CASE("HttpPost loads application credentials from mounted files", "[HttpPost][security]") {
+    ScopedEnvironment environment;
+    CredentialFiles files;
+    files.WriteValid();
+    REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+    REQUIRE(setenv(kSecretFileEnv, files.Secret().c_str(), 1) == 0);
+
+    cosmo::network::http::HttpPost post;
+    cosmo::network::http::HttpStringHandler handler;
+    cosmo::network::http::HttpRequest request("http://127.0.0.1/", handler);
+
+    REQUIRE(post.HasAppInfo());
+    REQUIRE(post.AppendHeaderS(request));
+}
+
+TEST_CASE("HttpPost accepts credential files at the exact size boundary", "[HttpPost][security]") {
+    ScopedEnvironment environment;
+    CredentialFiles files;
+    CredentialFiles::Write(files.Key(), std::string(4096, 'k'));
+    CredentialFiles::Write(files.Secret(), std::string(4096, 's'));
+    REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+    REQUIRE(setenv(kSecretFileEnv, files.Secret().c_str(), 1) == 0);
+
+    cosmo::network::http::HttpPost post;
+    REQUIRE(post.HasAppInfo());
+}
+
+TEST_CASE("HttpPost rejects partial or malformed credential mounts", "[HttpPost][security]") {
+    ScopedEnvironment environment;
+    CredentialFiles files;
+    files.WriteValid();
+
+    SECTION("only one file is configured") {
+        REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+        cosmo::network::http::HttpPost post;
+        REQUIRE_FALSE(post.HasAppInfo());
+    }
+
+    SECTION("credential file has multiple lines") {
+        CredentialFiles::Write(files.Secret(), std::string(16, 'a') + "\n" + std::string(16, 'b'));
+        REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+        REQUIRE(setenv(kSecretFileEnv, files.Secret().c_str(), 1) == 0);
+        cosmo::network::http::HttpPost post;
+        REQUIRE_FALSE(post.HasAppInfo());
+    }
+
+    SECTION("credential file has repeated trailing line endings") {
+        CredentialFiles::Write(files.Secret(), std::string(32, 's') + "\n\n");
+        REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+        REQUIRE(setenv(kSecretFileEnv, files.Secret().c_str(), 1) == 0);
+        cosmo::network::http::HttpPost post;
+        REQUIRE_FALSE(post.HasAppInfo());
+    }
+
+    SECTION("credential file contains a NUL byte") {
+        CredentialFiles::Write(files.Secret(), std::string("secret\0suffix", 13));
+        REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+        REQUIRE(setenv(kSecretFileEnv, files.Secret().c_str(), 1) == 0);
+        cosmo::network::http::HttpPost post;
+        REQUIRE_FALSE(post.HasAppInfo());
+    }
+
+    SECTION("credential file exceeds the bounded read limit") {
+        CredentialFiles::Write(files.Secret(), std::string(4097, 's'));
+        REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+        REQUIRE(setenv(kSecretFileEnv, files.Secret().c_str(), 1) == 0);
+        cosmo::network::http::HttpPost post;
+        REQUIRE_FALSE(post.HasAppInfo());
+    }
+
+    SECTION("credential file is empty after newline trimming") {
+        CredentialFiles::Write(files.Secret(), "\r\n");
+        REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+        REQUIRE(setenv(kSecretFileEnv, files.Secret().c_str(), 1) == 0);
+        cosmo::network::http::HttpPost post;
+        REQUIRE_FALSE(post.HasAppInfo());
+    }
+
+    SECTION("credential path is relative") {
+        REQUIRE(setenv(kKeyFileEnv, "relative-app-key", 1) == 0);
+        REQUIRE(setenv(kSecretFileEnv, files.Secret().c_str(), 1) == 0);
+        cosmo::network::http::HttpPost post;
+        REQUIRE_FALSE(post.HasAppInfo());
+    }
+
+    SECTION("credential path is not a regular file") {
+        REQUIRE(setenv(kKeyFileEnv, files.Key().c_str(), 1) == 0);
+        REQUIRE(setenv(kSecretFileEnv, files.Directory().c_str(), 1) == 0);
+        cosmo::network::http::HttpPost post;
+        REQUIRE_FALSE(post.HasAppInfo());
+    }
+}
+
+TEST_CASE("HttpPost explicit credential injection is all-or-nothing", "[HttpPost][security]") {
+    ScopedEnvironment environment;
+    cosmo::network::http::HttpPost post;
+
+    post.SetAppInfo(std::string("runtime-") + "key", std::string(32, 'r'));
+    REQUIRE(post.HasAppInfo());
+
+    post.SetAppInfo("", std::string(32, 'r'));
+    REQUIRE_FALSE(post.HasAppInfo());
+}


### PR DESCRIPTION
## What changed

- Preserve the API error contract when a plain exception reaches the router; it now reports an internal error instead of success.
- Remove built-in manager request-signing credentials.
- Load the manager app key and secret from two absolute, single-line credential files and fail closed when configuration is partial or invalid.
- Add focused credential tests, deployment documentation in Chinese and English, and a Gitleaks policy.

## Runtime contract

Signed manager requests now require both `COSMO_APP_KEY_FILE` and `COSMO_APP_SECRET_FILE`. Each variable must point to a regular file no larger than 4096 bytes containing exactly one non-empty line. If both are absent, manager signing is disabled. Local web and device APIs are unaffected.

## Validation

- Diff whitespace, conflict-marker, and Public/Private boundary checks passed.
- Gitleaks current-tree scan: 0 findings.
- Gitleaks full-history scan: 1 retired credential finding in historical commit `b1500832`; this PR does not rewrite public history, so external credential rotation remains required.
- Code-identical manager credential suite: 5 test cases, 94 assertions passed.
- Code-identical API exception regression: 1 test case, 5 assertions passed.
- Exact Public CPU build was attempted on the Ubuntu development host, but the baseline dependency build stopped before CosmoEdge product sources compiled: SRS requires missing host build prerequisites (including automake/cross-compiler checks), while Rust crates.io downloads hit TLS EOF. A single environment retry produced the same external blockers.

The PR remains a draft until the public CI/build environment supplies the baseline prerequisites and compiles the exact branch.
