### PR TITLE
fix(build): windows11部署修复mp4v2.cmake问题

### DIFF
--- a/cmake/mp4v2.cmake
+++ b/cmake/mp4v2.cmake
@@ -22,6 +22,13 @@ ExternalProject_Add(
 
     SOURCE_DIR ${MP4V2_SOURCE_DIR}
 
+    # mp4v2 2.0.0 由 automake 1.11 生成, 其 GNUmakefile 中的 GNUmakefile.in
+    # 再生成规则硬编码了 automake-1.11; 而 x86 构建镜像只提供 automake 1.16。
+    # 构建上下文中 aclocal.m4/configure 的 mtime 若新于 GNUmakefile.in,
+    # 该规则就会触发, 导致 "automake-1.11: command not found"。
+    # 此处 touch 生成的 autotools 文件, 使再生成规则永不触发。
+    PATCH_COMMAND touch <SOURCE_DIR>/GNUmakefile.in <SOURCE_DIR>/aclocal.m4 <SOURCE_DIR>/configure
+
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
         ${MP4V2_CONFIGURE_ARGS}
     


### PR DESCRIPTION
## Summary

Fix the Windows 11 x86 Docker build failure in mp4v2 by preventing its bundled Automake-generated files from being regenerated with the unavailable `automake-1.11` executable.

This fix was proposed and implemented by @QichengMei. The candidate was independently rebuilt and smoke-tested by a maintainer on Windows 11; the measured results are recorded below.

## Related issue

Closes #86

## Root cause

mp4v2 2.0.0 contains a `GNUmakefile` regeneration rule generated by Automake 1.11. When a Windows checkout/build-context copy gives `aclocal.m4` or `configure` a newer mtime than `GNUmakefile.in`, `make` runs the hard-coded `automake-1.11` command. The x86 builder image contains Automake 1.16.x instead, so the build stops with `automake-1.11: command not found`.

The added `PATCH_COMMAND` touches the already-generated Autotools inputs before configure/build, keeping the regeneration rule from firing.

## Scope

### In scope

- Stabilize the mp4v2 ExternalProject build when the source tree originates from Windows 11.
- Preserve the existing mp4v2 2.0.0 source and x86 builder toolchain.

### Out of scope

- Git-for-Windows CRLF normalization for shell scripts.
- Host port conflicts when Hyper-V reserves TCP port 8080.
- Changes to mp4v2 source code or third-party versions.

## Risk tags

- [ ] Runtime / lifecycle
- [ ] Thread / memory safety
- [ ] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Build / deployment
- [ ] Refactor
- [ ] Test

## Area

- [ ] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [x] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `3429e8ae2ef5c92b1a858c9fc3b0ba5e92629cac`
- Candidate commit: `d8d82a19b01aac5f4492185518e2b30714b30831`
- Candidate tree: `328fd4847e381a4792691e52d6ea034d02a4f52f`
- Package SHA-256: `N/A` (Docker image manifest-list digest recorded below)
- Test binary SHA-256: `N/A`

The candidate was not amended, rebased, merged, or otherwise changed after the evidence below was collected. Its head commit and tree were rechecked before this record was added.

## Verification

### Parent baseline

`FAIL` — the original report reproduced the failure on Windows 11 build `26200.8875`, Docker `29.5.3`, x86 Docker, baseline `a05af83`, using:

```text
docker compose -f docker-compose.x86.windows.yml up -d --build

Observed: /bin/bash: automake-1.11: command not found
Observed: gmake[3]: *** [GNUmakefile:605: .../GNUmakefile.in] Error 1
```

The report and full failure log are in #86. The PR's immediate parent was not rebuilt separately; the failure mechanism is the same generated-file mtime path changed by this commit.

### Candidate checks

`PASS` — independent maintainer verification on Windows 11 `10.0.26220.8925`, WSL `2.7.11`, Docker Desktop `4.85.0`, Docker Engine client/server `29.6.2`. The checkout was explicitly LF-normalized to keep an unrelated global `core.autocrlf=true` setting from changing container shell scripts.

```text
git -c core.autocrlf=false worktree add <isolated-D-drive-worktree> d8d82a19b01aac5f4492185518e2b30714b30831
docker compose --progress plain -f docker-compose.x86.windows.yml build --no-cache

Result: PASS (exit code 0, wall time 655.9 s)
Builder image: ghcr.io/cosmo-wander-ai/cosmo_edge-build-env_x86:v1@sha256:3345825c9255b9b73369af7ab6346c2cc7079786eb23309258acf7212ca03c1d
mp4v2 configure: PASS
mp4v2 build: PASS
mp4v2 install: PASS
Full cosmo-engine/web/package build: PASS
Built image: cosmo:x86-dev@sha256:aa857c6bd98c8e18747bfd2d77e548653bdb2b2fb0cc5350ef4b0b135acbab22
Build log SHA-256: 4b7d988728c7348bb7f7b7204c4c096db07b99b4c14cfb049ae2f7534ddda04b
```

`PASS with host-port override` — the built image stayed running with host mapping `8280:80`, and `http://127.0.0.1:8280/` returned HTTP 200 (`text/html`, 1934 bytes).

The exact Compose startup using host port 8080 was `BLOCKED` by this test machine's Hyper-V reserved TCP range `8038-8137`. That host-specific port conflict is unrelated to the mp4v2 change and is intentionally out of scope here.

### Risk-based evidence

- API/network: HTTP root smoke check returned 200 from the candidate image.
- Media/streaming: Not exercised; this change only affects third-party build orchestration.
- Sophon/device: Not applicable; validated on the x86 Docker route targeted by #86.
- Frontend/UI: The packaged web frontend completed and the root page was served.
- Package/deployment: Full no-cache Docker build passed with the same pinned x86 builder digest seen in the failure report.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this narrowly scoped build fix.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented (no new dependency is added).
- [x] Documentation was updated if behavior changed (no user-facing behavior change).
- [ ] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

The DCO checkbox remains intentionally open: commit `d8d82a1` currently uses `you@example.com` and has no author `Signed-off-by:` trailer. The contributor must amend and sign off the commit before merge; maintainers must not sign on the contributor's behalf.

## Acceptance and cleanup

- Candidate-bound acceptance: `d8d82a19b01aac5f4492185518e2b30714b30831`, image digest `sha256:aa857c6bd98c8e18747bfd2d77e548653bdb2b2fb0cc5350ef4b0b135acbab22`
- Device test filter: `N/A`
- Device backup state: `N/A`
- Temporary-data cleanup: `complete` (test container, image, volumes, build cache, and isolated worktree removed)
- Final Git status: maintainer's existing workspace changes were preserved; candidate verification used a separate clean worktree
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

- Code/build behavior is independently verified on Windows 11.
- Before merge, @QichengMei must amend the commit using the real author identity and `git commit --amend --signoff --no-edit`, then force-push with lease. Because the candidate commit changes, the identity fields above must be refreshed; the tree-bound build evidence remains applicable only if the resulting tree SHA stays `328fd4847e381a4792691e52d6ea034d02a4f52f`.
- Follow-up work will address Git-for-Windows CRLF normalization and configurable host ports without expanding this contributor's patch.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent).
