### PR TITLE
fix(http): harden thread pool lifecycle

### DIFF
--- a/src/network/http/HttpServer.cc
+++ b/src/network/http/HttpServer.cc
@@ -14,6 +14,7 @@
 #include <charconv>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <filesystem>
 #include <limits>
 #include <memory>
@@ -648,8 +649,16 @@ bool HttpServer::Initialize(const std::string& host_ip, int port, DispatcherFact
         return false;
     }
 
-    constexpr int kThreadNum = 4;
-    if (!thread_pool_.Initialize(kThreadNum, this, dispatcher_factory_)) {
+    constexpr int kThreadNum        = 4;
+    bool is_thread_pool_initialized = false;
+    try {
+        is_thread_pool_initialized = thread_pool_.Initialize(kThreadNum, this, dispatcher_factory_);
+    } catch (const std::exception& e) {
+        LOG_ERRO("Cannot initialize HTTP request thread pool: {}", e.what());
+    } catch (...) {
+        LOG_ERRO("{}", "Cannot initialize HTTP request thread pool: unknown exception");
+    }
+    if (!is_thread_pool_initialized) {
         CleanupEventResources();
         return false;
     }

--- a/src/network/http/HttpServerThreadPool.cc
+++ b/src/network/http/HttpServerThreadPool.cc
@@ -2,7 +2,13 @@
 
 #include "network/http/HttpServerThreadPool.h"
 
+#include <array>
+#include <cstddef>
+#include <exception>
 #include <limits>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "network/http/HttpCommon.h"
 #include "network/http/HttpServerThread.h"
@@ -10,104 +16,137 @@
 #include "util/StringUtil.h"
 
 namespace cosmo::network::http {
+namespace {
 
-HttpServerThreadPool::HttpServerThreadPool() : thread_num_(4), cur_thread_idx_(-1) {}
+    constexpr std::size_t kPriority0WorkerIndex = 0;
+    constexpr std::size_t kPriority1WorkerIndex = 1;
+    constexpr std::size_t kNormalWorkerBegin    = 2;
+    constexpr std::size_t kMinimumThreadCount   = kNormalWorkerBegin + 1;
+
+    constexpr std::array<const char*, 2> kPriority0Interfaces = {"dologin", "resetsystem"};
+    constexpr std::array<const char*, 2> kPriority1Interfaces = {"threaddebuginfo", "querydeviceinfo"};
+
+}  // namespace
+
+HttpServerThreadPool::HttpServerThreadPool() = default;
 
 HttpServerThreadPool::~HttpServerThreadPool() {
     Uninitialize();
 }
 
 bool HttpServerThreadPool::Initialize(int thread_num, HttpServer* server, DispatcherFactory factory) {
-    if (thread_num <= 0) {
+    if (!msg_handler_threads_.empty()) {
+        LOG_ERRO("{}", "HttpServerThreadPool is already initialized");
         return false;
     }
-    is_accepting_ = false;
-    thread_num_   = thread_num;
-    msg_handler_threads_.resize(thread_num_);
-    for (int idx = 0; idx < thread_num; ++idx) {
-        char name[64] = {0};
-        snprintf(name, sizeof(name), "MsgHanderThread_%d", idx);
-        msg_handler_threads_[idx] = std::make_unique<MsgHanderThread>(name, server, factory());
+    if (thread_num < static_cast<int>(kMinimumThreadCount)) {
+        LOG_ERRO("HttpServerThreadPool requires at least {} handler threads, got {}", kMinimumThreadCount,
+                 thread_num);
+        return false;
+    }
+    if (server == nullptr) {
+        LOG_ERRO("{}", "HttpServerThreadPool requires a valid HTTP server");
+        return false;
+    }
+    if (!factory) {
+        LOG_ERRO("{}", "HttpServerThreadPool dispatcher factory is not configured");
+        return false;
     }
 
-    for (int idx = 0; idx < thread_num; ++idx) {
-        if (!msg_handler_threads_[idx]->start()) {
-            LOG_ERRO("HttpServerThreadPool failed to start handler thread {}", idx);
-            Uninitialize();
-            return false;
+    is_accepting_.store(false, std::memory_order_release);
+    const auto handler_count = static_cast<std::size_t>(thread_num);
+    std::vector<std::unique_ptr<MsgHanderThread>> candidate_threads;
+    std::size_t handler_index = 0;
+
+    try {
+        candidate_threads.reserve(handler_count);
+        for (; handler_index < handler_count; ++handler_index) {
+            auto dispatcher = factory();
+            if (!dispatcher) {
+                LOG_ERRO("HttpServerThreadPool dispatcher factory returned null for handler {}",
+                         handler_index);
+                return false;
+            }
+
+            auto name = std::string("MsgHanderThread_") + std::to_string(handler_index);
+            candidate_threads.emplace_back(
+                std::make_unique<MsgHanderThread>(name, server, std::move(dispatcher)));
         }
+
+        for (handler_index = 0; handler_index < handler_count; ++handler_index) {
+            if (!candidate_threads[handler_index]->start()) {
+                LOG_ERRO("HttpServerThreadPool failed to start handler thread {}", handler_index);
+                return false;
+            }
+        }
+    } catch (const std::exception& ex) {
+        LOG_ERRO("HttpServerThreadPool initialization failed near handler {}: {}", handler_index, ex.what());
+        return false;
+    } catch (...) {
+        LOG_ERRO("HttpServerThreadPool initialization failed near handler {} with an unknown exception",
+                 handler_index);
+        return false;
     }
 
-    prio0_interface_.clear();
-    prio1_interface_.clear();
-
-    // Priority 0: restart, reset etc.
-    prio0_interface_.push_back(cosmo::util::ToLower("dologin"));
-    prio0_interface_.push_back(cosmo::util::ToLower("ResetSystem"));
-
-    // Priority 1: non-blocking or debug
-    prio1_interface_.push_back(cosmo::util::ToLower("ThreadDebugInfo"));
-    prio1_interface_.push_back(cosmo::util::ToLower("QueryDeviceInfo"));
-    is_accepting_ = true;
+    msg_handler_threads_.swap(candidate_threads);
+    is_accepting_.store(true, std::memory_order_release);
     return true;
 }
 
 void HttpServerThreadPool::Uninitialize() {
-    is_accepting_ = false;
-    if (!msg_handler_threads_.empty()) {
-        for (int idx = 0; idx < thread_num_; ++idx) {
-            msg_handler_threads_[idx]->DrainAndStop();
-        }
-
-        msg_handler_threads_.clear();
+    is_accepting_.store(false, std::memory_order_release);
+    for (auto& handler_thread : msg_handler_threads_) {
+        handler_thread->DrainAndStop();
     }
+    msg_handler_threads_.clear();
 }
 
-int HttpServerThreadPool::MsgInPrioIndex(cosmo::MsgEnvelope& msg) {
-    int nIdx    = -1;
-    auto* ptask = static_cast<HttpReqTask*>(msg.GetData());
-    if (!ptask) {
-        return nIdx;
+std::optional<std::size_t> HttpServerThreadPool::MsgInPrioIndex(const cosmo::MsgEnvelope& msg) const {
+    const auto* task = static_cast<const HttpReqTask*>(msg.GetData());
+    if (task == nullptr) {
+        return std::nullopt;
     }
 
-    auto interface = cosmo::util::ToLower(ptask->interface);
-    for (auto& prioInterface : prio0_interface_) {
-        if (std::string::npos != interface.find(prioInterface)) {
-            return 0;
+    const auto interface = cosmo::util::ToLower(task->interface);
+    for (const auto* priority_interface : kPriority0Interfaces) {
+        if (interface.find(priority_interface) != std::string::npos) {
+            return kPriority0WorkerIndex;
         }
     }
-    for (auto& prioInterface : prio1_interface_) {
-        if (std::string::npos != interface.find(prioInterface)) {
-            return 1;
+    for (const auto* priority_interface : kPriority1Interfaces) {
+        if (interface.find(priority_interface) != std::string::npos) {
+            return kPriority1WorkerIndex;
         }
     }
-    return nIdx;
+    return std::nullopt;
 }
 
 int HttpServerThreadPool::PutMsg(cosmo::MsgEnvelope&& msg) {
-    if (!is_accepting_ || msg_handler_threads_.empty())
+    if (!is_accepting_.load(std::memory_order_acquire) || msg_handler_threads_.size() < kMinimumThreadCount) {
         return -1;
+    }
 
-    size_t minMsgCount = std::numeric_limits<size_t>::max();
-    int nIdx           = MsgInPrioIndex(msg);
-    if (nIdx < 0) {
-        for (int idx = 2; idx < thread_num_; ++idx) {
-            auto msgCount = msg_handler_threads_[idx]->MsgCount();
-            if (minMsgCount > msgCount) {
-                minMsgCount = msgCount;
-                nIdx        = idx;
+    std::size_t handler_index = kNormalWorkerBegin;
+    std::size_t min_msg_count = std::numeric_limits<std::size_t>::max();
+    if (const auto priority_index = MsgInPrioIndex(msg)) {
+        handler_index = *priority_index;
+        min_msg_count = msg_handler_threads_[handler_index]->MsgCount();
+    } else {
+        for (std::size_t index = kNormalWorkerBegin; index < msg_handler_threads_.size(); ++index) {
+            const auto msg_count = msg_handler_threads_[index]->MsgCount();
+            if (min_msg_count > msg_count) {
+                min_msg_count = msg_count;
+                handler_index = index;
             }
 
-            if (0 == minMsgCount) {
+            if (min_msg_count == 0) {
                 break;
             }
         }
-    } else {
-        minMsgCount = msg_handler_threads_[nIdx]->MsgCount();
     }
 
-    LOG_INFO("PutMsg To Http Pool {}, This Pool Have {} Tasks in Queue", nIdx, minMsgCount);
-    return msg_handler_threads_[nIdx]->Put(std::move(msg));
+    LOG_INFO("PutMsg To Http Pool {}, This Pool Have {} Tasks in Queue", handler_index, min_msg_count);
+    return msg_handler_threads_[handler_index]->Put(std::move(msg));
 }
 
 }  // namespace cosmo::network::http

--- a/src/network/http/HttpServerThreadPool.h
+++ b/src/network/http/HttpServerThreadPool.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <functional>
 #include <memory>
-#include <string>
+#include <optional>
 #include <vector>
 
 #include "network/msg/MsgEnvelope.h"
@@ -20,7 +21,7 @@ public:
 
     using DispatcherFactory = std::function<std::unique_ptr<cosmo::IRequestDispatcher>()>;
 
-    // Initialize thread pool
+    // Initialize at least three workers. HttpServer serializes lifecycle calls with PutMsg().
     bool Initialize(int thread_num, HttpServer* server, DispatcherFactory factory);
 
     // Shutdown thread pool
@@ -30,13 +31,10 @@ public:
     int PutMsg(cosmo::MsgEnvelope&& msg);
 
 private:
-    int MsgInPrioIndex(cosmo::MsgEnvelope& msg);
+    std::optional<std::size_t> MsgInPrioIndex(const cosmo::MsgEnvelope& msg) const;
+
     std::vector<std::unique_ptr<MsgHanderThread>> msg_handler_threads_;
     std::atomic<bool> is_accepting_{false};
-    int thread_num_     = 4;
-    int cur_thread_idx_ = -1;
-    std::vector<std::string> prio0_interface_;
-    std::vector<std::string> prio1_interface_;
 };
 
 }  // namespace cosmo::network::http

--- a/test/test_http_server_lifetime.cc
+++ b/test/test_http_server_lifetime.cc
@@ -2,6 +2,8 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <array>
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <csignal>
@@ -10,6 +12,8 @@
 #include <fstream>
 #include <memory>
 #include <mutex>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <utility>
@@ -17,6 +21,7 @@
 
 #include "catch_amalgamated.hpp"
 #include "network/http/HttpServer.h"
+#include "network/http/HttpServerThreadPool.h"
 #include "nlohmann/json.hpp"
 #include "util/ErrorCode.h"
 #include "util/IRequestDispatcher.h"
@@ -140,6 +145,102 @@ namespace {
     private:
         std::shared_ptr<BlockingDispatchState> state_;
     };
+
+    struct DispatcherProbe {
+        std::atomic<int> live_count{0};
+        std::atomic<int> dispatch_count{0};
+        std::array<int, 5> dispatch_count_by_instance{};
+    };
+
+    class CountingDispatcher final : public cosmo::IRequestDispatcher {
+    public:
+        explicit CountingDispatcher(std::shared_ptr<DispatcherProbe> probe,
+                                    std::optional<std::size_t> instance_index = std::nullopt)
+            : probe_(std::move(probe)), instance_index_(instance_index) {
+            probe_->live_count.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        ~CountingDispatcher() override {
+            probe_->live_count.fetch_sub(1, std::memory_order_relaxed);
+        }
+
+        bool SupportsRoute(const std::string& /*interface*/) override {
+            return true;
+        }
+
+        cosmo::RequestAdmission InspectRequest(cosmo::RequestDispatchContext& context,
+                                               bool /*require_known_route*/) override {
+            context.principal = "thread-pool-test";
+            return cosmo::RequestAdmission::kAllowed;
+        }
+
+        bool DispatchRequest(const cosmo::RequestDispatchContext& /*context*/, const std::string& /*body*/,
+                             std::string& response) override {
+            probe_->dispatch_count.fetch_add(1, std::memory_order_relaxed);
+            if (instance_index_ && *instance_index_ < probe_->dispatch_count_by_instance.size()) {
+                ++probe_->dispatch_count_by_instance[*instance_index_];
+            }
+            response = R"({"ok":true})";
+            return true;
+        }
+
+    private:
+        std::shared_ptr<DispatcherProbe> probe_;
+        std::optional<std::size_t> instance_index_;
+    };
+
+    class CopyThrowingDispatcherFactory {
+    public:
+        CopyThrowingDispatcherFactory(std::shared_ptr<DispatcherProbe> probe,
+                                      std::shared_ptr<std::atomic<bool>> should_throw)
+            : probe_(std::move(probe)), should_throw_(std::move(should_throw)) {}
+
+        CopyThrowingDispatcherFactory(const CopyThrowingDispatcherFactory& other)
+            : probe_(other.probe_), should_throw_(other.should_throw_) {
+            if (should_throw_->load(std::memory_order_relaxed)) {
+                throw std::runtime_error("dispatcher factory copy failure");
+            }
+        }
+
+        CopyThrowingDispatcherFactory(CopyThrowingDispatcherFactory&&) noexcept        = default;
+        CopyThrowingDispatcherFactory& operator=(const CopyThrowingDispatcherFactory&) = delete;
+        CopyThrowingDispatcherFactory& operator=(CopyThrowingDispatcherFactory&&)      = delete;
+
+        std::unique_ptr<cosmo::IRequestDispatcher> operator()() const {
+            return std::make_unique<CountingDispatcher>(probe_);
+        }
+
+    private:
+        std::shared_ptr<DispatcherProbe> probe_;
+        std::shared_ptr<std::atomic<bool>> should_throw_;
+    };
+
+    HttpServerThreadPool::DispatcherFactory MakeCountingDispatcherFactory(
+        const std::shared_ptr<DispatcherProbe>& probe, std::size_t* call_count = nullptr) {
+        return [probe, call_count]() -> std::unique_ptr<cosmo::IRequestDispatcher> {
+            std::optional<std::size_t> instance_index;
+            if (call_count != nullptr) {
+                instance_index = (*call_count)++;
+            }
+            return std::make_unique<CountingDispatcher>(probe, instance_index);
+        };
+    }
+
+    HttpServerCallbacks MakeThreadPoolTestCallbacks() {
+        return {
+            []() { return std::string("/tmp"); },
+            []() { return std::string("/tmp"); },
+            []() { return std::string("/tmp"); },
+        };
+    }
+
+    cosmo::MsgEnvelope MakeHttpRequestMessage(std::string interface) {
+        auto task          = std::make_unique<HttpReqTask>();
+        task->request_time = std::chrono::steady_clock::now();
+        task->interface    = std::move(interface);
+        task->mtk          = "thread-pool-token";
+        return {static_cast<int>(InnerMsgId::kHttpReq), std::move(task)};
+    }
 
     class ReleaseGuard {
     public:
@@ -346,6 +447,162 @@ namespace {
     }
 
 }  // namespace
+
+TEST_CASE("HttpServerThreadPool rejects invalid initialization inputs",
+          "[http-server][thread-pool][lifecycle]") {
+    HttpServer server;
+    HttpServerThreadPool thread_pool;
+    auto probe               = std::make_shared<DispatcherProbe>();
+    std::size_t call_count   = 0;
+    const auto valid_factory = MakeCountingDispatcherFactory(probe, &call_count);
+
+    for (const int thread_count : {-1, 0, 1, 2}) {
+        CAPTURE(thread_count);
+        CHECK_FALSE(thread_pool.Initialize(thread_count, &server, valid_factory));
+    }
+    CHECK(call_count == 0);
+    CHECK_FALSE(thread_pool.Initialize(3, nullptr, valid_factory));
+    CHECK(call_count == 0);
+    CHECK_FALSE(thread_pool.Initialize(3, &server, HttpServerThreadPool::DispatcherFactory{}));
+    CHECK(call_count == 0);
+
+    CHECK_NOTHROW(thread_pool.Uninitialize());
+    CHECK_NOTHROW(thread_pool.Uninitialize());
+    CHECK(probe->live_count.load(std::memory_order_relaxed) == 0);
+}
+
+TEST_CASE("HttpServerThreadPool rolls back dispatcher factory failures",
+          "[http-server][thread-pool][lifecycle]") {
+    for (const bool should_throw : {false, true}) {
+        for (std::size_t failure_index = 0; failure_index < 3; ++failure_index) {
+            CAPTURE(should_throw, failure_index);
+            HttpServer server;
+            HttpServerThreadPool thread_pool;
+            auto probe             = std::make_shared<DispatcherProbe>();
+            std::size_t call_count = 0;
+            HttpServerThreadPool::DispatcherFactory failing_factory =
+                [probe, &call_count, failure_index,
+                 should_throw]() -> std::unique_ptr<cosmo::IRequestDispatcher> {
+                const auto current_index = call_count++;
+                if (current_index == failure_index) {
+                    if (should_throw) {
+                        throw std::runtime_error("dispatcher factory failure");
+                    }
+                    return nullptr;
+                }
+                return std::make_unique<CountingDispatcher>(probe);
+            };
+
+            CHECK_FALSE(thread_pool.Initialize(3, &server, std::move(failing_factory)));
+            CHECK(call_count == failure_index + 1);
+            CHECK(probe->live_count.load(std::memory_order_relaxed) == 0);
+            auto rejected_message = MakeHttpRequestMessage("/normal");
+            CHECK(thread_pool.PutMsg(std::move(rejected_message)) == -1);
+            CHECK_NOTHROW(thread_pool.Uninitialize());
+
+            REQUIRE(thread_pool.Initialize(3, &server, MakeCountingDispatcherFactory(probe)));
+            CHECK(probe->live_count.load(std::memory_order_relaxed) == 3);
+            thread_pool.Uninitialize();
+            CHECK(probe->live_count.load(std::memory_order_relaxed) == 0);
+        }
+    }
+}
+
+TEST_CASE("HttpServerThreadPool preserves active workers and drains accepted requests",
+          "[http-server][thread-pool][lifecycle]") {
+    constexpr std::array<const char*, 5> kInterfaces = {"/normal", "/api/dologin", "/api/ResetSystem",
+                                                        "/api/ThreadDebugInfo", "/api/QueryDeviceInfo"};
+
+    for (const int thread_count : {3, 4}) {
+        CAPTURE(thread_count);
+        HttpServer server;
+        HttpServerThreadPool thread_pool;
+        auto probe             = std::make_shared<DispatcherProbe>();
+        std::size_t call_count = 0;
+        const auto factory     = MakeCountingDispatcherFactory(probe, &call_count);
+
+        REQUIRE(thread_pool.Initialize(thread_count, &server, factory));
+        CHECK(probe->live_count.load(std::memory_order_relaxed) == thread_count);
+        CHECK(call_count == static_cast<std::size_t>(thread_count));
+
+        CHECK_FALSE(thread_pool.Initialize(thread_count, &server, factory));
+        CHECK(call_count == static_cast<std::size_t>(thread_count));
+
+        for (const auto* interface : kInterfaces) {
+            auto message = MakeHttpRequestMessage(interface);
+            REQUIRE(thread_pool.PutMsg(std::move(message)) >= 0);
+        }
+
+        CHECK_NOTHROW(thread_pool.Uninitialize());
+        CHECK(probe->dispatch_count.load(std::memory_order_relaxed) == static_cast<int>(kInterfaces.size()));
+        CHECK(probe->dispatch_count_by_instance[0] == 2);
+        CHECK(probe->dispatch_count_by_instance[1] == 2);
+        CHECK(probe->dispatch_count_by_instance[2] == 1);
+        if (thread_count == 4) {
+            CHECK(probe->dispatch_count_by_instance[3] == 0);
+        }
+        CHECK(probe->live_count.load(std::memory_order_relaxed) == 0);
+        CHECK_NOTHROW(thread_pool.Uninitialize());
+    }
+}
+
+TEST_CASE("HttpServer releases resources after worker dispatcher construction fails",
+          "[http-server][thread-pool][lifecycle]") {
+    auto port = FindAvailablePort();
+    REQUIRE(port != 0);
+
+    HttpServer server;
+    auto failing_probe                 = std::make_shared<DispatcherProbe>();
+    std::size_t call_count             = 0;
+    constexpr std::size_t kFailureCall = 2;
+    HttpServer::DispatcherFactory failing_factory =
+        [failing_probe, &call_count]() -> std::unique_ptr<cosmo::IRequestDispatcher> {
+        const auto current_call = call_count++;
+        if (current_call == kFailureCall) {
+            throw std::runtime_error("worker dispatcher construction failure");
+        }
+        return std::make_unique<CountingDispatcher>(failing_probe);
+    };
+
+    CHECK_FALSE(
+        server.Initialize("127.0.0.1", port, std::move(failing_factory), MakeThreadPoolTestCallbacks()));
+    CHECK(call_count == kFailureCall + 1);
+    CHECK(failing_probe->live_count.load(std::memory_order_relaxed) == 0);
+
+    auto valid_probe = std::make_shared<DispatcherProbe>();
+    REQUIRE(server.Initialize("127.0.0.1", port, MakeCountingDispatcherFactory(valid_probe),
+                              MakeThreadPoolTestCallbacks()));
+    CHECK(valid_probe->live_count.load(std::memory_order_relaxed) == 5);
+    CHECK_NOTHROW(server.UnInitialize());
+    CHECK(valid_probe->live_count.load(std::memory_order_relaxed) == 0);
+    CHECK_NOTHROW(server.UnInitialize());
+}
+
+TEST_CASE("HttpServer releases resources when the worker dispatcher factory copy throws",
+          "[http-server][thread-pool][lifecycle]") {
+    auto port = FindAvailablePort();
+    REQUIRE(port != 0);
+
+    HttpServer server;
+    auto failing_probe = std::make_shared<DispatcherProbe>();
+    auto should_throw  = std::make_shared<std::atomic<bool>>(false);
+    HttpServer::DispatcherFactory failing_factory =
+        CopyThrowingDispatcherFactory(failing_probe, should_throw);
+    should_throw->store(true, std::memory_order_relaxed);
+
+    bool is_initialized = true;
+    REQUIRE_NOTHROW(is_initialized = server.Initialize("127.0.0.1", port, std::move(failing_factory),
+                                                       MakeThreadPoolTestCallbacks()));
+    CHECK_FALSE(is_initialized);
+    CHECK(failing_probe->live_count.load(std::memory_order_relaxed) == 0);
+
+    auto valid_probe = std::make_shared<DispatcherProbe>();
+    REQUIRE(server.Initialize("127.0.0.1", port, MakeCountingDispatcherFactory(valid_probe),
+                              MakeThreadPoolTestCallbacks()));
+    CHECK(valid_probe->live_count.load(std::memory_order_relaxed) == 5);
+    CHECK_NOTHROW(server.UnInitialize());
+    CHECK(valid_probe->live_count.load(std::memory_order_relaxed) == 0);
+}
 
 TEST_CASE("HttpServer keeps libevent requests on the event thread during shutdown", "[http-server][thread]") {
     ScopedSignalIgnore ignore_sigpipe(SIGPIPE);


### PR DESCRIPTION
## Summary

Make `HttpServerThreadPool` initialization transactional, reject invalid lifecycle inputs, preserve active workers on duplicate initialization, and drain accepted work safely during shutdown. Add focused lifecycle/rollback coverage for pool and server initialization.

## Related issue

Closes #90

## Root cause

The pool previously wrote candidate workers directly into live member state, assumed worker indices 0/1/2 existed without enforcing a minimum size, and did not fully guard null/throwing dispatcher factories or duplicate initialization.

## Scope

### In scope

- Validate thread count, server pointer, dispatcher factory, and dispatcher results.
- Build and start all workers transactionally before publishing the pool.
- Make shutdown idempotent and use actual worker-vector bounds.
- Preserve priority routing and public method signatures.
- Roll back HTTP event resources after dispatcher construction/copy failures.
- Add thread-pool and server lifecycle tests.

### Out of scope

- File transfer, multipart behavior, `HttpPost`, `MsgThread`, or `util::Thread`.
- HTTP protocol/response changes and public type renames.

## Risk tags

- [x] Runtime / lifecycle
- [x] Thread / memory safety
- [x] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build / deployment
- [x] Refactor
- [x] Test

## Area

- [x] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [x] API / MQTT / WebSocket
- [ ] Media / streaming
- [ ] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `17cdd2e39f8ecc1164db986cd2c8e6f0a10cc393`
- Candidate commit: `7f6348e46d0bb76fd790c05efdff6e550afac8da`
- Candidate tree: `8899be440e83fdfa38f100b3090ceb852140c1f9`
- Package SHA-256: `d7021b10edb8f919445725704cd5eb1a8a85dbea3435aea507dae9cab1489485`
- Test binary SHA-256: `9ac2c4e833dc6be26f46147567e1cabc9a7a6b6383ef6416fe06b1b76b06dcd8`

The candidate was not amended, rebased, merged, or changed after evidence collection.

## Verification

### Parent baseline

```text
BLOCKED for exact regression attribution: the parent does not contain the new fault-injection cases.
Base identity and pre-change failure paths are recorded in #90.
```

### Candidate checks

```text
PASS clang-format 18.1.3 read-only check on all 4 changed files
PASS git diff --check
PASS cppcheck on all 4 changed files; only 3 existing warnings outside changed lines
PASS docker-compose -f docker-compose.sophon.yml run --rm cosmo-sophon-package
PASS cosmo-tests "[http-server][thread-pool]" — 5 cases, 112 assertions
PASS cosmo-tests "[http-server][lifecycle]" — 6 cases, 122 assertions
PASS cosmo-tests "[http-server][thread]" — 2 cases, 18 assertions
PASS default cosmo-tests — 884 cases: 883 passed, 1 declared host-backed-frame skip; 11872/11872 assertions passed
PASS hidden network — 2/2 cases, 2/2 assertions
PASS hidden device excluding WatchDogService — 20/20 cases, 88/88 assertions
N/A WatchDogService hidden start/stop — separate L3 required-for-release window, not part of this core delivery
```

### Risk-based evidence

- API/network: invalid input, authentication/error routing, same-port retry, event-thread shutdown, and thread-pool lifecycle tests passed.
- Media/streaming: not changed.
- Sophon/device: validated on an authorized BM1688/aarch64 device using the packaged runtime.
- Frontend/UI: not changed.
- Package/deployment: candidate engine SHA-256 `4f21dfa754d8ac2760579469bc794ee96812aa7fe2592c79f46d5ac07d8bf716`; matching Guard SHA-256 `05ea6d203f1ec536b638d6467ffc61eb44c9bbf0494696482c6d9010f53d7b6d`.

Real deployment smoke:

1. Engine-only compatibility probe correctly exposed the device old-Guard ABI mismatch; the original engine was immediately restored.
2. Engine and matching Guard from the same candidate package were deployed with independent backups.
3. First startup reached `active`; root page and anonymous Probe returned HTTP 200 through direct and nginx paths with baseline-identical response hashes.
4. Graceful stop closed ports 80/8000 in about 1.52 seconds; logs confirmed `MsgHanderThread_0` through `_3` stopped.
5. Second startup reached `active`, `NRestarts=0`, started all four handlers, and repeated direct/proxy HTTP 200 responses with no fatal startup log.
6. Second graceful stop again logged all four handler exits. Original engine and Guard link were restored; service returned to `active`, `NRestarts=0`, baseline hashes and HTTP responses matched, and boot ID was unchanged.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this internal lifecycle correction.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] No new dependencies were added.
- [x] Documentation impact was reviewed.
- [x] The commit is signed off.
- [x] `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` requirements were followed.

## Acceptance and cleanup

- Candidate-bound acceptance: `验证通过 7f6348e46d0bb76fd790c05efdff6e550afac8da d7021b10edb8f919445725704cd5eb1a8a85dbea3435aea507dae9cab1489485`
- Device test filter: default + `[.network]~[device]` + `[.device]~[WatchDogService]`
- Device backup state: restored and temporary backups removed
- Temporary-data cleanup: complete; uploaded tests/runtime and run directory removed
- Final Git status: clean
- [x] Evidence was collected from the candidate commit listed above.
- [x] No source change occurred after validation.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

`util::Thread::start()` registration behavior on a low-level `std::thread` construction exception remains explicitly out of scope. The pool structure still rolls back every worker object it owns.

