### PR TITLE
fix(storage): align extraction reserve with uploads

### DIFF
--- a/src/service/system/impl/PacketUpgrade.cc
+++ b/src/service/system/impl/PacketUpgrade.cc
@@ -2,10 +2,11 @@
 
 #include "service/system/impl/PacketUpgrade.h"
 
+#include <sys/stat.h>
+
 #include <algorithm>
 #include <array>
 #include <cstdint>
-#include <sys/stat.h>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -43,21 +44,20 @@ namespace {
     };
 
     std::uint64_t AllocatedTreeBytes(const fs::path& root) {
-        std::uint64_t total = 0;
+        std::uint64_t total  = 0;
         const auto add_entry = [&total](const fs::path& path) {
             struct stat status {};
             if (lstat(path.c_str(), &status) != 0 || status.st_blocks <= 0) {
                 return;
             }
             constexpr std::uint64_t kStatBlockBytes = 512;
-            const auto blocks = static_cast<std::uint64_t>(status.st_blocks);
-            const auto bytes =
-                blocks > std::numeric_limits<std::uint64_t>::max() / kStatBlockBytes
-                    ? std::numeric_limits<std::uint64_t>::max()
-                    : blocks * kStatBlockBytes;
-            total = bytes > std::numeric_limits<std::uint64_t>::max() - total
-                        ? std::numeric_limits<std::uint64_t>::max()
-                        : total + bytes;
+            const auto blocks                       = static_cast<std::uint64_t>(status.st_blocks);
+            const auto bytes = blocks > std::numeric_limits<std::uint64_t>::max() / kStatBlockBytes
+                                   ? std::numeric_limits<std::uint64_t>::max()
+                                   : blocks * kStatBlockBytes;
+            total            = bytes > std::numeric_limits<std::uint64_t>::max() - total
+                                   ? std::numeric_limits<std::uint64_t>::max()
+                                   : total + bytes;
         };
 
         std::error_code ec;
@@ -347,8 +347,8 @@ util::ErrorEnum PacketUpgrade(const fs::path& filePath) {
         util::UsableStorageBytesAfterReclaim(budget, AllocatedTreeBytes(upgradeFileDir));
     if (inspection.total_bytes > usable_bytes) {
         throw util::ResourceLimitError("Insufficient safe disk space to extract the upgrade package",
-                                       "archive-extraction", "upgrade", inspection.total_bytes,
-                                       usable_bytes, budget.reserve_bytes);
+                                       "archive-extraction", "upgrade", inspection.total_bytes, usable_bytes,
+                                       budget.reserve_bytes);
     }
     std::string resolved_upgrade_dir;
     if (!cosmo::path::ResolveExistingPathWithinRoot(cosmo::path::GetBaseDir(), upgradeFileDir.string(),

--- a/src/service/system/impl/PacketUpgrade.cc
+++ b/src/service/system/impl/PacketUpgrade.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <sys/stat.h>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -40,6 +41,33 @@ namespace {
         std::uintmax_t largest_file_bytes{0};
         std::uintmax_t total_bytes{0};
     };
+
+    std::uint64_t AllocatedTreeBytes(const fs::path& root) {
+        std::uint64_t total = 0;
+        const auto add_entry = [&total](const fs::path& path) {
+            struct stat status {};
+            if (lstat(path.c_str(), &status) != 0 || status.st_blocks <= 0) {
+                return;
+            }
+            constexpr std::uint64_t kStatBlockBytes = 512;
+            const auto blocks = static_cast<std::uint64_t>(status.st_blocks);
+            const auto bytes =
+                blocks > std::numeric_limits<std::uint64_t>::max() / kStatBlockBytes
+                    ? std::numeric_limits<std::uint64_t>::max()
+                    : blocks * kStatBlockBytes;
+            total = bytes > std::numeric_limits<std::uint64_t>::max() - total
+                        ? std::numeric_limits<std::uint64_t>::max()
+                        : total + bytes;
+        };
+
+        std::error_code ec;
+        add_entry(root);
+        for (fs::recursive_directory_iterator it(root, fs::directory_options::none, ec), end;
+             !ec && it != end; it.increment(ec)) {
+            add_entry(it->path());
+        }
+        return ec ? 0 : total;
+    }
 
     bool IsGzipFile(const std::string& path) {
         std::ifstream stream(path, std::ios::binary);
@@ -312,10 +340,15 @@ util::ErrorEnum PacketUpgrade(const fs::path& filePath) {
     if (!budget.valid) {
         throw util::ErrorMessage(util::ErrorEnum::SysErr, "Cannot inspect upgrade extraction storage");
     }
-    if (inspection.total_bytes > budget.usable_bytes) {
+    // A valid package replaces the previous prepared upgrade tree. Include
+    // those allocated blocks in the admission budget, while keeping the tree
+    // intact until all package validation above has succeeded.
+    const auto usable_bytes =
+        util::UsableStorageBytesAfterReclaim(budget, AllocatedTreeBytes(upgradeFileDir));
+    if (inspection.total_bytes > usable_bytes) {
         throw util::ResourceLimitError("Insufficient safe disk space to extract the upgrade package",
                                        "archive-extraction", "upgrade", inspection.total_bytes,
-                                       budget.usable_bytes, budget.reserve_bytes);
+                                       usable_bytes, budget.reserve_bytes);
     }
     std::string resolved_upgrade_dir;
     if (!cosmo::path::ResolveExistingPathWithinRoot(cosmo::path::GetBaseDir(), upgradeFileDir.string(),

--- a/src/util/ResourceBudget.cc
+++ b/src/util/ResourceBudget.cc
@@ -49,4 +49,14 @@ StorageResourceBudget InspectStorageResourceBudget(const std::string& path, std:
     return result;
 }
 
+std::uint64_t UsableStorageBytesAfterReclaim(const StorageResourceBudget& budget,
+                                             std::uint64_t reclaimable_bytes) {
+    if (!budget.valid) {
+        return 0;
+    }
+    const auto max_value = std::numeric_limits<std::uint64_t>::max();
+    return reclaimable_bytes > max_value - budget.usable_bytes ? max_value
+                                                               : budget.usable_bytes + reclaimable_bytes;
+}
+
 }  // namespace cosmo::util

--- a/src/util/ResourceBudget.h
+++ b/src/util/ResourceBudget.h
@@ -7,7 +7,7 @@
 
 namespace cosmo::util {
 
-constexpr std::uint64_t kDefaultStorageReserveBytes   = 512ULL * 1024 * 1024;
+constexpr std::uint64_t kDefaultStorageReserveBytes = 512ULL * 1024 * 1024;
 // Keep transfer admission and post-upload consumers on the same emergency
 // reserve policy. Event retention has its own business waterline; applying an
 // additional percentage here can reduce the usable budget to zero on devices

--- a/src/util/ResourceBudget.h
+++ b/src/util/ResourceBudget.h
@@ -8,7 +8,11 @@
 namespace cosmo::util {
 
 constexpr std::uint64_t kDefaultStorageReserveBytes   = 512ULL * 1024 * 1024;
-constexpr std::uint32_t kDefaultStorageReservePercent = 5;
+// Keep transfer admission and post-upload consumers on the same emergency
+// reserve policy. Event retention has its own business waterline; applying an
+// additional percentage here can reduce the usable budget to zero on devices
+// that still have enough space for a small operation.
+constexpr std::uint32_t kDefaultStorageReservePercent = 0;
 
 struct StorageResourceBudget {
     bool valid{false};
@@ -24,5 +28,10 @@ struct StorageResourceBudget {
 [[nodiscard]] StorageResourceBudget InspectStorageResourceBudget(
     const std::string& path, std::uint64_t reserve_bytes = kDefaultStorageReserveBytes,
     std::uint32_t reserve_percent = kDefaultStorageReservePercent);
+
+/// Return the usable budget after including bytes that the operation will
+/// reclaim before writing. The addition saturates on overflow.
+[[nodiscard]] std::uint64_t UsableStorageBytesAfterReclaim(const StorageResourceBudget& budget,
+                                                           std::uint64_t reclaimable_bytes);
 
 }  // namespace cosmo::util

--- a/test/test_resource_budget.cc
+++ b/test/test_resource_budget.cc
@@ -1,4 +1,5 @@
 #include <filesystem>
+#include <limits>
 
 #include "catch_amalgamated.hpp"
 #include "util/ResourceBudget.h"
@@ -16,4 +17,23 @@ TEST_CASE("Storage resource budget is derived from the target filesystem", "[res
         std::filesystem::temp_directory_path().string(), budget.available_bytes, 0);
     REQUIRE(reserved.valid);
     CHECK(reserved.usable_bytes == 0);
+}
+
+TEST_CASE("Storage resource budget defaults match upload admission policy", "[resource][storage]") {
+    CHECK(cosmo::util::kDefaultStorageReserveBytes == 512ULL * 1024 * 1024);
+    CHECK(cosmo::util::kDefaultStorageReservePercent == 0);
+}
+
+TEST_CASE("Reclaimable storage extends usable budget safely", "[resource][storage]") {
+    cosmo::util::StorageResourceBudget budget;
+    budget.valid        = true;
+    budget.usable_bytes = 100;
+    CHECK(cosmo::util::UsableStorageBytesAfterReclaim(budget, 25) == 125);
+
+    budget.usable_bytes = std::numeric_limits<std::uint64_t>::max() - 5;
+    CHECK(cosmo::util::UsableStorageBytesAfterReclaim(budget, 10) ==
+          std::numeric_limits<std::uint64_t>::max());
+
+    budget.valid = false;
+    CHECK(cosmo::util::UsableStorageBytesAfterReclaim(budget, 25) == 0);
 }


### PR DESCRIPTION
## Summary

Align post-upload extraction storage admission with the upload staging policy. This prevents the percentage reserve from reducing safe usable space to zero on large device filesystems while retaining the 512 MiB emergency reserve.

Upgrade admission now also credits blocks occupied by the validated upgrade tree that will be replaced, without deleting that tree before package validation succeeds.

## Related issue

No linked issue; the change is below the repository's 50-line large-change threshold in production code.

## Root cause

Upload staging had already disabled the percentage reserve, but model, algorithm, face-import, and upgrade extraction still called the shared storage budget with a 5% default. On a 46 GiB data filesystem with about 2.1 GiB free, that percentage reserve exceeded the real free space, reporting 0 B safe usable space for a 135 MiB upgrade.

## Scope

### In scope

- Unify extraction and upload admission on a 512 MiB fixed reserve with 0% percentage reserve.
- Include reclaimable allocated blocks from the previous upgrade tree.
- Add default-policy, reclaim, overflow, and invalid-budget tests.

### Out of scope

- Event retention waterlines.
- API schema changes.
- Automatic installation of the generated package.

## Risk tags

- [x] Runtime / lifecycle
- [ ] Thread / memory safety
- [ ] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build / deployment
- [ ] Refactor
- [x] Test

## Area

- [x] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [x] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [x] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `d4069150834680f1622d7ec6ca848b329abd8050`
- Candidate commit: `ba4049417b1b6924ae70f455db4e94d4aee907e1`
- Candidate tree: `64dee07612addc81df054b6292a9e31c191b5e80`
- Package SHA-256: `N/A` (package produced and retained on the build host)
- Test binary SHA-256: `N/A`

The candidate was not amended, rebased, or merged after evidence collection.

## Verification

### Parent baseline

`BLOCKED`: the failure depends on device filesystem capacity/free-space state; regression attribution was established from the concrete old 5% budget calculation rather than modifying the production device to reinstall the parent build.

### Candidate checks

```text
docker compose -f docker-compose.sophon.yml run --rm cosmo-sophon-package
PASS: Sophon aarch64 Release build, cosmo-engine, cosmo-tests, install, frontend, and package_all

cosmo-tests '[resource][storage]'
PASS: 3 test cases, 12 assertions

cosmo-tests '[system][upgrade]'
PASS: 6 test cases, 51 assertions

cosmo-tests '[AlgorithmPacketLoader][archive]'
PASS: 1 test case, 27 assertions

cosmo-tests '[model]'
PASS: 2 test cases, 89 assertions

cosmo-tests '[face]'
PASS: 2 test cases, 17 assertions

git diff --check
PASS
```

### Risk-based evidence

- API/network: No schema or routing changes.
- Media/streaming: Not affected.
- Sophon/device: Cross-compiled in the Sophon container and all targeted aarch64 tests passed on a BM1688 device.
- Frontend/UI: Frontend target completed as part of package build; no UI source changes.
- Package/deployment: `cosmo-V1.0.7-7fb31b1eae832f63534ffcad996cb2ad.tar.gz` generated successfully; production engine was not stopped or replaced.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented. (No new dependencies.)
- [x] Documentation was updated if behavior changed. (No documentation change required.)
- [ ] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`. (Repository AGENTS.md explicitly prohibits Signed-off-by metadata.)
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: `ba4049417b1b6924ae70f455db4e94d4aee907e1; targeted aarch64 device tests passed`
- Device test filter: `[resource][storage], [system][upgrade], [AlgorithmPacketLoader][archive], [model], [face]`
- Device backup state: `N/A; running engine was not replaced`
- Temporary-data cleanup: `complete on device`
- Final Git status: `clean`
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

The shared fixed reserve remains 512 MiB. Event-storage cleanup continues to use its independent business waterline. The upgrade archive is moved with `rename`, not copied, so admission correctly requires extracted bytes rather than a second archive copy.