### PR TITLE
fix(stream): normalize padded Annex-B packets

### DIFF
--- a/src/flow/stream/RtmpCodecConfig.cc
+++ b/src/flow/stream/RtmpCodecConfig.cc
@@ -43,6 +43,23 @@ namespace {
                       input.begin() + static_cast<std::ptrdiff_t>(offset + length));
         return true;
     }
+
+    bool FindAnnexBStartCode(const uint8_t* data, size_t size, size_t from, size_t& offset, size_t& length) {
+        for (size_t index = from; index + 3 <= size; ++index) {
+            if (index + 4 <= size && data[index] == 0x00 && data[index + 1] == 0x00 &&
+                data[index + 2] == 0x00 && data[index + 3] == 0x01) {
+                offset = index;
+                length = 4;
+                return true;
+            }
+            if (data[index] == 0x00 && data[index + 1] == 0x00 && data[index + 2] == 0x01) {
+                offset = index;
+                length = 3;
+                return true;
+            }
+        }
+        return false;
+    }
 }  // namespace
 
 RtmpCodecConfig::RtmpCodecConfig(media::VideoCodecType codec_type, int width, int height, float fps)
@@ -140,6 +157,8 @@ bool RtmpCodecConfig::ParseAndPrepare(const uint8_t* data, size_t size, const ui
     // SPS/PPS from in-band stream have 00 00 00 01 prefix (SeparateHVideoFrame
     // includes it); those from avcC extradata are raw NAL units.
     // Annex-B-mix would corrupt the bytestream — detect and add prefix as needed.
+    const uint8_t* effective_data = data;
+    size_t effective_size         = size;
     if (main_type == media::HFrameType::I && lead_type != media::HFrameType::SPS &&
         lead_type != media::HFrameType::VPS) {
         static const uint8_t kStartCode[]{0x00, 0x00, 0x00, 0x01};
@@ -163,13 +182,70 @@ bool RtmpCodecConfig::ParseAndPrepare(const uint8_t* data, size_t size, const ui
         appendNal(pps_);
         appendNal(sei_);
         prepend_buffer_.insert(prepend_buffer_.end(), data, data + size);
-        out_data = prepend_buffer_.data();
-        out_size = prepend_buffer_.size();
-    } else {
-        out_data = data;
-        out_size = size;
+        effective_data = prepend_buffer_.data();
+        effective_size = prepend_buffer_.size();
     }
 
+    // FFmpeg 4.4's FLV muxer can emit zero-length AVCC NAL units when an Annex-B packet
+    // contains legal trailing_zero_8bits (for example 00 00 00 00 00 01 between PPS and
+    // SEI). Rebuild a canonical Annex-B packet so the legacy muxer receives exactly one
+    // start code per non-empty NAL. This preserves the existing FFmpeg ABI while making
+    // periodic keyframes decodable by standard H.264 clients.
+    if (!NormalizeAnnexB(effective_data, effective_size, out_data, out_size)) {
+        out_data = effective_data;
+        out_size = effective_size;
+    }
+
+    return true;
+}
+
+bool RtmpCodecConfig::NormalizeAnnexB(const uint8_t* data, size_t size, const uint8_t*& out_data,
+                                      size_t& out_size) {
+    size_t start_offset = 0;
+    size_t start_length = 0;
+    if (!data || !FindAnnexBStartCode(data, size, 0, start_offset, start_length)) {
+        return false;
+    }
+
+    static constexpr uint8_t kStartCode[]{0x00, 0x00, 0x00, 0x01};
+    normalized_buffer_.clear();
+    normalized_buffer_.reserve(size + 16);
+    bool needs_normalization = start_offset != 0 || start_length != sizeof(kStartCode);
+
+    size_t nal_start = start_offset + start_length;
+    while (nal_start < size) {
+        size_t next_offset             = 0;
+        size_t next_length             = 0;
+        const bool has_next            = FindAnnexBStartCode(data, size, nal_start, next_offset, next_length);
+        size_t nal_end                 = has_next ? next_offset : size;
+        const size_t untrimmed_nal_end = nal_end;
+        while (nal_end > nal_start && data[nal_end - 1] == 0x00) {
+            --nal_end;
+        }
+        if (nal_end > nal_start) {
+            const size_t nal_size = nal_end - nal_start;
+            if (normalized_buffer_.size() > kMaxEncodedPacketBytes - sizeof(kStartCode) ||
+                nal_size > kMaxEncodedPacketBytes - normalized_buffer_.size() - sizeof(kStartCode)) {
+                normalized_buffer_.clear();
+                return false;
+            }
+            normalized_buffer_.insert(normalized_buffer_.end(), kStartCode, kStartCode + 4);
+            normalized_buffer_.insert(normalized_buffer_.end(), data + nal_start, data + nal_end);
+        }
+        needs_normalization = needs_normalization || nal_end != untrimmed_nal_end ||
+                              (has_next && next_length != sizeof(kStartCode));
+        if (!has_next) {
+            break;
+        }
+        nal_start = next_offset + next_length;
+    }
+
+    if (normalized_buffer_.empty() || !needs_normalization) {
+        normalized_buffer_.clear();
+        return false;
+    }
+    out_data = normalized_buffer_.data();
+    out_size = normalized_buffer_.size();
     return true;
 }
 

--- a/src/flow/stream/RtmpCodecConfig.h
+++ b/src/flow/stream/RtmpCodecConfig.h
@@ -59,6 +59,7 @@ public:
 private:
     [[nodiscard]] bool ParseAvcC(const std::vector<uint8_t>& data);
     [[nodiscard]] bool ParseHevcC(const std::vector<uint8_t>& data);
+    bool NormalizeAnnexB(const uint8_t* data, size_t size, const uint8_t*& out_data, size_t& out_size);
 
     media::VideoCodecType codec_type_;
     int width_;
@@ -69,7 +70,8 @@ private:
     std::vector<uint8_t> sps_;
     std::vector<uint8_t> pps_;
     std::vector<uint8_t> sei_;
-    std::vector<uint8_t> prepend_buffer_;  // reusable buffer for I-frame parameter prepend
+    std::vector<uint8_t> prepend_buffer_;     // reusable buffer for I-frame parameter prepend
+    std::vector<uint8_t> normalized_buffer_;  // canonical Annex-B packet without empty/padded NAL units
 };
 
 }  // namespace cosmo

--- a/test/test_rtmp_codec_config.cc
+++ b/test/test_rtmp_codec_config.cc
@@ -108,4 +108,130 @@ TEST_CASE("RtmpCodecConfig recognizes an Annex-B packet with parameter sets and 
     CHECK(output_size == packet.size());
 }
 
+namespace {
+    std::vector<std::vector<uint8_t>> ParseCanonicalAnnexB(const uint8_t* data, size_t size) {
+        std::vector<std::vector<uint8_t>> nal_units;
+        size_t offset = 0;
+        while (offset < size) {
+            REQUIRE(offset + 4 <= size);
+            REQUIRE(data[offset] == 0x00);
+            REQUIRE(data[offset + 1] == 0x00);
+            REQUIRE(data[offset + 2] == 0x00);
+            REQUIRE(data[offset + 3] == 0x01);
+            const size_t nal_start = offset + 4;
+            size_t next            = nal_start;
+            while (next + 4 <= size && !(data[next] == 0x00 && data[next + 1] == 0x00 &&
+                                         data[next + 2] == 0x00 && data[next + 3] == 0x01)) {
+                ++next;
+            }
+            const size_t nal_end = next + 4 <= size ? next : size;
+            REQUIRE(nal_end > nal_start);
+            nal_units.emplace_back(data + nal_start, data + nal_end);
+            offset = nal_end;
+        }
+        return nal_units;
+    }
+}  // namespace
+
+TEST_CASE("RTMP codec config removes padded Annex-B separators", "[media][preview][rtmp]") {
+    const std::vector<uint8_t> packet{
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x67,
+        0x4d,
+        0x40,
+        0x32,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x68,
+        0xce,
+        0x3c,
+        0x80,
+        // Legal trailing_zero_8bits followed by a four-byte start code. The legacy
+        // FLV muxer previously serialized this run as an empty AVCC NAL.
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x06,
+        0x05,
+        0x2f,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x65,
+        0x88,
+        0x80,
+        0x0e,
+    };
+
+    cosmo::RtmpCodecConfig config(cosmo::media::VideoCodecType::kH264, 1920, 1080, 24.0F);
+    const uint8_t* output = nullptr;
+    size_t output_size    = 0;
+    cosmo::media::HFrameType main_type{};
+    cosmo::media::HFrameType lead_type{};
+
+    REQUIRE(config.ParseAndPrepare(packet.data(), packet.size(), output, output_size, main_type, lead_type));
+    REQUIRE(main_type == cosmo::media::HFrameType::I);
+    REQUIRE(lead_type == cosmo::media::HFrameType::SPS);
+
+    const auto nal_units = ParseCanonicalAnnexB(output, output_size);
+    REQUIRE(nal_units.size() == 4);
+    REQUIRE((nal_units[0][0] & 0x1f) == 7);
+    REQUIRE((nal_units[1][0] & 0x1f) == 8);
+    REQUIRE((nal_units[2][0] & 0x1f) == 6);
+    REQUIRE((nal_units[3][0] & 0x1f) == 5);
+}
+
+TEST_CASE("RTMP codec config canonicalizes ordinary H264 access units", "[media][preview][rtmp]") {
+    const std::vector<uint8_t> packet{
+        0x00, 0x00, 0x00, 0x01, 0x09, 0x30, 0x00, 0x00, 0x01, 0x41, 0x9a, 0x02, 0x07,
+    };
+
+    cosmo::RtmpCodecConfig config(cosmo::media::VideoCodecType::kH264, 1280, 720, 25.0F);
+    const uint8_t* output = nullptr;
+    size_t output_size    = 0;
+    cosmo::media::HFrameType main_type{};
+    cosmo::media::HFrameType lead_type{};
+
+    REQUIRE(config.ParseAndPrepare(packet.data(), packet.size(), output, output_size, main_type, lead_type));
+    const auto nal_units = ParseCanonicalAnnexB(output, output_size);
+    REQUIRE(nal_units.size() == 2);
+    REQUIRE((nal_units[0][0] & 0x1f) == 9);
+    REQUIRE((nal_units[1][0] & 0x1f) == 1);
+}
+
+TEST_CASE("RTMP codec config removes padded H265 Annex-B separators", "[media][preview][rtmp]") {
+    const std::vector<uint8_t> packet{
+        0x00, 0x00, 0x00, 0x01, 0x40, 0x01, 0x0c, 0x00, 0x00, 0x00, 0x01, 0x42, 0x01,
+        0x01, 0x00, 0x00, 0x00, 0x01, 0x44, 0x01, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01, 0x4e, 0x01, 0x80, 0x00, 0x00, 0x00, 0x01, 0x26, 0x01, 0xaf,
+    };
+
+    cosmo::RtmpCodecConfig config(cosmo::media::VideoCodecType::kH265, 1920, 1080, 25.0F);
+    const uint8_t* output = nullptr;
+    size_t output_size    = 0;
+    cosmo::media::HFrameType main_type{};
+    cosmo::media::HFrameType lead_type{};
+
+    REQUIRE(config.ParseAndPrepare(packet.data(), packet.size(), output, output_size, main_type, lead_type));
+    REQUIRE(main_type == cosmo::media::HFrameType::I);
+    REQUIRE(lead_type == cosmo::media::HFrameType::VPS);
+
+    const auto nal_units = ParseCanonicalAnnexB(output, output_size);
+    REQUIRE(nal_units.size() == 5);
+    REQUIRE(((nal_units[0][0] & 0x7e) >> 1) == 32);
+    REQUIRE(((nal_units[1][0] & 0x7e) >> 1) == 33);
+    REQUIRE(((nal_units[2][0] & 0x7e) >> 1) == 34);
+    REQUIRE(((nal_units[3][0] & 0x7e) >> 1) == 39);
+    REQUIRE(((nal_units[4][0] & 0x7e) >> 1) == 19);
+}
+
 }  // namespace cosmo


### PR DESCRIPTION
## What changed

- Canonicalize mixed three-byte/four-byte Annex-B start codes before handing packets to the FLV/RTMP muxer.
- Remove legal `trailing_zero_8bits` padding that legacy FFmpeg can otherwise serialize as empty AVCC NAL units.
- Apply the behavior to both H.264 and H.265 while preserving already-canonical packets without an extra copy.
- Add focused H.264/H.265 regression coverage for padded separators and ordinary access units.

## Root cause and impact

FFmpeg 4.4 can emit zero-length AVCC NAL units when an Annex-B packet contains padded separators between parameter sets, SEI, and keyframes. Standard clients may then fail to decode periodic keyframes, presenting as an intermittent RTMP preview failure even though the source stream remains active.

The fix keeps the existing FFmpeg ABI and normalizes only packets that contain leading padding, mixed start-code lengths, or trailing zero padding. Packet size remains bounded by the existing 64 MiB guard.

## Validation

- Focused `[media][preview][rtmp]` suite: 3 test cases, 87 assertions passed.
- Diff whitespace and conflict-marker checks passed.
- Public/Private boundary scan passed: no NVIDIA, CUDA, TensorRT, Qwen, NVCodec, private host, or private repository references.
- The Public implementation preserves the same behavior and regression coverage already validated by the private full suite; it is formatted and committed here as a clean Public change with the current contributor identity.

This PR changes only the RTMP codec configuration and its tests.