### PR TITLE
fix(build): harden Windows Docker checkout and web port

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# 第三方源码中的 configure 等无扩展名脚本也必须以 LF 进入 Linux 构建容器。
+3rd/**  text=auto eol=lf
+.gitattributes text eol=lf
+
 # 强制所有源代码文件使用 LF 换行符，防止 Windows 带入 CRLF
 *.cc    text eol=lf
 *.h     text eol=lf
@@ -20,6 +24,10 @@
 *.html  text eol=lf
 CMakeLists.txt text eol=lf
 Makefile       text eol=lf
+
+# Windows 原生批处理脚本保留 CRLF。
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
 
 # 二进制文件不做转换
 *.bmodel binary

--- a/docker-compose.x86.windows.yml
+++ b/docker-compose.x86.windows.yml
@@ -10,7 +10,7 @@ services:
     init: true
     restart: unless-stopped
     ports:
-      - "8080:80"  # Use port 8080 to avoid conflicts with host port 80.
+      - "${COSMO_X86_WEB_PORT:-8080}:80"  # Override when Windows reserves host port 8080.
       - "1936:1936"
       - "1985:1985"
       - "18088:18088"

--- a/docs/en/guide/troubleshooting.md
+++ b/docs/en/guide/troubleshooting.md
@@ -59,7 +59,34 @@ The x86 Compose file publishes:
 - `18088`
 - `8000/udp`
 
-If a port is occupied, you can modify the host port in `docker-compose.x86.yml` (or `docker-compose.x86.windows.yml` on Windows), or stop the service that occupies the port.
+If a port is occupied, you can modify the host port in `docker-compose.x86.yml`, or stop the service that occupies the port.
+
+On Windows, Hyper-V / WSL can reserve a TCP port range. Docker may therefore report a bind failure even when `netstat` shows no listening process. Check the reserved ranges first:
+
+```powershell
+netsh interface ipv4 show excludedportrange protocol=tcp
+```
+
+`docker-compose.x86.windows.yml` accepts `COSMO_X86_WEB_PORT`, so you can change the web host port without editing a tracked file. For example, use `8280`:
+
+```powershell
+$env:COSMO_X86_WEB_PORT = "8280"
+docker compose -f docker-compose.x86.windows.yml up -d --build
+```
+
+Then open `http://127.0.0.1:8280`. The default remains `8080` when the variable is unset.
+
+## Windows Build Scripts Report `No such file or directory`
+
+If a Docker build reports that an existing `configure`, `config`, or `Configure` file cannot be executed, Git for Windows may have checked out the extensionless script with CRLF endings. The container then cannot parse its shebang.
+
+The root `.gitattributes` pins automatically detected text files, including these extensionless scripts, to LF. After pulling the latest rules, retry from a fresh clone or clean worktree with no uncommitted changes. Confirm the rules with:
+
+```powershell
+git check-attr text eol -- 3rd/mp4v2-2.0.0/configure 3rd/openssl-3.5.3/config 3rd/srs-6.0-r0/trunk/configure
+```
+
+All three files should report `text: auto` and `eol: lf`.
 
 ## No Release Package in `build_output/`
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -59,7 +59,34 @@ x86 Compose 会发布：
 - `18088`
 - `8000/udp`
 
-如果端口被占用，可以修改 `docker-compose.x86.yml` (或 Windows 上的 `docker-compose.x86.windows.yml`) 的主机端口，或停止占用端口的服务。
+如果端口被占用，可以修改 `docker-compose.x86.yml` 的主机端口，或停止占用端口的服务。
+
+Windows 的 Hyper-V / WSL 可能保留一段 TCP 端口，即使 `netstat` 没显示监听进程，Docker 仍会报告端口绑定失败。可以先查看系统保留范围：
+
+```powershell
+netsh interface ipv4 show excludedportrange protocol=tcp
+```
+
+`docker-compose.x86.windows.yml` 支持通过 `COSMO_X86_WEB_PORT` 改 Web 主机端口，无需修改受版本控制的文件。例如使用 `8280`：
+
+```powershell
+$env:COSMO_X86_WEB_PORT = "8280"
+docker compose -f docker-compose.x86.windows.yml up -d --build
+```
+
+随后访问 `http://127.0.0.1:8280`。不设置该变量时仍默认使用 `8080`。
+
+## Windows 构建脚本提示 `No such file or directory`
+
+如果 Docker 构建在执行 `configure`、`config` 或 `Configure` 时报告文件存在但无法执行，通常是 Git for Windows 将无扩展名脚本检出为 CRLF，导致容器无法识别 shebang。
+
+仓库根目录的 `.gitattributes` 会把自动识别出的文本文件（包括这些无扩展名脚本）固定为 LF。拉取最新规则后，请在没有未保存修改的全新 clone 或干净 worktree 中重试。可以用以下命令确认规则：
+
+```powershell
+git check-attr text eol -- 3rd/mp4v2-2.0.0/configure 3rd/openssl-3.5.3/config 3rd/srs-6.0-r0/trunk/configure
+```
+
+三个文件都应显示 `text: auto` 和 `eol: lf`。
 
 ## `build_output/` 没有发布包
 


### PR DESCRIPTION
## Summary

Harden the remaining Windows 11 x86 Docker path discovered while independently verifying #87:

- Keep text files under `3rd/`, including extensionless `configure`/`config`/`Configure` scripts, on LF even when Git for Windows has global `core.autocrlf=true`.
- Preserve CRLF for native `.bat`/`.cmd` files.
- Allow the Windows Compose web host port to be overridden with `COSMO_X86_WEB_PORT` while keeping `8080` as the default.
- Document both troubleshooting paths in Chinese and English.

This is a follow-up to, not a replacement for, @QichengMei's mp4v2 fix in #87.

## Related issue

Refs #86

Follow-up to #87

## Root cause

The root `.gitattributes` already pinned common extensions such as `*.sh` to LF, but several vendored Linux build entry points have no extension. With Git for Windows global `core.autocrlf=true`, files such as mp4v2 `configure`, OpenSSL `config`, and SRS `configure` were checked out with CRLF. Inside Docker their shebangs became unexecutable and CMake reported `Command failed: No such file or directory` even though the files existed.

Separately, Windows Hyper-V / WSL can reserve TCP ranges that include host port 8080. Docker then cannot start the container even when no process is listening on that port. The Windows Compose file hard-coded `8080:80`, so users had to edit a tracked file to recover.

## Scope

### In scope

- Git checkout normalization for vendored text files used by Linux container builds.
- A backward-compatible Windows web-port override.
- Bilingual troubleshooting guidance and reproducible checks.

### Out of scope

- The mp4v2 Automake regeneration fix, which remains owned by #87.
- Automatically selecting a free port.
- Changing the other RTMP/SRS/device-discovery host ports.
- Linux Compose behavior.

## Risk tags

- [ ] Runtime / lifecycle
- [ ] Thread / memory safety
- [x] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Documentation
- [x] Build / deployment
- [ ] Refactor
- [x] Test

## Area

- [ ] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [x] Build / deployment
- [x] Documentation

## Candidate identity

- Base commit: `3429e8ae2ef5c92b1a858c9fc3b0ba5e92629cac`
- Candidate commit: `f43a1f3e666c6e92396ba8b999f58ec0077a1c2d`
- Candidate tree: `7a60cf720d080b32e2758b2c0072c02d56f766d6`
- Package SHA-256: `N/A` (integration image digest recorded below)
- Test binary SHA-256: `N/A`

The final candidate commit above was not amended, rebased, merged, or otherwise changed after the candidate-bound checks below. A separate uncommitted integration tree combined this candidate with #87 only for end-to-end validation; it was not pushed.

## Verification

### Parent baseline

`FAIL` — Windows 11 `10.0.26220.8925`, Git for Windows global `core.autocrlf=true`, Docker Desktop `4.85.0`, Docker Engine `29.6.2`. A clean checkout containing #87 but not this follow-up used:

```text
docker compose --progress plain -f docker-compose.x86.windows.yml build --no-cache

Observed: mp4v2 configure -> Command failed: No such file or directory
Observed: OpenSSL configure -> Command failed: No such file or directory
Observed: SRS configure -> Command failed: No such file or directory
Build log SHA-256: bb7ab84dfba11aee88e34bd9161455c1b077546b03c7fd066615e55a67b5f262
```

`BLOCKED` — after an LF-normalized build succeeded, the unchanged Windows Compose file could not publish `8080:80` because Hyper-V had reserved TCP range `8038-8137` on the host. No listener owned port 8080.

### Candidate checks

`PASS` — exact candidate commit `f43a1f3e666c6e92396ba8b999f58ec0077a1c2d`:

```text
git diff --check origin/main...HEAD
git check-attr text eol -- 3rd/mp4v2-2.0.0/configure 3rd/openssl-3.5.3/config 3rd/srs-6.0-r0/trunk/configure 3rd/SQLiteCpp-3.3.3/build.bat

Result:
- mp4v2/OpenSSL/SRS extensionless scripts: text=auto, eol=lf
- Windows build.bat: text=set, eol=crlf
```

`PASS` — clean detached Windows checkout with the user's unchanged global `core.autocrlf=true`:

```text
git worktree add --detach <clean-worktree> f43a1f3e666c6e92396ba8b999f58ec0077a1c2d
git -C <clean-worktree> ls-files --eol -- 3rd/mp4v2-2.0.0/configure 3rd/openssl-3.5.3/config 3rd/srs-6.0-r0/trunk/configure

Result: all three reported i/lf, w/lf, attr/text=auto eol=lf; direct byte checks found 0 CR bytes.
```

`PASS` — Compose interpolation:

```text
docker compose -f docker-compose.x86.windows.yml config --format json
# published web port: 8080

$env:COSMO_X86_WEB_PORT = "8280"
docker compose -f docker-compose.x86.windows.yml config --format json
# published web port: 8280
```

`PASS` — documentation:

```text
npm ci
npm run docs:verify

Tutorial documentation check: PASS (10 core pages, 2 indexes, bilingual pairs, links, images, navigation)
VitePress build: PASS
Rendered bilingual page smoke test: PASS (10 pages)
```

`PASS` — full integration of this candidate plus unchanged #87 commit `d8d82a19b01aac5f4492185518e2b30714b30831` in temporary tree `c3e4e9f053580cb78e0dcb96487859ed9d200fd8`:

```text
git merge --no-commit --no-ff d8d82a19b01aac5f4492185518e2b30714b30831
$env:COSMO_X86_WEB_PORT = "8280"
docker compose --progress plain -f docker-compose.x86.windows.yml build --no-cache
docker compose -f docker-compose.x86.windows.yml up -d --no-build

Build result: PASS (exit code 0, 796.9 s)
mp4v2/OpenSSL/SRS configure and build: PASS
Full cosmo-engine, web frontend, and package build: PASS
Forbidden failure markers (`automake-1.11`, `/bin/sh^M`, `/bin/bash^M`, missing configure command): 0
Image digest: sha256:ab4242fde38e895ccfcc5978ea40dfa2d6d1b97edb11fb429fd375b0e76c10a3
Build log SHA-256: b91a098233ef78b28a984e1ecfe9b21a257feecaf954d1441fdf1ff62b22345d
Compose status: running with 0.0.0.0:8280->80/tcp
HTTP http://127.0.0.1:8280/: 200, text/html, 1934 bytes
```

The first integration attempt was blocked before project build by a transient Docker Hub IPv6 token timeout. Pull retry succeeded, and the complete no-cache rerun above passed.

### Risk-based evidence

- API/network: Default `8080` and override `8280` both resolve correctly; real Compose startup and HTTP 200 verified on 8280.
- Media/streaming: Published RTMP/SRS/UDP port mappings were unchanged; runtime media flows were not exercised.
- Sophon/device: Not applicable; this PR targets the Windows x86 Docker route.
- Frontend/UI: VitePress docs passed; integrated CosmoEdge frontend built and served its root page.
- Package/deployment: Fresh `core.autocrlf=true` checkout plus #87 passed a full no-cache image/package build.

## Documentation impact

- [x] Documentation was updated.
- [ ] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [x] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts (Windows Compose accepts one new optional environment variable; the default is unchanged).
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented (no dependency is added).
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: `f43a1f3e666c6e92396ba8b999f58ec0077a1c2d`; integration tree `c3e4e9f053580cb78e0dcb96487859ed9d200fd8`; image `sha256:ab4242fde38e895ccfcc5978ea40dfa2d6d1b97edb11fb429fd375b0e76c10a3`
- Device test filter: `N/A`
- Device backup state: `N/A`
- Temporary-data cleanup: `complete` (integration container, volumes, network, images, temporary worktree, and 7.766 GB build cache removed)
- Final Git status: clean candidate worktree; the maintainer's unrelated existing workspace edits remain untouched
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

- #87 remains the contributor-owned mp4v2 fix and has been independently approved. This PR contains only the additional Windows checkout/port hardening found during that review.
- The full Docker integration tree included #87 because `main` still contains the separate mp4v2 Automake failure tracked by #86. The two patches do not overlap and merged cleanly.
- `npm ci` reported the repository's existing audit summary (2 moderate, 2 high); this PR does not change npm dependencies or the lockfile.
