### PR TITLE
feat(push-test): render detection targets on HTTP alert cards

### DIFF
--- a/test/push-test-service/README.md
+++ b/test/push-test-service/README.md
@@ -61,6 +61,21 @@ curl -X POST http://127.0.0.1:18080/events \
   -d "{\"messageId\":\"msg-1\",\"recordId\":\"rec-1\",\"devId\":\"box-1\",\"algorithmCode\":\"face\",\"property\":{\"face\":{\"confidence\":0.98}}}"
 ```
 
+携带检测目标（`targets`，对应入侵/越界等检测类告警，commit `3fcabdc8`）：
+
+```bash
+curl -X POST http://127.0.0.1:18080/events \
+  -H "Content-Type: application/json" \
+  -d "{\"messageId\":\"msg-2\",\"recordId\":\"rec-2\",\"devId\":\"box-1\",\"algorithmName\":\"入侵检测\",\"category\":\"alarm\",\"targets\":[{\"label\":\"person\",\"confidence\":0.93,\"trackId\":\"T12\",\"box\":{\"x\":120,\"y\":80,\"width\":240,\"height\":360}}],\"property\":{}}"
+```
+
+页面上每条告警卡片会展示：
+
+- 头部算法名旁的 `🎯 N` 徽标 = 本事件的检测目标数量；
+- 「检测目标」行：每个目标一个徽标，含类别、置信度、跟踪 ID，鼠标悬停可看像素目标框 `(x, y, w, h)`。
+
+无独立目标的统计类事件（如人流统计）设备端不下发 `targets`，卡片上不显示该区块。
+
 服务正常时返回：
 
 ```json

--- a/test/push-test-service/public/app.js
+++ b/test/push-test-service/public/app.js
@@ -493,11 +493,39 @@ tabs.forEach(tab => {
 
 // --- HTTP Alerts ---
 
+// 渲染检测目标列表，对应设备推送 payload 里的 `targets` 字段（commit 3fcabdc8，
+// PR #51）。每个目标含 label / confidence / trackId / box。无独立目标的统计类
+// 事件设备端不会下发 targets，此时返回空串，卡片上不占位。
+function buildTargetsHtml(alert) {
+    const targets = Array.isArray(alert.targets) ? alert.targets : [];
+    if (targets.length === 0) return '';
+
+    const items = targets.map((t, idx) => {
+        const label = escapeHtml(t.label || `目标 ${idx + 1}`);
+        const conf = typeof t.confidence === 'number'
+            ? `<span class="alert-target-conf">${Math.round(t.confidence * 100)}%</span>`
+            : '';
+        const track = t.trackId
+            ? `<span class="alert-target-track">#${escapeHtml(t.trackId)}</span>`
+            : '';
+        const b = t.box || {};
+        const hasBox = b.x != null || b.y != null || b.width != null || b.height != null;
+        const boxTitle = hasBox
+            ? ` title="目标框 (x, y, w, h): ${b.x ?? '-'}, ${b.y ?? '-'}, ${b.width ?? '-'}, ${b.height ?? '-'} px"`
+            : '';
+        return `<span class="alert-target"${boxTitle}><span class="alert-target-label">${label}</span>${conf}${track}</span>`;
+    }).join('');
+
+    return `<p class="alert-targets-row"><strong>检测目标:</strong> <span class="alert-targets">${items}</span></p>`;
+}
+
 function addAlertToUI(alert, prepend = false) {
     const card = document.createElement('div');
     card.className = 'alert-card';
     
     const time = new Date(alert._receivedAt || Date.now()).toLocaleTimeString();
+    const targetCount = Array.isArray(alert.targets) ? alert.targets.length : 0;
+    const targetsHtml = buildTargetsHtml(alert);
     
     let imagesHtml = '';
     if (alert.orignalPicture) imagesHtml += `<div class="alert-img-container"><img src="data:image/jpeg;base64,${alert.orignalPicture}" onclick="showDetail('image', '${alert.orignalPicture}')"></div>`;
@@ -506,7 +534,10 @@ function addAlertToUI(alert, prepend = false) {
 
     card.innerHTML = `
         <div class="alert-header">
-            <span>${alert.algorithmName || '未知算法'}</span>
+            <span>
+                ${alert.algorithmName || '未知算法'}
+                ${targetCount > 0 ? `<span class="alert-target-count" title="检测目标数">🎯 ${targetCount}</span>` : ''}
+            </span>
             <span>${time}</span>
         </div>
         <div class="alert-body">
@@ -515,6 +546,7 @@ function addAlertToUI(alert, prepend = false) {
                 <p><strong>设备 ID:</strong> ${alert.devId || 'N/A'}</p>
                 <p><strong>通道:</strong> ${alert.channelName || alert.videoChannelId || 'N/A'}</p>
                 <p><strong>类别:</strong> ${alert.category || 'N/A'}</p>
+                ${targetsHtml}
                 ${alert.video ? `<button class="btn btn-primary btn-sm" onclick="showDetail('video', '${alert.video}')">播放视频</button>` : ''}
             </div>
         </div>

--- a/test/push-test-service/public/style.css
+++ b/test/push-test-service/public/style.css
@@ -146,6 +146,58 @@ main {
     color: var(--secondary-color);
 }
 
+/* 检测目标徽章（推送 payload 的 targets 字段） */
+.alert-target-count {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 0 7px;
+    border-radius: 10px;
+    background: #dbeafe;
+    color: #1d4ed8;
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+
+.alert-targets-row {
+    margin: 6px 0 4px;
+}
+
+.alert-targets {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    vertical-align: middle;
+}
+
+.alert-target {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 7px;
+    border-radius: 10px;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    font-size: 0.72rem;
+    line-height: 1.5;
+    color: #1e293b;
+    cursor: help;
+}
+
+.alert-target-label {
+    font-weight: 600;
+    color: #1d4ed8;
+}
+
+.alert-target-conf {
+    color: #16a34a;
+    font-variant-numeric: tabular-nums;
+}
+
+.alert-target-track {
+    color: #64748b;
+    font-size: 0.68rem;
+}
+
 /* MQTT Layout */
 .mqtt-layout {
     display: grid;


### PR DESCRIPTION
## 背景
设备 HTTP 告警推送新增了检测目标字段 `targets`（3fcabdc8 / #51），每个目标含 `label` / `confidence` / `trackId` / `box`。本 PR 让联调测试工具 `test/push-test-service` 的可视化界面体现该字段。

## 改动
- **`public/app.js`**：新增 `buildTargetsHtml()`，将 `targets` 渲染为 badge 列表（类别、置信度、跟踪 ID，悬停查看像素目标框）；卡片头部增加目标计数徽章；`targets` 为空时不占位（与设备端「统计类事件不下发 targets」一致）；`label` / `trackId` 经 `escapeHtml` 转义。
- **`public/style.css`**：新增 `.alert-target*` 样式，沿用现有蓝色系配色。
- **`README.md`**：常用验证中新增带 `targets` 的 curl 示例与展示说明。

## 验证
- `node --check public/app.js` 通过
- 针对真实源码的 10 项静态断言全部 PASS（含 XSS 转义确认）

## 说明
仅前端展示层改动；`server.js` 已原样透传 payload，无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
