### PR TITLE
fix(validation): align scenario video upload with staging protocol

### DIFF
--- a/tools/scenario-bench/src/channel-manager.js
+++ b/tools/scenario-bench/src/channel-manager.js
@@ -15,6 +15,8 @@
 import path from 'node:path';
 import fs from 'node:fs';
 
+const UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024;
+
 export class ChannelManager {
   /**
    * @param {import('./cosmo-client.js').CosmoClient} client
@@ -81,26 +83,24 @@ export class ChannelManager {
       // Two ways to source a local video:
       //   - file:     a path on THIS machine → uploaded to the device temp store first.
       //   - filePath: a path already staged on the device → used directly (skip upload).
-      let filePath;
-      let contentLength;
+      let videoPayload;
       if (src.file) {
-        // NOTE: AddVideo CONSUMES (moves) the temp file, so the same uploaded
-        // filePath cannot be reused across channels — each channel needs its own
-        // upload. See MessageCameraHandler / CameraDeviceCrud (code 17 文件不存在).
-        filePath = await this._uploadLocalVideo(src);
-        contentLength = this._localSize(src);
+        // AddVideo consumes the upload session, so every channel needs its own
+        // upload even when all channels use the same local source.
+        videoPayload = { uploadId: await this._uploadLocalVideo(src) };
       } else if (src.filePath) {
-        filePath = src.filePath;
-        contentLength = Number(src.contentLength ?? 0);
+        // Compatibility path for a caller-managed device-side fixture.
+        videoPayload = {
+          filePath: src.filePath,
+          contentLength: String(Number(src.contentLength ?? 0)),
+        };
       } else {
         throw new Error(`scenario.yml channels: local source must define 'file' or 'filePath'`);
       }
-      // Backend (MessageCameraHandler.cc:44) reads only {filePath, channelName, contentLength}
-      // from AddVideo; channelCode is NOT consumed there, so we omit it.
       const res = await this.client.cameraAddVideo({
         channelName: this._channelNameForSource(name, src),
-        filePath,
-        contentLength: String(contentLength),
+        channelCode: code,
+        ...videoPayload,
       });
       const id = res?.resData?.id;
       if (!id) throw new Error(`AddVideo for ${code} returned no id`);
@@ -130,51 +130,64 @@ export class ChannelManager {
 
   /**
    * Upload a local video file to the device temp store in chunks, returning the
-   * device-side filePath to pass to AddVideo. Mirrors the frontend
-   * uploadVideoByChunk (CHUNK_SIZE = 32 MiB). The returned filePath comes from the
-   * LAST chunk's response (when all chunks are merged).
+   * canonical upload ID to pass to AddVideo. Mirrors the frontend
+   * uploadFileInChunks (CHUNK_SIZE = 8 MiB). Chunk zero creates a server-side
+   * session; later chunks use the returned opaque upload ID. The completed
+   * session is consumed by Camera/AddVideo.
    */
   async _uploadLocalVideo(src) {
     const localPath = src.file;
     if (!localPath) throw new Error(`scenario.yml channels: local source missing 'file' path`);
     const stat = fs.statSync(localPath);
     const totalSize = stat.size;
-    const CHUNK_SIZE = 32 * 1024 * 1024;
-    const totalChunks = Math.max(1, Math.ceil(totalSize / CHUNK_SIZE));
-    const uploadId = `bench_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+    const totalChunks = Math.max(1, Math.ceil(totalSize / UPLOAD_CHUNK_SIZE));
+    const clientRequestId = `bench_${Date.now()}_${Math.random().toString(16).slice(2)}`;
     const fileName = path.basename(localPath);
     const fd = fs.openSync(localPath, 'r');
-    let filePath = null;
+    let uploadId = '';
     try {
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
-        const start = chunkIndex * CHUNK_SIZE;
-        const chunkSize = Math.min(CHUNK_SIZE, totalSize - start);
+        const start = chunkIndex * UPLOAD_CHUNK_SIZE;
+        const chunkSize = Math.min(UPLOAD_CHUNK_SIZE, totalSize - start);
         const chunkBuf = Buffer.alloc(chunkSize);
         fs.readSync(fd, chunkBuf, 0, chunkSize, start);
         const res = await this.client.uploadTempChunk(chunkBuf, fileName, {
           uploadId,
+          clientRequestId,
+          purpose: 'video',
           chunkIndex,
           totalChunks,
           totalSize,
           chunkSize,
         });
-        if (chunkIndex === totalChunks - 1) {
-          filePath = res?.resData?.filePath ?? null;
+        const responseUploadId = res?.resData?.uploadId ?? '';
+        if (!responseUploadId) {
+          throw new Error(`uploadTemp returned no uploadId for ${fileName} chunk ${chunkIndex}`);
+        }
+        if (uploadId && responseUploadId !== uploadId) {
+          throw new Error(`uploadTemp changed uploadId for ${fileName}`);
+        }
+        uploadId = responseUploadId;
+        const nextChunkIndex = Number(res?.resData?.nextChunkIndex);
+        if (!Number.isInteger(nextChunkIndex) || nextChunkIndex !== chunkIndex + 1) {
+          throw new Error(`uploadTemp returned invalid nextChunkIndex for ${fileName}`);
+        }
+        if (chunkIndex === totalChunks - 1 && res?.resData?.complete !== true) {
+          throw new Error(`uploadTemp did not complete ${fileName}`);
         }
       }
+    } catch (error) {
+      if (uploadId) {
+        try {
+          await this.client.cancelUpload(uploadId);
+        } catch { /* preserve the upload failure */ }
+      }
+      throw error;
     } finally {
       fs.closeSync(fd);
     }
-    if (!filePath) throw new Error(`uploadTemp returned no filePath for ${fileName}`);
-    this.log?.debug?.(`uploaded ${fileName} → ${filePath}`);
-    return filePath;
-  }
-
-  /** Cached local-file size, used for AddVideo contentLength. */
-  _localSize(src) {
-    if (src._size != null) return src._size;
-    const s = fs.statSync(src.file);
-    return (src._size = s.size);
+    this.log?.debug?.(`uploaded ${fileName} → ${uploadId}`);
+    return uploadId;
   }
 
   /**

--- a/tools/scenario-bench/src/cosmo-client.js
+++ b/tools/scenario-bench/src/cosmo-client.js
@@ -74,14 +74,35 @@ export class CosmoClient {
    * The final chunk returns resData.filePath on the device.
    * @param {Buffer} chunkBuf  raw chunk bytes
    * @param {string} fileName  original file name (used for extension + naming)
-   * @param {object} meta { uploadId, chunkIndex, totalChunks, totalSize, chunkSize }
-   * @returns {Promise<object>} wire response; resData.filePath present on the last chunk
+   * @param {object} meta upload session and chunk metadata
+   * @returns {Promise<object>} wire response with the canonical resData.uploadId
    */
-  async uploadTempChunk(chunkBuf, fileName, { uploadId, chunkIndex, totalChunks, totalSize, chunkSize }) {
-    return this._postMultipart(
-      '/atomic/model/uploadTemp',
-      { file: { value: chunkBuf, filename: fileName }, uploadId, chunkIndex: String(chunkIndex), totalChunks: String(totalChunks), totalSize: String(totalSize), chunkSize: String(chunkSize) },
-    );
+  async uploadTempChunk(chunkBuf, fileName, {
+    uploadId,
+    clientRequestId,
+    purpose,
+    chunkIndex,
+    totalChunks,
+    totalSize,
+    chunkSize,
+  }) {
+    const fields = {
+      file: { value: chunkBuf, filename: fileName },
+      purpose,
+      clientRequestId,
+      chunkIndex: String(chunkIndex),
+      totalChunks: String(totalChunks),
+      totalSize: String(totalSize),
+      chunkSize: String(chunkSize),
+    };
+    // The first chunk creates the server-side session. Later chunks must use
+    // the opaque upload ID returned by that first response.
+    if (uploadId) fields.uploadId = uploadId;
+    return this._postMultipart('/atomic/model/uploadTemp', fields);
+  }
+
+  async cancelUpload(uploadId) {
+    return this._post('/atomic/model/cancelUpload', { uploadId });
   }
 
   /** Add an RTSP camera channel. */

--- a/tools/scenario-bench/test/channel-manager.test.js
+++ b/tools/scenario-bench/test/channel-manager.test.js
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import { ChannelManager } from '../src/channel-manager.js';
@@ -58,4 +61,53 @@ test('created local AddVideo channel names keep a stable bench prefix', async ()
   assert.equal(payloads[0].channelName, 'bench-case-01-clip');
   assert.equal(payloads[0].filePath, '/device/clip.mp4');
   assert.equal(payloads[0].contentLength, '100');
+});
+
+test('uploads local videos with bounded chunks and consumes the server upload ID', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scenario-bench-upload-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const video = path.join(dir, 'clip.mp4');
+  fs.writeFileSync(video, '');
+  fs.truncateSync(video, 8 * 1024 * 1024 + 1);
+
+  const chunks = [];
+  const payloads = [];
+  const client = {
+    async cameraPage() {
+      return { rows: [] };
+    },
+    async uploadTempChunk(buffer, fileName, meta) {
+      chunks.push({ size: buffer.length, fileName, meta });
+      return {
+        resData: {
+          uploadId: 'server-upload-id',
+          nextChunkIndex: String(meta.chunkIndex + 1),
+          complete: meta.chunkIndex + 1 === meta.totalChunks,
+        },
+      };
+    },
+    async cameraAddVideo(payload) {
+      payloads.push(payload);
+      return { resData: { id: 'created-1' } };
+    },
+  };
+  const manager = new ChannelManager(client, {
+    channelPrefix: 'bench-case',
+    reuse: true,
+  });
+
+  const ids = await manager.ensureChannels({
+    mode: 'local',
+    local: [{ name: 'clip', file: video }],
+  }, 1);
+
+  assert.deepEqual(ids, ['created-1']);
+  assert.deepEqual(chunks.map((chunk) => chunk.size), [8 * 1024 * 1024, 1]);
+  assert.equal(chunks[0].meta.uploadId, '');
+  assert.equal(chunks[1].meta.uploadId, 'server-upload-id');
+  assert.equal(chunks[0].meta.purpose, 'video');
+  assert.equal(chunks[0].meta.clientRequestId, chunks[1].meta.clientRequestId);
+  assert.equal(payloads[0].uploadId, 'server-upload-id');
+  assert.equal(payloads[0].filePath, undefined);
+  assert.equal(payloads[0].contentLength, undefined);
 });


### PR DESCRIPTION
## What changed

- limit scenario video upload chunks to the backend's 8 MiB staging contract
- create the upload session with the first chunk and reuse the server-issued opaque upload ID
- consume completed video uploads through `Camera/AddVideo`
- cancel incomplete sessions on failure
- add regression coverage for chunk sizing, session continuity, completion, and AddVideo payloads

## Root cause

`scenario-bench` still used the previous 32 MiB/client-generated upload flow. The hardened staging API accepts at most 8 MiB per chunk and owns upload-session IDs, so real BM1688 scenario runs failed with HTTP 413 before channel creation.

## Validation

- `node --test tools/scenario-bench/test/*.test.js`: 39 passed
- BM1688 host `192.168.0.33`: 1/2/4-channel No Safety Helmet scenario passed
- BM1688 VLM scenario ran for 180 seconds with completed inference and alarms
- upload failure was reproduced before the patch and the same scenario completed after the patch

## Scope

Validation tooling only; no runtime decoder or inference behavior is changed.
