### PR TITLE
fix(http): raise JSON body cap so image analysis (PTaskDetectPic) works

### DIFF
--- a/src/network/http/HttpServer.cc
+++ b/src/network/http/HttpServer.cc
@@ -36,10 +36,15 @@ namespace cosmo::network::http {
 
 namespace {
 
-    constexpr auto kShutdownDrainTimeout                         = chrono::seconds(5);
-    constexpr std::size_t kMaxRequestTargetBytes                 = 2048;
-    constexpr std::size_t kMaxJsonBodyBytes                      = 1 * 1024 * 1024;
-    constexpr std::size_t kMaxHttpBodyBytes                      = 10 * 1024 * 1024;
+    constexpr auto kShutdownDrainTimeout         = chrono::seconds(5);
+    constexpr std::size_t kMaxRequestTargetBytes = 2048;
+    // JSON body cap. PTaskDetectPic (image test, /aihost/PTaskDetectPic) embeds the full
+    // image as base64 inside the JSON body, so a phone/camera photo (multi-MB base64) must
+    // fit. Keep aligned with kMaxHttpBodyBytes so the app layer never rejects what the
+    // transport already accepted. (6dd6324c originally set this to 1MB, which 413'd every
+    // non-tiny image and silently broke image analysis.)
+    constexpr std::size_t kMaxJsonBodyBytes                      = 32 * 1024 * 1024;
+    constexpr std::size_t kMaxHttpBodyBytes                      = 32 * 1024 * 1024;
     constexpr std::size_t kMaxHttpHeaderBytes                    = 32 * 1024;
     constexpr std::size_t kMaxMultipartSpoolRequests             = 8;
     constexpr std::size_t kMaxMultipartSpoolRequestsPerPrincipal = 2;

--- a/test/test_http_server_lifetime.cc
+++ b/test/test_http_server_lifetime.cc
@@ -509,7 +509,7 @@ TEST_CASE("HttpServer reports payload limits as 413 before dispatch", "[http-ser
     SECTION("libevent transport limit preserves 413 when the URI is cleared") {
         auto client = Connect(port);
         REQUIRE(client.Get() >= 0);
-        constexpr std::size_t kOversizedBody = 10 * 1024 * 1024 + 1;
+        constexpr std::size_t kOversizedBody = 32 * 1024 * 1024 + 1;
         const std::string request =
             "POST /test/request-lifetime HTTP/1.1\r\n"
             "Host: 127.0.0.1\r\n"


### PR DESCRIPTION
## 问题
部署最新 main 到设备后，web「图片测试」所有模型都检测不到内容（视频/预览正常，之前版本正常）。

## 根因
`6dd6324c`(fix(api): harden upload and runtime boundaries) 在 `src/network/http/HttpServer.cc` 新增了应用层 JSON 请求体上限 `kMaxJsonBodyBytes = 1MB`（及 `kPayloadTooLarge=413`）。

`PTaskDetectPic`（图片测试，`/gtw/cwai/aihost/PTaskDetectPic`）把整张图以 `imageBase64` 塞在 **JSON body** 里。一张正常测试图 base64 后 2~6MB，超过 1MB → 服务端直接回 **413**，`DetectPic` handler 根本不执行 → 前端 catch → 显示"未检测到目标"。

为什么只有图片测试挂：
- 视频推理走 Task/流路径，不大 JSON body；
- `PTaskCreate`/`PTaskCancle` 是几十字节小 JSON；
- 只有 `PTaskDetectPic` 携带大 base64 → 唯一被 413 掐掉。与模型无关，只看图片大小。

## 设备复现证据（.26，最新 main 二进制）
| 请求体 | HTTP | 后端 |
|---|---|---|
| 100KB（<1MB，合法 base64） | 200 | 到达 handler，`ImageDecodeFailed`（JPEG 解码失败，因是假数据；证明 base64 解码与路由正常） |
| 1.05MB / 2MB / 5MB | **413 PAYLOAD TOO LARGE** | handler 未执行 |

journal 也证实：每个图片测试会话只有 `PTaskCreate → PTaskCancle`，全程 0 次 `PTaskDetectPic` 到达后端。

## 改动
- `src/network/http/HttpServer.cc`：`kMaxJsonBodyBytes` 1MB→32MB，`kMaxHttpBodyBytes` 10MB→32MB（传输层 `evhttp_set_max_body_size` 与 multipart spool 上限均派生自后者，自动跟随）。加注释说明为何是 32MB、为何必须 ≥ 传输层，防止以后硬化时改回 1MB 重蹈覆辙。
- `test/test_http_server_lifetime.cc`：传输层 413 测试的越界值 `kOversizedBody` 10MB+1 → 32MB+1。multipart 的 8MB+1 测试不受影响（其上限独立于 transport）。

## 副作用
multipart 上传磁盘 spool 从 `8×10MB=80MB` 涨到 `8×32MB=256MB`（每 principal 20MB→64MB）。对模型导入/人脸库上传反而更宽松（旧 80MB 对大模型包偏紧），盒子磁盘可接受。

## 验证
- [x] 静态：`git log -S kMaxJsonBodyBytes` 确认 6dd6324c 是唯一引入该常量的提交；LLVM clang-format 通过
- [ ] 待交叉编译出包 → 部署 .26 → 重跑 repro：>1MB 应从 413 变 200 且出检测框

🤖 Generated with [Claude Code](https://claude.com/claude-code)
