### PR TITLE
fix: make preview startup and task saves resilient

### DIFF
--- a/src/api/MessageVideoTaskHandler.cc
+++ b/src/api/MessageVideoTaskHandler.cc
@@ -109,17 +109,8 @@ VideoTask::MsgQuerySwitchSend MessageVideoTaskHandler::Handle(VideoTask::MsgQuer
 VideoTask::MsgSaveOrUpdateSend MessageVideoTaskHandler::Handle(VideoTask::MsgSaveOrUpdateRecv&& data,
                                                                std::error_condition& errc) {
     VideoTask::MsgSaveOrUpdateSend retData{};
-    errc = task_config_.ModifyTaskParam(data.channelId, data.algorithmId, data.taskConfig);
-    if (util::ErrorEnum::Success != errc) {
-        return retData;
-    }
-
-    errc = task_config_.ModifyTaskStrategy(data.channelId, data.algorithmId, data.scheduleId);
-    if (util::ErrorEnum::Success != errc) {
-        return retData;
-    }
-
-    errc = task_config_.SwitchTask(data.channelId, data.algorithmId, true);
+    errc = task_config_.SaveOrUpdateTask(data.channelId, data.algorithmId, data.taskConfig,
+                                         data.scheduleId);
     return retData;
 }
 
@@ -237,14 +228,8 @@ VideoTask::MsgApplyParamsBatchSend MessageVideoTaskHandler::Handle(VideoTask::Ms
     VideoTask::MsgApplyParamsBatchSend retData{};
 
     for (const auto& channelId : data.targetChannelIds) {
-        auto params              = data.taskConfig;
-        std::error_condition ret = task_config_.ModifyTaskParam(channelId, data.algorithmId, params);
-        if (util::ErrorEnum::Success == ret) {
-            ret = task_config_.ModifyTaskStrategy(channelId, data.algorithmId, data.scheduleId);
-        }
-        if (util::ErrorEnum::Success == ret) {
-            ret = task_config_.SwitchTask(channelId, data.algorithmId, true);
-        }
+        std::error_condition ret = task_config_.SaveOrUpdateTask(
+            channelId, data.algorithmId, data.taskConfig, data.scheduleId);
         if (util::ErrorEnum::Success != ret) {
             MsgResultInfo failedEl;
             failedEl.id      = channelId;

--- a/src/api/MessageVideoTaskHandler.cc
+++ b/src/api/MessageVideoTaskHandler.cc
@@ -109,8 +109,7 @@ VideoTask::MsgQuerySwitchSend MessageVideoTaskHandler::Handle(VideoTask::MsgQuer
 VideoTask::MsgSaveOrUpdateSend MessageVideoTaskHandler::Handle(VideoTask::MsgSaveOrUpdateRecv&& data,
                                                                std::error_condition& errc) {
     VideoTask::MsgSaveOrUpdateSend retData{};
-    errc = task_config_.SaveOrUpdateTask(data.channelId, data.algorithmId, data.taskConfig,
-                                         data.scheduleId);
+    errc = task_config_.SaveOrUpdateTask(data.channelId, data.algorithmId, data.taskConfig, data.scheduleId);
     return retData;
 }
 
@@ -228,8 +227,8 @@ VideoTask::MsgApplyParamsBatchSend MessageVideoTaskHandler::Handle(VideoTask::Ms
     VideoTask::MsgApplyParamsBatchSend retData{};
 
     for (const auto& channelId : data.targetChannelIds) {
-        std::error_condition ret = task_config_.SaveOrUpdateTask(
-            channelId, data.algorithmId, data.taskConfig, data.scheduleId);
+        std::error_condition ret =
+            task_config_.SaveOrUpdateTask(channelId, data.algorithmId, data.taskConfig, data.scheduleId);
         if (util::ErrorEnum::Success != ret) {
             MsgResultInfo failedEl;
             failedEl.id      = channelId;
@@ -275,7 +274,8 @@ namespace {
             std::error_condition qerr = queue_status.actionStatus;
             action.statusCode         = std::to_string(qerr.value());
             action.statusDesc         = qerr.message();
-            action.statusDescKey      = "api.error." + util::ErrorEnumName(static_cast<util::ErrorEnum>(qerr.value()));
+            action.statusDescKey =
+                "api.error." + util::ErrorEnumName(static_cast<util::ErrorEnum>(qerr.value()));
             action.holdCount          = queue_status.queueStatus.holdCount;
             action.alarmCount         = queue_status.alarmCount;
             action.insertCount        = queue_status.queueStatus.insertCount;

--- a/src/flow/stream/StreamViewerEncoder.cc
+++ b/src/flow/stream/StreamViewerEncoder.cc
@@ -2,24 +2,13 @@
 
 #include "flow/stream/StreamViewerEncoder.h"
 
-#include <algorithm>
-
 #include "media/PixelFormat.h"
-#include "media/VideoUtil.h"
 #include "mem/IDeviceContext.h"
 #include "service/detail/ServiceRegistry.h"
 #include "service/media/IVideoFrameTransform.h"
 #include "util/Log.h"
 
 namespace cosmo {
-namespace {
-    size_t MinStartupKeyFrameSize(int width, int height) {
-        const auto pixels =
-            static_cast<size_t>(std::max(width, 1)) * static_cast<size_t>(std::max(height, 1));
-        return std::max<size_t>(1024, pixels / 4096);
-    }
-}  // namespace
-
 StreamViewerEncoder::~StreamViewerEncoder() {
     async_queue_.Stop();
     if (encoder_) {
@@ -56,37 +45,7 @@ bool StreamViewerEncoder::OpenEncoder() {
         return false;
     }
 
-    startup_small_key_frame_count_ = 0;
-    startup_key_frame_accepted_    = false;
     return true;
-}
-
-bool StreamViewerEncoder::ContainsKeyFrame(const uint8_t* data, size_t size) const {
-    if (!data || size == 0) {
-        return false;
-    }
-
-    size_t offset = 0;
-    while (offset < size) {
-        const size_t nal_size = media::SeparateHVideoFrame(data + offset, size - offset);
-        if (nal_size == 0) {
-            break;
-        }
-        if (media::GetFrameType(video_type_, data + offset, nal_size) == media::HFrameType::I) {
-            return true;
-        }
-        offset += nal_size;
-    }
-
-    return false;
-}
-
-bool StreamViewerEncoder::IsSmallStartupKeyFrame(const uint8_t* data, size_t size) const {
-    if (startup_key_frame_accepted_) {
-        return false;
-    }
-
-    return ContainsKeyFrame(data, size) && size < MinStartupKeyFrameSize(width_, height_);
 }
 
 bool StreamViewerEncoder::HandFrame(VideoFramePtr frame) {
@@ -122,20 +81,7 @@ void StreamViewerEncoder::ProcFrame(VideoFramePtr frame) {
         if (!packet) {
             return;
         }
-        if (IsSmallStartupKeyFrame(packet->GetData(), packet->GetSize())) {
-            startup_small_key_frame_count_ += 1;
-            LOG_WARN("Drop small startup keyframe size:{} min:{} count:{}", packet->GetSize(),
-                     MinStartupKeyFrameSize(width_, height_), startup_small_key_frame_count_);
-            LOG_WARN("Reopen encoder after small startup keyframe, width:{} height:{}", width_, height_);
-            encoder_.reset();
-            OpenEncoder();
-            return;
-        }
-        if (packet && video_pusher_) {
-            if (ContainsKeyFrame(packet->GetData(), packet->GetSize())) {
-                startup_key_frame_accepted_ = true;
-            }
-            startup_small_key_frame_count_ = 0;
+        if (video_pusher_) {
             debug_info_.sendFrames += 1;
             video_pusher_->PushFrame(packet->GetData(), packet->GetSize());
         }

--- a/src/flow/stream/StreamViewerEncoder.h
+++ b/src/flow/stream/StreamViewerEncoder.h
@@ -36,8 +36,6 @@ public:
 
 private:
     bool OpenEncoder();
-    bool ContainsKeyFrame(const uint8_t* data, size_t size) const;
-    bool IsSmallStartupKeyFrame(const uint8_t* data, size_t size) const;
     void ProcFrame(VideoFramePtr frame);
 
     std::mutex mtx_;
@@ -45,8 +43,6 @@ private:
     media::VideoCodecType video_type_{media::VideoCodecType::kInvalid};
     int width_{0};
     int height_{0};
-    int startup_small_key_frame_count_{0};
-    bool startup_key_frame_accepted_{false};
     std::shared_ptr<media::VideoEncoder> encoder_ = nullptr;
     RtmpStreamPusherPtr video_pusher_{nullptr};
     AsyncQueue<VideoFramePtr> async_queue_;

--- a/src/service/camera/ICameraTaskConfig.h
+++ b/src/service/camera/ICameraTaskConfig.h
@@ -33,6 +33,13 @@ public:
                                                    const std::string& algorithmId,
                                                    cosmo::MsgTaskConfig& params) = 0;
 
+    /// Atomically validate, persist, and enable a camera-algorithm task.
+    /// Validation failures must leave the task list and task configuration unchanged.
+    virtual cosmo::util::ErrorEnum SaveOrUpdateTask(const std::string& cameraId,
+                                                    const std::string& algorithmId,
+                                                    const cosmo::MsgTaskConfig& params,
+                                                    const std::string& scheduleId) = 0;
+
     /// Query current dynamic parameters for a camera–algorithm task.
     /// @param cameraId    Camera identifier.
     /// @param algorithmId Algorithm identifier.

--- a/src/service/camera/impl/CameraServiceImpl.h
+++ b/src/service/camera/impl/CameraServiceImpl.h
@@ -106,8 +106,7 @@ public:
     util::ErrorEnum ModifyTaskParam(const std::string& cameraId, const std::string& algorithmId,
                                     MsgTaskConfig& params) override;
     util::ErrorEnum SaveOrUpdateTask(const std::string& cameraId, const std::string& algorithmId,
-                                     const MsgTaskConfig& params,
-                                     const std::string& scheduleId) override;
+                                     const MsgTaskConfig& params, const std::string& scheduleId) override;
     util::ErrorEnum QueryTaskParam(const std::string& cameraId, const std::string& algorithmId,
                                    std::vector<MsgDynamicKeyValue>& params) override;
     util::ErrorEnum ModifyTaskArea(const std::string& cameraId, const std::string& algorithmId,

--- a/src/service/camera/impl/CameraServiceImpl.h
+++ b/src/service/camera/impl/CameraServiceImpl.h
@@ -105,6 +105,9 @@ public:
 
     util::ErrorEnum ModifyTaskParam(const std::string& cameraId, const std::string& algorithmId,
                                     MsgTaskConfig& params) override;
+    util::ErrorEnum SaveOrUpdateTask(const std::string& cameraId, const std::string& algorithmId,
+                                     const MsgTaskConfig& params,
+                                     const std::string& scheduleId) override;
     util::ErrorEnum QueryTaskParam(const std::string& cameraId, const std::string& algorithmId,
                                    std::vector<MsgDynamicKeyValue>& params) override;
     util::ErrorEnum ModifyTaskArea(const std::string& cameraId, const std::string& algorithmId,
@@ -185,6 +188,7 @@ private:
     void LoadCameraTaskList(CameraEntityPtr camera);
     void SaveCameraTaskList(const CameraEntityPtr& camera);
     util::ErrorEnum MakeCameraTask(const CameraEntityPtr& camera, CameraTaskPtr task);
+    util::ErrorEnum CheckTaskStartResource() const;
     void PrepareCameraTaskOverview(const CameraEntityPtr& camera, CameraTaskPtr task);
     void SwitchCameraTask(const CameraEntityPtr& camera, CameraTaskPtr task);
     void SwitchCameraTaskAsync(CameraEntityPtr camera, CameraTaskPtr task);

--- a/src/service/camera/impl/CameraTaskConfig.cc
+++ b/src/service/camera/impl/CameraTaskConfig.cc
@@ -46,6 +46,34 @@ namespace {
 //  Task parameter / area / strategy / switch operations
 // ============================================================
 
+util::ErrorEnum CameraServiceImpl::CheckTaskStartResource() const {
+#ifdef COSMO_NN_USE_SOPHON_BACKEND
+    if (!ServiceRegistry::Instance().Get<IConfigReadService>().GetResourceLimit()) {
+        return util::ErrorEnum::Success;
+    }
+
+    size_t packet_total = 0, packet_proc = 0, packet_discard = 0, continues_discard_sec = 0;
+    ServiceRegistry::Instance().Get<ITaskQuery>().PacketStatus(packet_total, packet_proc, packet_discard,
+                                                               continues_discard_sec);
+    double discard_percent = 0.0;
+    if (packet_total > 0) {
+        discard_percent = static_cast<double>(packet_discard) / static_cast<double>(packet_total);
+    }
+    auto gpu_info = ServiceRegistry::Instance().Get<IDeviceInfoService>().GetGpuUtilization();
+    std::vector<GpuMemSnapshot> devs;
+    devs.reserve(gpu_info.gpudevusage.size());
+    std::transform(gpu_info.gpudevusage.begin(), gpu_info.gpudevusage.end(), std::back_inserter(devs),
+                   [](const auto& d) { return GpuMemSnapshot{d.gpumemtotal, d.gpumemavailable}; });
+    auto score = CalcCustomScore(gpu_info.gpuusage, gpu_info.gpumemtotal, gpu_info.gpumemavailable, devs,
+                                 discard_percent, continues_discard_sec);
+    if (score > 100.0) {
+        LOG_WARN("Task start rejected by resource guard, score:{}", score);
+        return util::ErrorEnum::ResourceLimit;
+    }
+#endif
+    return util::ErrorEnum::Success;
+}
+
 std::string CameraServiceImpl::GetChannelName(const std::string& channelId) const {
     std::shared_lock<std::shared_mutex> lock(mtx_);
     auto it = std::find_if(cameras_.begin(), cameras_.end(), [&](const CameraEntityPtr& camera) {
@@ -56,6 +84,103 @@ std::string CameraServiceImpl::GetChannelName(const std::string& channelId) cons
     }
     LOG_INFO("{} Not Exist", channelId);
     return "";
+}
+
+util::ErrorEnum CameraServiceImpl::SaveOrUpdateTask(const std::string& cameraId,
+                                                    const std::string& algorithmId,
+                                                    const MsgTaskConfig& params,
+                                                    const std::string& scheduleId) {
+    auto camera = GetCamera(cameraId);
+    if (!camera) {
+        LOG_INFO("{} Not Exist", cameraId);
+        return util::ErrorEnum::CameraNotExist;
+    }
+
+    std::lock_guard<std::mutex> command_lock(camera->command_mtx_);
+    if (camera->deleting_) {
+        LOG_INFO("{} Is Being Deleted", cameraId);
+        return util::ErrorEnum::CameraNotExist;
+    }
+
+    std::string scheduleName;
+    if (!ServiceRegistry::Instance().Get<IScheduleService>().Exist(scheduleId, scheduleName)) {
+        return util::ErrorEnum::TimeTemplateNotExist;
+    }
+
+    bool needs_enable = true;
+    {
+        std::shared_lock<std::shared_mutex> lock(camera->task_mtx_);
+        auto it = std::find_if(camera->tasks_.begin(), camera->tasks_.end(),
+                               [&](const CameraTaskPtr& cfg) { return cfg->algorithm_code_ == algorithmId; });
+        if (it != camera->tasks_.end()) {
+            if (!(*it)->task_ || !(*it)->task_->IsReady()) {
+                LOG_WARN("[{}/{}] SaveOrUpdate skipped because task unit is not ready", cameraId,
+                         algorithmId);
+                return util::ErrorEnum::TaskCreateFailed;
+            }
+            needs_enable = !(*it)->is_enabled_.load(std::memory_order_acquire);
+        } else if (camera->tasks_.size() >= camera->max_task_count_) {
+            return util::ErrorEnum::TaskTooMuch;
+        }
+    }
+
+    if (needs_enable) {
+        auto resource_ret = CheckTaskStartResource();
+        if (util::ErrorEnum::Success != resource_ret) {
+            LOG_WARN("[{}/{}] SaveOrUpdate rejected before mutation: {}", cameraId, algorithmId,
+                     static_cast<uint32_t>(resource_ret));
+            return resource_ret;
+        }
+    }
+
+    CameraTaskPtr task;
+    bool start_task = false;
+    {
+        std::lock_guard<std::shared_mutex> lock(camera->task_mtx_);
+        auto it = std::find_if(camera->tasks_.begin(), camera->tasks_.end(),
+                               [&](const CameraTaskPtr& cfg) { return cfg->algorithm_code_ == algorithmId; });
+        if (it != camera->tasks_.end()) {
+            task = *it;
+            MsgTaskConfig previous;
+            previous.params = task->task_->GetParams();
+            task->task_->GetArea(previous.areas, previous.shieldedAreas);
+
+            auto ret = task->task_->SetParams(params);
+            if (util::ErrorEnum::Success != ret) {
+                auto rollback_ret = task->task_->SetParams(previous);
+                if (util::ErrorEnum::Success != rollback_ret) {
+                    LOG_ERRO("[{}/{}] SaveOrUpdate parameter rollback failed: {}", cameraId,
+                             algorithmId, static_cast<uint32_t>(rollback_ret));
+                }
+                return ret;
+            }
+        } else {
+            task                  = std::make_shared<CameraTask>();
+            task->algorithm_code_ = algorithmId;
+            auto ret              = MakeCameraTask(camera, task);
+            if (util::ErrorEnum::Success != ret) {
+                return ret;
+            }
+            ret = task->task_->SetParams(params);
+            if (util::ErrorEnum::Success != ret) {
+                return ret;
+            }
+            camera->tasks_.push_back(task);
+        }
+
+        const bool was_enabled = task->is_enabled_.load(std::memory_order_acquire);
+        task->data_.taskConfig = params;
+        task->schedule_id_     = scheduleId;
+        task->schedule_name_   = scheduleName;
+        task->is_enabled_.store(true, std::memory_order_release);
+        SaveCameraTaskList(camera);
+        start_task = !was_enabled;
+    }
+
+    if (start_task) {
+        SwitchCameraTaskAsync(camera, task);
+    }
+    return util::ErrorEnum::Success;
 }
 
 util::ErrorEnum CameraServiceImpl::ModifyTaskParam(const std::string& cameraId,
@@ -214,30 +339,7 @@ bool CameraServiceImpl::ScheduleInUse(const std::string& scheduleId) {
 
 util::ErrorEnum CameraServiceImpl::SwitchTask(const std::string& cameraId, const std::string& algorithmId,
                                               bool enable) {
-    // Authorization removed: no longer reject task start due to auth/expiry/limit (matches old 23461e05)
-#ifdef COSMO_NN_USE_SOPHON_BACKEND
-    if (enable) {
-        if (ServiceRegistry::Instance().Get<IConfigReadService>().GetResourceLimit()) {
-            size_t packet_total = 0, packet_proc = 0, packet_discard = 0, continues_discard_sec = 0;
-            ServiceRegistry::Instance().Get<ITaskQuery>().PacketStatus(packet_total, packet_proc,
-                                                                       packet_discard, continues_discard_sec);
-            double discard_percent = 0.0;
-            if (packet_total > 0) {
-                discard_percent = static_cast<double>(packet_discard) / static_cast<double>(packet_total);
-            }
-            auto gpu_info = ServiceRegistry::Instance().Get<IDeviceInfoService>().GetGpuUtilization();
-            std::vector<GpuMemSnapshot> devs;
-            devs.reserve(gpu_info.gpudevusage.size());
-            std::transform(gpu_info.gpudevusage.begin(), gpu_info.gpudevusage.end(), std::back_inserter(devs),
-                           [](const auto& d) { return GpuMemSnapshot{d.gpumemtotal, d.gpumemavailable}; });
-            auto score = CalcCustomScore(gpu_info.gpuusage, gpu_info.gpumemtotal, gpu_info.gpumemavailable,
-                                         devs, discard_percent, continues_discard_sec);
-            if (score > 100.0) {
-                return util::ErrorEnum::ResourceLimit;
-            }
-        }
-    }
-#endif
+    // Authorization checks were removed; resource admission remains enforced for real start transitions.
     auto camera = GetCamera(cameraId);
     if (!camera) {
         LOG_INFO("{} Not Exist", cameraId);
@@ -247,6 +349,22 @@ util::ErrorEnum CameraServiceImpl::SwitchTask(const std::string& cameraId, const
     std::lock_guard<std::mutex> command_lock(camera->command_mtx_);
     if (camera->deleting_) {
         return util::ErrorEnum::CameraNotExist;
+    }
+
+    {
+        std::shared_lock<std::shared_mutex> lock(camera->task_mtx_);
+        auto it = std::find_if(camera->tasks_.begin(), camera->tasks_.end(),
+                               [&](const CameraTaskPtr& cfg) { return cfg->algorithm_code_ == algorithmId; });
+        if (it != camera->tasks_.end() && (*it)->is_enabled_.load(std::memory_order_acquire) == enable) {
+            return util::ErrorEnum::Success;
+        }
+    }
+
+    if (enable) {
+        auto resource_ret = CheckTaskStartResource();
+        if (util::ErrorEnum::Success != resource_ret) {
+            return resource_ret;
+        }
     }
 
     CameraTaskPtr taskToSwitch = nullptr;

--- a/src/service/camera/impl/CameraTaskConfig.cc
+++ b/src/service/camera/impl/CameraTaskConfig.cc
@@ -149,8 +149,8 @@ util::ErrorEnum CameraServiceImpl::SaveOrUpdateTask(const std::string& cameraId,
             if (util::ErrorEnum::Success != ret) {
                 auto rollback_ret = task->task_->SetParams(previous);
                 if (util::ErrorEnum::Success != rollback_ret) {
-                    LOG_ERRO("[{}/{}] SaveOrUpdate parameter rollback failed: {}", cameraId,
-                             algorithmId, static_cast<uint32_t>(rollback_ret));
+                    LOG_ERRO("[{}/{}] SaveOrUpdate parameter rollback failed: {}", cameraId, algorithmId,
+                             static_cast<uint32_t>(rollback_ret));
                 }
                 return ret;
             }

--- a/test/mock/MockCameraService.h
+++ b/test/mock/MockCameraService.h
@@ -21,6 +21,10 @@ public:
     MAKE_MOCK3(ModifyTaskParam,
                cosmo::util::ErrorEnum(const std::string&, const std::string&, cosmo::MsgTaskConfig&),
                override);
+    MAKE_MOCK4(SaveOrUpdateTask,
+               cosmo::util::ErrorEnum(const std::string&, const std::string&,
+                                      const cosmo::MsgTaskConfig&, const std::string&),
+               override);
     MAKE_MOCK3(QueryTaskParam,
                cosmo::util::ErrorEnum(const std::string&, const std::string&,
                                       std::vector<cosmo::MsgDynamicKeyValue>&),

--- a/test/mock/MockCameraService.h
+++ b/test/mock/MockCameraService.h
@@ -22,8 +22,8 @@ public:
                cosmo::util::ErrorEnum(const std::string&, const std::string&, cosmo::MsgTaskConfig&),
                override);
     MAKE_MOCK4(SaveOrUpdateTask,
-               cosmo::util::ErrorEnum(const std::string&, const std::string&,
-                                      const cosmo::MsgTaskConfig&, const std::string&),
+               cosmo::util::ErrorEnum(const std::string&, const std::string&, const cosmo::MsgTaskConfig&,
+                                      const std::string&),
                override);
     MAKE_MOCK3(QueryTaskParam,
                cosmo::util::ErrorEnum(const std::string&, const std::string&,

--- a/test/test_camera_task_mng.cc
+++ b/test/test_camera_task_mng.cc
@@ -74,9 +74,7 @@ TEST_CASE("CameraServiceImpl SaveOrUpdateTask commits configuration atomically",
     (void)!system("rm -rf /tmp/cosmo_test/conf/camera/test_camera_atomic");
     TestFixture fx("test_camera_atomic", "rtsp://test");
 
-    ALLOW_CALL(fx.mocks.scheduleSvc, Exist2("sched1", _))
-        .LR_SIDE_EFFECT(_2 = "Schedule 1")
-        .RETURN(true);
+    ALLOW_CALL(fx.mocks.scheduleSvc, Exist2("sched1", _)).LR_SIDE_EFFECT(_2 = "Schedule 1").RETURN(true);
     ALLOW_CALL(fx.mocks.scheduleSvc, Exist2("missing", _)).RETURN(false);
 
     MsgTaskConfig params;
@@ -117,8 +115,7 @@ TEST_CASE("CameraServiceImpl SaveOrUpdateTask commits configuration atomically",
         CHECK(fx.svc.GetTasks(fx.cameraId).empty());
 
         std::vector<MsgDynamicKeyValue> saved_params;
-        CHECK(fx.svc.QueryTaskParam(fx.cameraId, "test_alg", saved_params) ==
-              util::ErrorEnum::TaskNotExist);
+        CHECK(fx.svc.QueryTaskParam(fx.cameraId, "test_alg", saved_params) == util::ErrorEnum::TaskNotExist);
     }
 
     SECTION("validation failure preserves an existing task") {
@@ -126,7 +123,7 @@ TEST_CASE("CameraServiceImpl SaveOrUpdateTask commits configuration atomically",
                 util::ErrorEnum::Success);
 
         params.params[0].value = "20";
-        auto ret = fx.svc.SaveOrUpdateTask(fx.cameraId, "test_alg", params, "missing");
+        auto ret               = fx.svc.SaveOrUpdateTask(fx.cameraId, "test_alg", params, "missing");
         REQUIRE(ret == util::ErrorEnum::TimeTemplateNotExist);
 
         std::vector<MsgDynamicKeyValue> saved_params;
@@ -142,9 +139,7 @@ TEST_CASE("CameraServiceImpl resource rejection leaves no partial task",
     (void)!system("rm -rf /tmp/cosmo_test/conf/camera/test_camera_resource");
     TestFixture fx("test_camera_resource", "rtsp://test");
 
-    ALLOW_CALL(fx.mocks.scheduleSvc, Exist2("sched1", _))
-        .LR_SIDE_EFFECT(_2 = "Schedule 1")
-        .RETURN(true);
+    ALLOW_CALL(fx.mocks.scheduleSvc, Exist2("sched1", _)).LR_SIDE_EFFECT(_2 = "Schedule 1").RETURN(true);
     REQUIRE_CALL(fx.mocks.configReadSvc, GetResourceLimit()).RETURN(true);
     REQUIRE_CALL(fx.mocks.taskSvc, PacketStatus(_, _, _, _))
         .LR_SIDE_EFFECT(_1 = 100; _2 = 0; _3 = 100; _4 = 30);
@@ -173,8 +168,7 @@ TEST_CASE("CameraServiceImpl resource rejection leaves no partial task",
     CHECK(fx.svc.GetTasks(fx.cameraId).empty());
 
     std::vector<MsgDynamicKeyValue> saved_params;
-    CHECK(fx.svc.QueryTaskParam(fx.cameraId, "test_alg", saved_params) ==
-          util::ErrorEnum::TaskNotExist);
+    CHECK(fx.svc.QueryTaskParam(fx.cameraId, "test_alg", saved_params) == util::ErrorEnum::TaskNotExist);
 }
 #endif
 

--- a/test/test_camera_task_mng.cc
+++ b/test/test_camera_task_mng.cc
@@ -5,6 +5,8 @@
  *  after CameraTaskMng was inlined.)
  */
 #include "mock/MockAppInfoService.h"
+#include "mock/MockConfigReadService.h"
+#include "mock/MockDeviceInfoService.h"
 #include "mock/MockScheduleService.h"
 #include "mock/MockServiceRegistry.h"
 #include "mock/MockTaskService.h"
@@ -66,6 +68,115 @@ TEST_CASE("CameraServiceImpl basic task operations", "[CameraServiceImpl]") {
         REQUIRE(ret == util::ErrorEnum::TaskNotExist);
     }
 }
+
+TEST_CASE("CameraServiceImpl SaveOrUpdateTask commits configuration atomically",
+          "[CameraServiceImpl][save-or-update]") {
+    (void)!system("rm -rf /tmp/cosmo_test/conf/camera/test_camera_atomic");
+    TestFixture fx("test_camera_atomic", "rtsp://test");
+
+    ALLOW_CALL(fx.mocks.scheduleSvc, Exist2("sched1", _))
+        .LR_SIDE_EFFECT(_2 = "Schedule 1")
+        .RETURN(true);
+    ALLOW_CALL(fx.mocks.scheduleSvc, Exist2("missing", _)).RETURN(false);
+
+    MsgTaskConfig params;
+    MsgDynamicKeyValue threshold;
+    threshold.key   = "param.threshold";
+    threshold.value = "10";
+    params.params.push_back(threshold);
+    MsgTaskArea area;
+    area.name = "zone-1";
+    params.areas.push_back(area);
+
+    SECTION("successful save creates one enabled task with all configuration") {
+        auto ret = fx.svc.SaveOrUpdateTask(fx.cameraId, "test_alg", params, "sched1");
+        REQUIRE(ret == util::ErrorEnum::Success);
+
+        auto tasks = fx.svc.GetTasks(fx.cameraId);
+        REQUIRE(tasks.size() == 1);
+        CHECK(tasks[0].algorithmCode == "test_alg");
+        CHECK(tasks[0].scheduleId == "sched1");
+        CHECK(tasks[0].enable);
+
+        std::vector<MsgDynamicKeyValue> saved_params;
+        REQUIRE(fx.svc.QueryTaskParam(fx.cameraId, "test_alg", saved_params) == util::ErrorEnum::Success);
+        REQUIRE(saved_params.size() == 1);
+        CHECK(saved_params[0].value == "10");
+
+        std::vector<MsgTaskArea> saved_areas;
+        std::vector<MsgTaskArea> saved_shielded_areas;
+        REQUIRE(fx.svc.QueryTaskArea(fx.cameraId, "test_alg", saved_areas, saved_shielded_areas) ==
+                util::ErrorEnum::Success);
+        REQUIRE(saved_areas.size() == 1);
+        CHECK(saved_areas[0].name == "zone-1");
+    }
+
+    SECTION("validation failure leaves a new task absent") {
+        auto ret = fx.svc.SaveOrUpdateTask(fx.cameraId, "test_alg", params, "missing");
+        REQUIRE(ret == util::ErrorEnum::TimeTemplateNotExist);
+        CHECK(fx.svc.GetTasks(fx.cameraId).empty());
+
+        std::vector<MsgDynamicKeyValue> saved_params;
+        CHECK(fx.svc.QueryTaskParam(fx.cameraId, "test_alg", saved_params) ==
+              util::ErrorEnum::TaskNotExist);
+    }
+
+    SECTION("validation failure preserves an existing task") {
+        REQUIRE(fx.svc.SaveOrUpdateTask(fx.cameraId, "test_alg", params, "sched1") ==
+                util::ErrorEnum::Success);
+
+        params.params[0].value = "20";
+        auto ret = fx.svc.SaveOrUpdateTask(fx.cameraId, "test_alg", params, "missing");
+        REQUIRE(ret == util::ErrorEnum::TimeTemplateNotExist);
+
+        std::vector<MsgDynamicKeyValue> saved_params;
+        REQUIRE(fx.svc.QueryTaskParam(fx.cameraId, "test_alg", saved_params) == util::ErrorEnum::Success);
+        REQUIRE(saved_params.size() == 1);
+        CHECK(saved_params[0].value == "10");
+    }
+}
+
+#ifdef COSMO_NN_USE_SOPHON_BACKEND
+TEST_CASE("CameraServiceImpl resource rejection leaves no partial task",
+          "[CameraServiceImpl][save-or-update][sophon]") {
+    (void)!system("rm -rf /tmp/cosmo_test/conf/camera/test_camera_resource");
+    TestFixture fx("test_camera_resource", "rtsp://test");
+
+    ALLOW_CALL(fx.mocks.scheduleSvc, Exist2("sched1", _))
+        .LR_SIDE_EFFECT(_2 = "Schedule 1")
+        .RETURN(true);
+    REQUIRE_CALL(fx.mocks.configReadSvc, GetResourceLimit()).RETURN(true);
+    REQUIRE_CALL(fx.mocks.taskSvc, PacketStatus(_, _, _, _))
+        .LR_SIDE_EFFECT(_1 = 100; _2 = 0; _3 = 100; _4 = 30);
+
+    MsgGpuInfo gpu_info;
+    gpu_info.gpuusage        = 1.0;
+    gpu_info.gpumemtotal     = 8000;
+    gpu_info.gpumemavailable = 0;
+    MsgGpuDevUsage device;
+    device.gpumemtotal     = 8000;
+    device.gpumemavailable = 0;
+    gpu_info.gpudevusage.push_back(device);
+    REQUIRE_CALL(fx.mocks.deviceInfoSvc, GetGpuUtilization()).RETURN(gpu_info);
+
+    MsgTaskConfig params;
+    MsgDynamicKeyValue threshold;
+    threshold.key   = "param.threshold";
+    threshold.value = "20";
+    params.params.push_back(threshold);
+    MsgTaskArea area;
+    area.name = "must-not-persist";
+    params.areas.push_back(area);
+
+    auto ret = fx.svc.SaveOrUpdateTask(fx.cameraId, "test_alg", params, "sched1");
+    REQUIRE(ret == util::ErrorEnum::ResourceLimit);
+    CHECK(fx.svc.GetTasks(fx.cameraId).empty());
+
+    std::vector<MsgDynamicKeyValue> saved_params;
+    CHECK(fx.svc.QueryTaskParam(fx.cameraId, "test_alg", saved_params) ==
+          util::ErrorEnum::TaskNotExist);
+}
+#endif
 
 TEST_CASE("CameraServiceImpl monitor logic", "[CameraServiceImpl]") {
     (void)!system("rm -rf /tmp/cosmo_test/conf/camera/test_camera_01");

--- a/test/test_message_video_task_handler.cc
+++ b/test/test_message_video_task_handler.cc
@@ -312,28 +312,26 @@ TEST_CASE("VideoTaskHandler: SaveOrUpdate success", "[video-task-handler]") {
     recv.channelId   = "ch1";
     recv.algorithmId = "alg1";
 
-    REQUIRE_CALL(f.mocks.cameraSvc, ModifyTaskParam(trompeloeil::_, trompeloeil::_, trompeloeil::_))
-        .RETURN(cosmo::util::ErrorEnum::Success);
-    REQUIRE_CALL(f.mocks.cameraSvc, ModifyTaskStrategy(trompeloeil::_, trompeloeil::_, trompeloeil::_))
-        .RETURN(cosmo::util::ErrorEnum::Success);
-    REQUIRE_CALL(f.mocks.cameraSvc, SwitchTask(trompeloeil::_, trompeloeil::_, trompeloeil::_))
+    REQUIRE_CALL(f.mocks.cameraSvc,
+                 SaveOrUpdateTask(trompeloeil::_, trompeloeil::_, trompeloeil::_, trompeloeil::_))
         .RETURN(cosmo::util::ErrorEnum::Success);
     f.handler.Handle(std::move(recv), errc);
     REQUIRE(errc == cosmo::util::ErrorEnum::Success);
 }
 
-TEST_CASE("VideoTaskHandler: SaveOrUpdate fails at ModifyParam", "[video-task-handler]") {
+TEST_CASE("VideoTaskHandler: SaveOrUpdate resource rejection is a single atomic call",
+          "[video-task-handler]") {
     TestFixture f;
     std::error_condition errc;
     cosmo::VideoTask::MsgSaveOrUpdateRecv recv;
     recv.channelId   = "ch1";
     recv.algorithmId = "alg1";
 
-    REQUIRE_CALL(f.mocks.cameraSvc, ModifyTaskParam(trompeloeil::_, trompeloeil::_, trompeloeil::_))
-        .RETURN(cosmo::util::ErrorEnum::CameraNotExist);
-    // ModifyTaskStrategy and SwitchTask should NOT be called
+    REQUIRE_CALL(f.mocks.cameraSvc,
+                 SaveOrUpdateTask(trompeloeil::_, trompeloeil::_, trompeloeil::_, trompeloeil::_))
+        .RETURN(cosmo::util::ErrorEnum::ResourceLimit);
     f.handler.Handle(std::move(recv), errc);
-    REQUIRE(errc == cosmo::util::ErrorEnum::CameraNotExist);
+    REQUIRE(errc == cosmo::util::ErrorEnum::ResourceLimit);
 }
 
 // ============================================================================
@@ -485,11 +483,8 @@ TEST_CASE("VideoTaskHandler: ApplyParamsBatch all success", "[video-task-handler
     recv.algorithmId      = "alg1";
     recv.targetChannelIds = {"ch1"};
 
-    REQUIRE_CALL(f.mocks.cameraSvc, ModifyTaskParam(trompeloeil::_, trompeloeil::_, trompeloeil::_))
-        .RETURN(cosmo::util::ErrorEnum::Success);
-    REQUIRE_CALL(f.mocks.cameraSvc, ModifyTaskStrategy(trompeloeil::_, trompeloeil::_, trompeloeil::_))
-        .RETURN(cosmo::util::ErrorEnum::Success);
-    REQUIRE_CALL(f.mocks.cameraSvc, SwitchTask(trompeloeil::_, trompeloeil::_, trompeloeil::_))
+    REQUIRE_CALL(f.mocks.cameraSvc,
+                 SaveOrUpdateTask(trompeloeil::_, trompeloeil::_, trompeloeil::_, trompeloeil::_))
         .RETURN(cosmo::util::ErrorEnum::Success);
 
     auto ret = f.handler.Handle(std::move(recv), errc);
@@ -504,21 +499,17 @@ TEST_CASE("VideoTaskHandler: ApplyParamsBatch partial failure", "[video-task-han
     recv.algorithmId      = "alg1";
     recv.targetChannelIds = {"ch1", "ch2"};
 
-    // ch1 succeeds fully
+    // ch1 succeeds atomically
     REQUIRE_CALL(f.mocks.cameraSvc,
-                 ModifyTaskParam(trompeloeil::eq(std::string("ch1")), trompeloeil::_, trompeloeil::_))
-        .RETURN(cosmo::util::ErrorEnum::Success);
-    REQUIRE_CALL(f.mocks.cameraSvc,
-                 ModifyTaskStrategy(trompeloeil::eq(std::string("ch1")), trompeloeil::_, trompeloeil::_))
-        .RETURN(cosmo::util::ErrorEnum::Success);
-    REQUIRE_CALL(f.mocks.cameraSvc,
-                 SwitchTask(trompeloeil::eq(std::string("ch1")), trompeloeil::_, trompeloeil::_))
+                 SaveOrUpdateTask(trompeloeil::eq(std::string("ch1")), trompeloeil::_,
+                                  trompeloeil::_, trompeloeil::_))
         .RETURN(cosmo::util::ErrorEnum::Success);
 
-    // ch2 fails at ModifyTaskParam
+    // ch2 is rejected without a partial task update
     REQUIRE_CALL(f.mocks.cameraSvc,
-                 ModifyTaskParam(trompeloeil::eq(std::string("ch2")), trompeloeil::_, trompeloeil::_))
-        .RETURN(cosmo::util::ErrorEnum::CameraNotExist);
+                 SaveOrUpdateTask(trompeloeil::eq(std::string("ch2")), trompeloeil::_,
+                                  trompeloeil::_, trompeloeil::_))
+        .RETURN(cosmo::util::ErrorEnum::ResourceLimit);
 
     auto ret = f.handler.Handle(std::move(recv), errc);
     REQUIRE(errc == cosmo::util::ErrorEnum::Success);

--- a/test/test_message_video_task_handler.cc
+++ b/test/test_message_video_task_handler.cc
@@ -500,15 +500,13 @@ TEST_CASE("VideoTaskHandler: ApplyParamsBatch partial failure", "[video-task-han
     recv.targetChannelIds = {"ch1", "ch2"};
 
     // ch1 succeeds atomically
-    REQUIRE_CALL(f.mocks.cameraSvc,
-                 SaveOrUpdateTask(trompeloeil::eq(std::string("ch1")), trompeloeil::_,
-                                  trompeloeil::_, trompeloeil::_))
+    REQUIRE_CALL(f.mocks.cameraSvc, SaveOrUpdateTask(trompeloeil::eq(std::string("ch1")), trompeloeil::_,
+                                                     trompeloeil::_, trompeloeil::_))
         .RETURN(cosmo::util::ErrorEnum::Success);
 
     // ch2 is rejected without a partial task update
-    REQUIRE_CALL(f.mocks.cameraSvc,
-                 SaveOrUpdateTask(trompeloeil::eq(std::string("ch2")), trompeloeil::_,
-                                  trompeloeil::_, trompeloeil::_))
+    REQUIRE_CALL(f.mocks.cameraSvc, SaveOrUpdateTask(trompeloeil::eq(std::string("ch2")), trompeloeil::_,
+                                                     trompeloeil::_, trompeloeil::_))
         .RETURN(cosmo::util::ErrorEnum::ResourceLimit);
 
     auto ret = f.handler.Handle(std::move(recv), errc);

--- a/test/test_video_util.cc
+++ b/test/test_video_util.cc
@@ -39,4 +39,12 @@ TEST_CASE("VideoUtil separator helpers honor supplied buffer lengths", "[media][
     CHECK(SeparateHVideoFrame(two_nalus.data(), two_nalus.size()) == 5);
 }
 
+TEST_CASE("Small H264 IDR packets remain valid startup frames", "[media][video-util][regression]") {
+    const std::array<std::uint8_t, 7> small_idr{0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x84};
+
+    REQUIRE(small_idr.size() < 1024);
+    CHECK(SeparateHVideoFrame(small_idr.data(), small_idr.size()) == small_idr.size());
+    CHECK(GetFrameType(VideoCodecType::kH264, small_idr.data(), small_idr.size()) == HFrameType::I);
+}
+
 }  // namespace cosmo::media


### PR DESCRIPTION
## Summary

- forward valid small startup IDR packets instead of reopening the preview encoder and waiting indefinitely for a larger keyframe
- route single and batch task saves through one service-layer `SaveOrUpdateTask` operation
- validate schedules and resource admission before creating tasks or changing parameters, areas, schedules, or enable state
- restore the previous parameters and areas when a parameter update fails
- only apply resource admission to real disabled-to-enabled transitions

## Root cause

Preview startup treated a valid keyframe as invalid based only on encoded packet size. The encoder was reopened repeatedly, so channel 1 algorithm overlay preview could fail until the device was restarted.

Task saving performed parameter, area, and strategy updates before `SwitchTask(true)` checked the resource score. When that final check returned `ResourceLimit`, the API reported failure after task state had already been persisted, with no transaction or compensation path. Batch apply used the same sequence.

## Impact

Valid preview startup frames are now published normally. A failed task save is rejected before mutation when its schedule or start-resource admission is invalid, so callers no longer receive an error after partial state has been applied. Existing enabled tasks can still update parameters while the device is busy because no new start transition is required.

## Validation

- x86 build and full test suite passed: https://github.com/cosmo-wander-ai/cosmo-edge/actions/runs/30814785785
- Sophon package and test binary build/upload passed: https://github.com/cosmo-wander-ai/cosmo-edge/actions/runs/30814785449
- Sophon target tests passed directly on the test device:
  - `[save-or-update]`: 2 cases, 72 assertions
  - `[video-task-handler]`: 34 cases, 96 assertions
- resource score `200` regression test returns `ResourceLimit` without creating or changing a task
- controlled invalid-schedule save left `taskList.json`, `param.json`, and `area.json` byte-identical
- successful save and restore round trip passed on `192.168.100.1`
- algorithm overlay preview returned FLV data with a valid header, about 164 ms first-frame latency, and zero preview failures
- deployed Sophon binary remained healthy with no crashes or service restarts

The Sophon CI hardware-test job is still queued on the self-hosted runner; the same generated test binary has already passed the targeted suites directly on the target device.
