### PR TITLE
fix(media): preserve Sophon sequence warmup budget

### DIFF
--- a/src/media/VideoDecoderSophon.cc
+++ b/src/media/VideoDecoderSophon.cc
@@ -17,10 +17,11 @@
 static std::mutex g_vpuLifecycleMutex;
 
 namespace {
-// A newly created VPU channel, or one starting a repeated file sequence, can transiently report
-// WRONG_RESOLUTION until enough packets have arrived. Bound the warmup window by output attempts
-// so an invalid stream still becomes visible promptly while allowing the caller to feed packets.
-constexpr unsigned int kOutputWarmupAttemptBudget = 16;
+// A newly created VPU channel can transiently report WRONG_RESOLUTION while it is still consuming
+// sequence headers. Count only that specific error so successful output does not close the warmup
+// window prematurely. AlgChannelDecode recreates the VPU channel for every new stream sequence, so
+// Open() naturally starts a fresh bounded budget without tracking packet or frame index rewinds.
+constexpr unsigned int kWrongResolutionErrorBudget = 50;
 }  // namespace
 
 namespace cosmo {
@@ -103,10 +104,9 @@ namespace media {
             return false;
         }
 
-        code_handle_                      = next_handle;
-        frame_                            = std::move(next_frame);
-        output_warmup_attempts_remaining_ = kOutputWarmupAttemptBudget;
-        last_input_frame_index_           = -1;
+        code_handle_                       = next_handle;
+        frame_                             = std::move(next_frame);
+        wrong_resolution_errors_remaining_ = kWrongResolutionErrorBudget;
         stop_.store(false);
         opened_.store(true);
         LOG_INFO("{} VPU decoder opened", idx_name_);
@@ -133,8 +133,7 @@ namespace media {
         }
 
         frame_.reset();
-        output_warmup_attempts_remaining_ = 0;
-        last_input_frame_index_           = -1;
+        wrong_resolution_errors_remaining_ = 0;
 
         opened_.store(false);
         LOG_INFO("{} VPU decoder closed", idx_name_);
@@ -149,12 +148,6 @@ namespace media {
         std::lock_guard<std::mutex> operation_lock(operation_mutex_);
         if (stop_.load() || !opened_.load() || code_handle_ == nullptr) {
             return false;
-        }
-
-        // Local-file repeat keeps the same decoder but resets packet indices. The VPU then
-        // re-enters sequence initialization and may briefly report WRONG_RESOLUTION.
-        if (frame_idx >= 0 && last_input_frame_index_ >= 0 && frame_idx < last_input_frame_index_) {
-            output_warmup_attempts_remaining_ = kOutputWarmupAttemptBudget;
         }
 
         BMVidStream stream{};
@@ -174,7 +167,6 @@ namespace media {
         for (int attempt = 0; attempt < kMaxDecodeAttempts; ++attempt) {
             const auto ret = bmvpu_dec_decode(code_handle_, stream);
             if (ret == BMVidDecRetStatus::BM_ERR_VDEC_SUCCESS) {
-                last_input_frame_index_ = frame_idx;
                 return true;
             }
             if (ret != BMVidDecRetStatus::BM_ERR_VDEC_BUF_FULL &&
@@ -219,17 +211,14 @@ namespace media {
                 }
                 const auto status = bmvpu_dec_get_status(code_handle_);
                 if (ret == BMVidDecRetStatus::BM_ERR_VDEC_ILLEGAL_PARAM &&
-                    status == BMDecStatus::BMDEC_WRONG_RESOLUTION && output_warmup_attempts_remaining_ > 0) {
-                    --output_warmup_attempts_remaining_;
+                    status == BMDecStatus::BMDEC_WRONG_RESOLUTION && wrong_resolution_errors_remaining_ > 0) {
+                    --wrong_resolution_errors_remaining_;
                     return nullptr;
                 }
-                LOG_WARN("{} bmvpu_dec_get_output failed: {}, status: {}, warmup attempts remaining: {}",
-                         idx_name_, ret, status, output_warmup_attempts_remaining_);
+                LOG_WARN(
+                    "{} bmvpu_dec_get_output failed: {}, status: {}, wrong-resolution errors remaining: {}",
+                    idx_name_, ret, status, wrong_resolution_errors_remaining_);
                 return nullptr;
-            }
-
-            if (output_warmup_attempts_remaining_ > 0) {
-                --output_warmup_attempts_remaining_;
             }
 
             auto pkt_cnt = bmvpu_dec_get_pkt_in_buf_cnt(code_handle_);

--- a/src/media/VideoDecoderSophon.h
+++ b/src/media/VideoDecoderSophon.h
@@ -47,8 +47,7 @@ namespace media {
 
         size_t cache_size_ = 5;
 
-        unsigned int output_warmup_attempts_remaining_ = 0;
-        int64_t last_input_frame_index_                = -1;
+        unsigned int wrong_resolution_errors_remaining_ = 0;
 
         std::mutex operation_mutex_;
         std::atomic_bool stop_{true};


### PR DESCRIPTION
## What changed

- count only `BM_ERR_VDEC_ILLEGAL_PARAM` with `BMDEC_WRONG_RESOLUTION` against the Sophon decoder warmup budget
- initialize a bounded 50-error budget on each successful decoder `Open()` and clear it on `Close()`
- remove frame-index rewind tracking because a new stream sequence recreates the VPU channel

## Why

PR #50 counted every successful output attempt against a 16-attempt warmup budget. Normal decoder activity could therefore exhaust the allowance before the VPU had consumed enough sequence headers, causing a transient `WRONG_RESOLUTION` during valid startup to be surfaced as a hard failure.

## Impact

This preserves bounded error reporting for invalid streams while preventing valid Sophon streams from failing during decoder sequence warmup.

## Validation

- `git diff --check public/main...941c7655`
- native test suite: 850 cases, 849 passed, 1 skipped, 11,577 assertions
- targeted four-stream gate: 5 minutes, zero VDEC/FFmpeg/preview/discard/restart errors
- BM1688 soak: 8 hours, four publishers and eight clients continuous, zero service restarts and zero VDEC/FFmpeg/preview/discard errors

Exact head commit required for the release gate: `941c76555eed1887bb47b2c2bc2580901db71983`.
