### PR TITLE
fix(media): handle Sophon decoder warmup on repeated streams

### DIFF
--- a/src/media/VideoDecoderSophon.cc
+++ b/src/media/VideoDecoderSophon.cc
@@ -16,6 +16,13 @@
 // handle, returning BM_ERR_VDEC_ILLEGAL_PARAM. This global lock serializes all VPU lifecycle operations.
 static std::mutex g_vpuLifecycleMutex;
 
+namespace {
+// A newly created VPU channel can transiently return ILLEGAL_PARAM before its first output is ready.
+// Bound the retry budget so a genuinely invalid stream still becomes visible promptly.
+constexpr unsigned int kOutputWarmupRetryCount = 50;
+constexpr auto kOutputWarmupRetryInterval      = std::chrono::milliseconds(1);
+}  // namespace
+
 namespace cosmo {
 namespace media {
 
@@ -96,8 +103,9 @@ namespace media {
             return false;
         }
 
-        code_handle_ = next_handle;
-        frame_       = std::move(next_frame);
+        code_handle_                     = next_handle;
+        frame_                           = std::move(next_frame);
+        output_warmup_retries_remaining_ = kOutputWarmupRetryCount;
         stop_.store(false);
         opened_.store(true);
         LOG_INFO("{} VPU decoder opened", idx_name_);
@@ -124,6 +132,7 @@ namespace media {
         }
 
         frame_.reset();
+        output_warmup_retries_remaining_ = 0;
 
         opened_.store(false);
         LOG_INFO("{} VPU decoder closed", idx_name_);
@@ -196,11 +205,21 @@ namespace media {
         while (!stop_.load()) {
             auto ret = bmvpu_dec_get_output(code_handle_, frame_.get());
             if (ret != BMVidDecRetStatus::BM_ERR_VDEC_SUCCESS) {
+                if (ret == BMVidDecRetStatus::BM_ERR_VDEC_ILLEGAL_PARAM &&
+                    output_warmup_retries_remaining_ > 0) {
+                    --output_warmup_retries_remaining_;
+                    std::this_thread::sleep_for(kOutputWarmupRetryInterval);
+                    continue;
+                }
                 if (ret != BMVidDecRetStatus::BM_ERR_VDEC_BUF_EMPTY) {
-                    LOG_WARN("bmvpu_dec_get_output failed: {}", ret);
+                    const auto status = bmvpu_dec_get_status(code_handle_);
+                    LOG_WARN("{} bmvpu_dec_get_output failed: {}, status: {}, warmup retries remaining: {}",
+                             idx_name_, ret, status, output_warmup_retries_remaining_);
                 }
                 return nullptr;
             }
+
+            output_warmup_retries_remaining_ = 0;
 
             auto pkt_cnt = bmvpu_dec_get_pkt_in_buf_cnt(code_handle_);
             if (pkt_cnt < 0) {
@@ -216,6 +235,10 @@ namespace media {
                 continue;
             }
             break;
+        }
+
+        if (stop_.load()) {
+            return nullptr;
         }
 
         BmImagePtr vpu_frame_image(new bm_image());

--- a/src/media/VideoDecoderSophon.cc
+++ b/src/media/VideoDecoderSophon.cc
@@ -17,10 +17,10 @@
 static std::mutex g_vpuLifecycleMutex;
 
 namespace {
-// A newly created VPU channel can transiently return ILLEGAL_PARAM before its first output is ready.
-// Bound the retry budget so a genuinely invalid stream still becomes visible promptly.
-constexpr unsigned int kOutputWarmupRetryCount = 50;
-constexpr auto kOutputWarmupRetryInterval      = std::chrono::milliseconds(1);
+// A newly created VPU channel, or one starting a repeated file sequence, can transiently report
+// WRONG_RESOLUTION until enough packets have arrived. Bound the warmup window by output attempts
+// so an invalid stream still becomes visible promptly while allowing the caller to feed packets.
+constexpr unsigned int kOutputWarmupAttemptBudget = 16;
 }  // namespace
 
 namespace cosmo {
@@ -103,9 +103,10 @@ namespace media {
             return false;
         }
 
-        code_handle_                     = next_handle;
-        frame_                           = std::move(next_frame);
-        output_warmup_retries_remaining_ = kOutputWarmupRetryCount;
+        code_handle_                      = next_handle;
+        frame_                            = std::move(next_frame);
+        output_warmup_attempts_remaining_ = kOutputWarmupAttemptBudget;
+        last_input_frame_index_           = -1;
         stop_.store(false);
         opened_.store(true);
         LOG_INFO("{} VPU decoder opened", idx_name_);
@@ -132,7 +133,8 @@ namespace media {
         }
 
         frame_.reset();
-        output_warmup_retries_remaining_ = 0;
+        output_warmup_attempts_remaining_ = 0;
+        last_input_frame_index_           = -1;
 
         opened_.store(false);
         LOG_INFO("{} VPU decoder closed", idx_name_);
@@ -147,6 +149,12 @@ namespace media {
         std::lock_guard<std::mutex> operation_lock(operation_mutex_);
         if (stop_.load() || !opened_.load() || code_handle_ == nullptr) {
             return false;
+        }
+
+        // Local-file repeat keeps the same decoder but resets packet indices. The VPU then
+        // re-enters sequence initialization and may briefly report WRONG_RESOLUTION.
+        if (frame_idx >= 0 && last_input_frame_index_ >= 0 && frame_idx < last_input_frame_index_) {
+            output_warmup_attempts_remaining_ = kOutputWarmupAttemptBudget;
         }
 
         BMVidStream stream{};
@@ -166,6 +174,7 @@ namespace media {
         for (int attempt = 0; attempt < kMaxDecodeAttempts; ++attempt) {
             const auto ret = bmvpu_dec_decode(code_handle_, stream);
             if (ret == BMVidDecRetStatus::BM_ERR_VDEC_SUCCESS) {
+                last_input_frame_index_ = frame_idx;
                 return true;
             }
             if (ret != BMVidDecRetStatus::BM_ERR_VDEC_BUF_FULL &&
@@ -205,21 +214,23 @@ namespace media {
         while (!stop_.load()) {
             auto ret = bmvpu_dec_get_output(code_handle_, frame_.get());
             if (ret != BMVidDecRetStatus::BM_ERR_VDEC_SUCCESS) {
+                if (ret == BMVidDecRetStatus::BM_ERR_VDEC_BUF_EMPTY) {
+                    return nullptr;
+                }
+                const auto status = bmvpu_dec_get_status(code_handle_);
                 if (ret == BMVidDecRetStatus::BM_ERR_VDEC_ILLEGAL_PARAM &&
-                    output_warmup_retries_remaining_ > 0) {
-                    --output_warmup_retries_remaining_;
-                    std::this_thread::sleep_for(kOutputWarmupRetryInterval);
-                    continue;
+                    status == BMDecStatus::BMDEC_WRONG_RESOLUTION && output_warmup_attempts_remaining_ > 0) {
+                    --output_warmup_attempts_remaining_;
+                    return nullptr;
                 }
-                if (ret != BMVidDecRetStatus::BM_ERR_VDEC_BUF_EMPTY) {
-                    const auto status = bmvpu_dec_get_status(code_handle_);
-                    LOG_WARN("{} bmvpu_dec_get_output failed: {}, status: {}, warmup retries remaining: {}",
-                             idx_name_, ret, status, output_warmup_retries_remaining_);
-                }
+                LOG_WARN("{} bmvpu_dec_get_output failed: {}, status: {}, warmup attempts remaining: {}",
+                         idx_name_, ret, status, output_warmup_attempts_remaining_);
                 return nullptr;
             }
 
-            output_warmup_retries_remaining_ = 0;
+            if (output_warmup_attempts_remaining_ > 0) {
+                --output_warmup_attempts_remaining_;
+            }
 
             auto pkt_cnt = bmvpu_dec_get_pkt_in_buf_cnt(code_handle_);
             if (pkt_cnt < 0) {

--- a/src/media/VideoDecoderSophon.h
+++ b/src/media/VideoDecoderSophon.h
@@ -47,7 +47,8 @@ namespace media {
 
         size_t cache_size_ = 5;
 
-        unsigned int output_warmup_retries_remaining_ = 0;
+        unsigned int output_warmup_attempts_remaining_ = 0;
+        int64_t last_input_frame_index_                = -1;
 
         std::mutex operation_mutex_;
         std::atomic_bool stop_{true};

--- a/src/media/VideoDecoderSophon.h
+++ b/src/media/VideoDecoderSophon.h
@@ -47,6 +47,8 @@ namespace media {
 
         size_t cache_size_ = 5;
 
+        unsigned int output_warmup_retries_remaining_ = 0;
+
         std::mutex operation_mutex_;
         std::atomic_bool stop_{true};
         std::atomic_bool opened_{false};


### PR DESCRIPTION
## Related issue

Follow-up from the Public BM1688 validation run; no standalone issue.

## Root cause

On a looping local H.264 file, packet indices regress from the end of the file back to frame 1. The BM1688 VPU can then transiently return `BM_ERR_VDEC_ILLEGAL_PARAM (-26)` with decoder status `BMDEC_WRONG_RESOLUTION (4)` while it consumes the first packets of the new sequence.

Two device runs narrowed the boundary:

- Retrying inside one `GetFrame` call did not help because the VPU needed later packets to progress.
- Clearing an opening-only guard after the first successful output was also too early; the transient status can arrive several output attempts later at a loop boundary.

## Scope

- Keep a bounded warmup window of 16 output attempts after decoder open.
- Re-arm that bounded window when input packet indices regress at a local-file loop boundary.
- Defer only the exact `ILLEGAL_PARAM + WRONG_RESOLUTION` combination while the window is active, returning control so the next packet can be fed.
- Count both successful and deferred output attempts toward the same finite window.
- Preserve all other VPU errors, and any occurrence after the window, as visible warnings with decoder status.
- Retain the shutdown guard before consuming a decoded frame.

No API, model, task, preview, upload, or non-Sophon decoder behavior changes.

## Candidate identity

- Candidate commit: `b6ea0e5a`
- Base commit: `52a103bdb66ed10bd40a8bc2ad23cce3be1f5378`
- BM1688 package MD5: `57460ae935a33465c7d6bc854175fb40`

## Verification

- Diff check and Apple clang-format 21 passed on both changed files.
- Full Sophon/aarch64 build and package generation passed in `ghcr.io/cosmo-wander-ai/cosmo_edge-build-env_sophon:v1`.
- Deployed the resulting package to BM1688 host `192.168.0.33`; `cosmo.service` remained active.
- Four local H.264 channels ran for 60 seconds and crossed 22 observed loop boundaries.
- Final candidate log: `-26 = 0`, `WRONG_RESOLUTION = 0`.
- Scenario report: completed, overall pass, 24 samples, decoder 24.39-24.41 FPS, discard rate 0.

The quick run did not enable preview/OSD, so that remains a separate readiness gate.

## Acceptance before marking ready

- Extend to at least 100 loop boundaries on BM1688.
- Confirm `-26 = 0`, `packetDiscard = 0`, stable process health, and no first-frame regression.
- Exercise preview/OSD and confirm `previewStreamFailures = 0` with visible output.
- Preserve any non-warmup `-26` as a visible error with decoder status.
