### PR TITLE
fix(upgrade): accept safe internal symlinks in package verification

### DIFF
--- a/src/service/system/impl/PacketUpgrade.cc
+++ b/src/service/system/impl/PacketUpgrade.cc
@@ -73,6 +73,26 @@ namespace {
         return true;
     }
 
+    // A symlink is acceptable only if its target resolves to a path inside the
+    // archive root: relative (never absolute), no backslashes, and it must not
+    // traverse above the root via "..". This permits the normal shared-library
+    // versioning chains (libfoo.so -> libfoo.so.1 -> libfoo.so.1.0.0) while
+    // still blocking symlinks that would escape the extraction directory.
+    bool IsSafeSymlinkTarget(const std::string& link_member, const std::string& target) {
+        if (target.empty() || target.front() == '/' || target.find('\\') != std::string::npos) {
+            return false;
+        }
+        fs::path resolved = fs::path(link_member).parent_path();
+        resolved /= target;
+        resolved = resolved.lexically_normal();
+        for (const auto& component : resolved) {
+            if (component == "..") {
+                return false;
+            }
+        }
+        return true;
+    }
+
     bool ValidateUpgradeArchiveListing(const std::string& archive_path) {
         std::string listing;
         if (util::Exec({"tar", "-tzvf", archive_path, "--quoting-style=escape"}, listing) != 0) {
@@ -94,8 +114,10 @@ namespace {
                 return false;
             }
 
-            const bool is_directory = line.front() == 'd';
-            if (line.front() != '-' && !is_directory) {
+            const char entry_type   = line.front();
+            const bool is_directory = entry_type == 'd';
+            const bool is_symlink   = entry_type == 'l';
+            if (entry_type != '-' && !is_directory && !is_symlink) {
                 LOG_ERRO("{}", "upgrade archive contains a non-regular entry");
                 return false;
             }
@@ -112,12 +134,31 @@ namespace {
             }
             std::getline(line_stream >> std::ws, member);
 
+            std::string link_target;
+            if (is_symlink) {
+                // tar lists a symlink as "linkpath -> target"; split on the
+                // literal separator so the link path and its target are
+                // validated independently.
+                static const std::string kArrow = " -> ";
+                const auto arrow_pos            = member.find(kArrow);
+                if (arrow_pos == std::string::npos) {
+                    LOG_ERRO("upgrade archive contains an unparsable symlink: {}", member);
+                    return false;
+                }
+                link_target = member.substr(arrow_pos + kArrow.size());
+                member.resize(arrow_pos);
+            }
+
             std::string normalized;
             if (++entry_count > kMaxUpgradeArchiveEntries || entry_size > kMaxUpgradeFileBytes ||
                 entry_size > kMaxUpgradeExtractedBytes - total_size ||
                 !NormalizeUpgradeArchiveMember(member, is_directory, normalized) ||
                 !members.insert(normalized).second) {
                 LOG_ERRO("upgrade archive contains unsafe entry: {}", member);
+                return false;
+            }
+            if (is_symlink && !IsSafeSymlinkTarget(normalized, link_target)) {
+                LOG_ERRO("upgrade archive symlink target is unsafe: {} -> {}", normalized, link_target);
                 return false;
             }
             total_size += entry_size;

--- a/src/util/PathUtil.cc
+++ b/src/util/PathUtil.cc
@@ -373,8 +373,31 @@ std::string GetBaseDir() {
         }
 
         const auto link_status = it->symlink_status(ec);
-        if (ec || fs::is_symlink(link_status) ||
-            (!fs::is_directory(link_status) && !fs::is_regular_file(link_status))) {
+        if (ec) {
+            return false;
+        }
+        if (fs::is_symlink(link_status)) {
+            // Permit symlinks whose targets resolve inside the root (the
+            // normal shared-library versioning chains). Reject absolute or
+            // root-escaping targets so an archive cannot write outside it.
+            std::error_code read_ec;
+            const fs::path target = fs::read_symlink(it->path(), read_ec);
+            if (read_ec || target.empty() || target.is_absolute()) {
+                return false;
+            }
+            fs::path resolved = it->path().parent_path() / target;
+            const auto rel    = fs::relative(resolved, resolved_root, ec);
+            if (ec || rel.empty()) {
+                return false;
+            }
+            for (const auto& component : rel) {
+                if (component == "..") {
+                    return false;
+                }
+            }
+            continue;  // a symlink itself contributes no extracted bytes
+        }
+        if (!fs::is_directory(link_status) && !fs::is_regular_file(link_status)) {
             return false;
         }
 

--- a/test/test_path_util.cc
+++ b/test/test_path_util.cc
@@ -269,6 +269,23 @@ TEST_CASE("PathUtil: extracted tree validation enforces type and size limits", "
     REQUIRE_FALSE(ValidateDirectoryTreeWithinRoot(root.string(), 3, 16, 32));
 }
 
+TEST_CASE("PathUtil: extracted tree validation accepts safe internal symlinks", "[path-util][security]") {
+    TestPathFixture fix;
+    const auto root = std::filesystem::path(fix.test_dir) / "extracted";
+    std::filesystem::create_directories(root / "lib");
+
+    // Shared-library versioning chain, all relative and confined to lib/.
+    std::ofstream(root / "lib" / "libfoo.so.1.0.0") << "payload";
+    std::filesystem::create_symlink("libfoo.so.1.0.0", root / "lib" / "libfoo.so.1");
+    std::filesystem::create_symlink("libfoo.so.1", root / "lib" / "libfoo.so");
+
+    REQUIRE(ValidateDirectoryTreeWithinRoot(root.string(), 10, 1024, 1024));
+
+    // A symlink whose target escapes the root must still be rejected.
+    std::filesystem::create_symlink("../../etc/passwd", root / "lib" / "escape");
+    REQUIRE_FALSE(ValidateDirectoryTreeWithinRoot(root.string(), 10, 1024, 1024));
+}
+
 TEST_CASE("PathUtil: task overview path rejects traversal without side effects", "[path-util][security]") {
     TestPathFixture fix;
     const auto expected_root = fix.test_dir + "/cwai/overview";

--- a/test/test_system_operation_service_impl.cc
+++ b/test/test_system_operation_service_impl.cc
@@ -163,12 +163,14 @@ TEST_CASE("PacketUpgrade validates archive boundaries before extraction", "[syst
         REQUIRE_FALSE(fs::exists(data_root / "payload"));
     }
 
-    SECTION("rejects a package containing a symbolic link") {
-        const auto source = root / "symlink_source";
+    SECTION("rejects a package containing an unsafe symlink") {
+        const auto source = root / "symlink_unsafe_source";
         CreateUpgradeLayout(source);
-        fs::create_symlink(root / "outside-target", source / "bin" / "unsafe-link", ec);
+        // Target traverses above the archive root: must still be rejected even
+        // though safe same-directory symlinks are now allowed.
+        fs::create_symlink("../../etc/passwd", source / "bin" / "unsafe-link", ec);
         REQUIRE(!ec);
-        const auto unsigned_archive = staging / "symlink.tar.gz";
+        const auto unsigned_archive = staging / "symlink_unsafe.tar.gz";
         std::string output;
         REQUIRE(cosmo::util::Exec({"tar", "-czf", unsigned_archive.string(), "-C", source.string(), "."},
                                   output) == 0);
@@ -177,6 +179,29 @@ TEST_CASE("PacketUpgrade validates archive boundaries before extraction", "[syst
 
         REQUIRE(cosmo::PacketUpgrade(archive) == cosmo::util::ErrorEnum::UpgradeFileVerifyFailed);
         REQUIRE(fs::is_regular_file(archive));
+    }
+
+    SECTION("accepts a package containing safe internal symlinks") {
+        const auto source = root / "symlink_safe_source";
+        CreateUpgradeLayout(source);
+        // Shared-library versioning chain: libfoo.so -> libfoo.so.1 -> the real
+        // file, all relative and confined to lib/. Must be accepted.
+        std::ofstream(source / "lib" / "libfoo.so.1.0.0") << "payload";
+        fs::create_symlink("libfoo.so.1.0.0", source / "lib" / "libfoo.so.1", ec);
+        REQUIRE(!ec);
+        fs::create_symlink("libfoo.so.1", source / "lib" / "libfoo.so", ec);
+        REQUIRE(!ec);
+        const auto unsigned_archive = staging / "symlink_safe.tar.gz";
+        std::string output;
+        REQUIRE(cosmo::util::Exec({"tar", "-czf", unsigned_archive.string(), "-C", source.string(), "."},
+                                  output) == 0);
+        const auto archive = AddUpgradeChecksumToName(unsigned_archive, staging, "9.9.4");
+        REQUIRE_FALSE(archive.empty());
+
+        REQUIRE(cosmo::PacketUpgrade(archive) == cosmo::util::ErrorEnum::Success);
+        const auto upgrade_root = fs::path(cosmo::path::GetUpgradePath());
+        REQUIRE(fs::is_symlink(upgrade_root / "lib" / "libfoo.so"));
+        REQUIRE(fs::is_regular_file(upgrade_root / "lib" / "libfoo.so.1.0.0"));
     }
 
     SECTION("rejects a sparse member above the declared per-file limit") {


### PR DESCRIPTION
## 根因

升级报 `UpgradeFileVerifyFailed` (msgCode 38, "安装包校验错误"),但文件名 / MD5 / gzip / 布局 / 磁盘全部正常。

硬化提交 `6dd6324c` 在升级校验里**拒绝所有符号链接**,但打包流程 (`build_sophon_package.ps1` Step3 restore 软链 + CPack TGZ 保留软链 + `install.sh` 指望包里有可用 lib) 仍产出含 `.so` 版本链(软链)的包。两者不一致 → main 上任何正常打的包都无法自升级。盒子日志实测两道关卡分别报 `non-regular entry` 与 `unsafe directory tree`。

## 改动

放行**安全软链**(target 相对、不逃逸出包根),仍拒绝绝对路径 / 逃逸软链,保留防 zip-slip 的安全目标。升级流程两道关卡都改:

| 关卡 | 文件 | 逻辑 |
|---|---|---|
| tar 列表层 | `PacketUpgrade::ValidateUpgradeArchiveListing` | 解析 `linkpath -> target`;target 相对 / 无反斜杠 / `lexically_normal` 后无 `..` |
| 解压后目录树层 | `PathUtil::ValidateDirectoryTreeWithinRoot` | `read_symlink` 读 target;`fs::relative(resolved, root)` 判逃逸 |

> 踩坑:`ValidateDirectoryTreeWithinRoot` 里 `it->path()` 是绝对路径,第一版用 `lexically_normal` + 查 `..` 漏判逃逸,已改用 `fs::relative`。

## 测试

- `test_system_operation_service_impl.cc`:reject unsafe symlink (`../../etc/passwd` 逃逸) + accept safe `.so` 链
- `test_path_util.cc`:`ValidateDirectoryTreeWithinRoot` accept safe internal symlinks + reject escape

## 验证状态

- ✅ clang-format 干净
- ⚠️ **未构建 / 未跑测试**(本机无编译器)。合并前建议在构建机跑 `cosmo-tests`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
