### PR TITLE
fix(media): align decoded frame to even dims for odd-dimension images

### DIFF
--- a/src/media/VideoFrameCodec.cc
+++ b/src/media/VideoFrameCodec.cc
@@ -1,6 +1,7 @@
 // VideoFrameCodec.cc — JPEG encode/decode operations for VideoFrameProcSophon.
 // Split from VideoFrameProcSophon.cc to reduce file size (DEBT-007).
 
+#include <cstring>
 #include <memory>
 #include <vector>
 
@@ -113,15 +114,42 @@ namespace media {
             stbi_load_from_memory(data.data(), static_cast<int>(data.size()), &w, &h, &channels, 3),
             stbi_image_free);
         if (img_guard) {
-            auto rgb_frame = std::make_shared<VideoFrame>(w, h, PixelFormat::PIXEL_RGB8);
+            // RGB2I420 below produces I420, which requires even-aligned dims.
+            // stb-decoded images (PNG, or JPEG the JPU rejected) frequently have
+            // odd width/height; align the RGB frame down to even and copy only
+            // that subset so the I420 frame is valid (mirrors the alignment done
+            // in DecodeJpegHardware for the JPU path).
+            const int out_w = w & ~1;
+            const int out_h = h & ~1;
+            if (out_w == 0 || out_h == 0) {
+                LOG_ERRO("DecodeJpeg() - software-decoded dims too small {}x{}", w, h);
+                return nullptr;
+            }
+            auto rgb_frame = std::make_shared<VideoFrame>(out_w, out_h, PixelFormat::PIXEL_RGB8);
             if (!VideoFrameValid(rgb_frame, true)) {
                 LOG_ERRO("{}", "DecodeJpeg() - allocate rgb frame failed");
                 return nullptr;
             }
 
             auto dst_mem = reinterpret_cast<bm_device_mem_t*>(rgb_frame->GetData());
-            auto ret     = bm_memcpy_s2d_partial(handle, *dst_mem, img_guard.get(),
-                                                 static_cast<unsigned int>(rgb_frame->GetSize()));
+            int ret      = BM_SUCCESS;
+            if (out_w == w && out_h == h) {
+                // Even dims: bulk-copy the whole stb buffer straight to device.
+                ret = bm_memcpy_s2d_partial(handle, *dst_mem, img_guard.get(),
+                                            static_cast<unsigned int>(rgb_frame->GetSize()));
+            } else {
+                // Odd source: copy even-aligned rows into a host buffer first.
+                const std::size_t row_bytes = static_cast<std::size_t>(out_w) * 3;
+                std::vector<u_int8_t> host(row_bytes * static_cast<std::size_t>(out_h));
+                const unsigned char* src = img_guard.get();
+                for (int y = 0; y < out_h; ++y) {
+                    std::memcpy(host.data() + row_bytes * static_cast<std::size_t>(y),
+                                src + static_cast<std::size_t>(w) * 3 * static_cast<std::size_t>(y),
+                                row_bytes);
+                }
+                ret = bm_memcpy_s2d_partial(handle, *dst_mem, host.data(),
+                                            static_cast<unsigned int>(host.size()));
+            }
 
             if (ret != BM_SUCCESS) {
                 LOG_ERRO("DecodeJpeg() - bm_memcpy_s2d_partial failed {}", ret);
@@ -161,9 +189,24 @@ namespace media {
             return nullptr;
         }
 
+        // I420 (YUV 4:2:0) requires even-aligned width/height. Source JPEGs —
+        // especially ID/portrait photos — frequently have odd dimensions (e.g.
+        // 343x456), which made the I420 VideoFrame invalid and failed the whole
+        // decode ("Image too small or decode failed"). Align the output down to
+        // even; bmcv_image_vpp_convert below scales the native (possibly odd) JPU
+        // output into the even frame.
+        const int out_width  = img_width & ~1;
+        const int out_height = img_height & ~1;
+        if (out_width == 0 || out_height == 0) {
+            LOG_ERRO("DecodeJpegHardware() - dimensions too small after even alignment {}x{}", img_width,
+                     img_height);
+            bm_image_destroy(&decode_img);
+            return nullptr;
+        }
+
         // Create output VideoFrame and bm_image, associate memory via VideoFrameAttach
         auto pixel_fmt = PixelFormat::PIXEL_I420;
-        auto frame     = std::make_shared<VideoFrame>(img_width, img_height, pixel_fmt);
+        auto frame     = std::make_shared<VideoFrame>(out_width, out_height, pixel_fmt);
         if (!VideoFrameValid(frame)) {
             LOG_ERRO("{}", "DecodeJpegHardware() - create VideoFrame failed");
             bm_image_destroy(&decode_img);
@@ -171,7 +214,7 @@ namespace media {
         }
 
         auto yuv_image =
-            CreateBMImage(static_cast<size_t>(img_width), static_cast<size_t>(img_height), pixel_fmt);
+            CreateBMImage(static_cast<size_t>(out_width), static_cast<size_t>(out_height), pixel_fmt);
         if (!yuv_image) {
             LOG_ERRO("{}", "DecodeJpegHardware() - CreateBMImage failed");
             bm_image_destroy(&decode_img);


### PR DESCRIPTION
## 问题

人脸库导入（证件照 ZIP）大量图片报 `Image too small or decode failed`，单个库从原本 ~8 张失败暴涨到 200+ 张。

## 根因

提交 `25e67a5c`(validate sophon crop dimensions) 给 `CalculateFrameSize` 加了 `PIXEL_I420/NV12/NV21` 的宽高偶数对齐强制。`DecodeJpeg` 最终产出 I420 VideoFrame，源图宽或高为奇数时帧无效 → 解码返回 null → 报 `Image too small or decode failed`。

证件照奇数维度很常见（实测 441 张里 203 张奇数维度，如 343×456），全部被打成解码失败。CPU 后端返回 `PIXEL_BGR8`（对齐=1）不受影响，所以只在 Sophon 生产路径复现。

## 修复

`src/media/VideoFrameCodec.cc` 两条解码子路径都把输出对齐到偶数（向下取整 `& ~1`）：

1. **JPU 硬解** `DecodeJpegHardware`（解 JPEG）：`out_width/out_height` 喂给 VideoFrame 与 CreateBMImage，`bmcv_image_vpp_convert` 把原生（可能奇数）JPU 输出缩放进偶数帧。
2. **stb 软解兜底**（解 PNG / JPU 拒绝的 JPEG）：RGB 帧按偶数维度建，奇数源按行拷偶数子集到 host buffer 再 s2d，然后 RGB2I420。

偶数对齐是 I420 的正确物理约束（4:2:0 色度下采样），因此不动 `CalculateFrameSize`，只在解码入口保证输出偶数。

## 验证

BM1688 真机用 441 张证件照 ZIP 导入：

| | 修复前 | 修复后 |
|---|---|---|
| 解码失败 | 200+ | **0** |
| 入库成功 | ~230 | **433** |
| 总失败 | 200+ | **8**（全是 `get face feature failed`：5 张图太小 109–180px、低于人脸模型最小输入；3 张正常尺寸但提不到脸）|

剩余 8 张是数据集本身的问题（图太小/没脸），与代码 bug 无关，回归前后一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
