### PR TITLE
fix(http): propagate client transfer failures

### DIFF
--- a/src/network/http/HttpPost.cc
+++ b/src/network/http/HttpPost.cc
@@ -166,7 +166,7 @@ void HttpPost::AppendData(const std::string& key, const std::string& value) {
 
 long HttpPost::Submit() {
     http_post_.SetData(data_);
-    return http_post_.Submit();
+    return http_post_.Submit(HttpRequestMethod::kPost);
 }
 
 std::string HttpPost::GetContentType() const {

--- a/src/network/http/HttpRequest.cc
+++ b/src/network/http/HttpRequest.cc
@@ -34,28 +34,32 @@ struct HttpRequest::MimePart {
     }
 };
 
-const char* GetMethodString(HttpRequestMethod method) {
-    switch (method) {
-        case HttpRequestMethod::kGet:
-            return "GET";
-        case HttpRequestMethod::kPost:
-            return "POST";
-        case HttpRequestMethod::kPut:
-            return "PUT";
-        case HttpRequestMethod::kDelete:
-            return "DELETE";
-        case HttpRequestMethod::kConnect:
-            return "CONNECT";
-        case HttpRequestMethod::kOptions:
-            return "OPTIONS";
-        case HttpRequestMethod::kTrace:
-            return "TRACE";
-        case HttpRequestMethod::kPatch:
-            return "PATCH";
-        default:
-            return nullptr;
+namespace {
+
+    const char* GetMethodString(HttpRequestMethod method) {
+        switch (method) {
+            case HttpRequestMethod::kGet:
+                return "GET";
+            case HttpRequestMethod::kPost:
+                return "POST";
+            case HttpRequestMethod::kPut:
+                return "PUT";
+            case HttpRequestMethod::kDelete:
+                return "DELETE";
+            case HttpRequestMethod::kConnect:
+                return "CONNECT";
+            case HttpRequestMethod::kOptions:
+                return "OPTIONS";
+            case HttpRequestMethod::kTrace:
+                return "TRACE";
+            case HttpRequestMethod::kPatch:
+                return "PATCH";
+            default:
+                return nullptr;
+        }
     }
-}
+
+}  // namespace
 
 HttpRequest::HttpRequest(const std::string& url, HttpRequestHandler& resultHandler)
     : HttpRequest(url, &resultHandler) {}
@@ -64,10 +68,8 @@ HttpRequest::HttpRequest(const std::string& url, HttpRequestHandler* result_hand
     : url_(url),
       post_content_type_("text/plain"),
       result_handler_(result_handler),
-      status_(0),
       timeout_(10L),
-      connect_timeout_(10L),
-      follow_location_(1L) {}
+      connect_timeout_(10L) {}
 
 HttpRequest::~HttpRequest() = default;
 
@@ -142,8 +144,89 @@ const std::string& HttpRequest::GetContentType() const {
 }
 
 namespace {
+    constexpr long kFollowLocation = 1L;
+    constexpr long kMaxRedirects   = 5L;
+
+    bool CurlSucceeded(CURLcode result, const char* operation) {
+        if (result == CURLE_OK) {
+            return true;
+        }
+        LOG_ERRO("{} failed: [{}]", operation, curl_easy_strerror(result));
+        return false;
+    }
+
+    template <typename Value>
+    bool SetCurlOption(CURL* curl, CURLoption option, Value value, const char* option_name) {
+        return CurlSucceeded(curl_easy_setopt(curl, option, value), option_name);
+    }
+
+    template <typename Value>
+    bool GetCurlInfo(CURL* curl, CURLINFO info, Value* value, const char* info_name) {
+        return CurlSucceeded(curl_easy_getinfo(curl, info, value), info_name);
+    }
+
+    class CurlHeaderList {
+    public:
+        CurlHeaderList() = default;
+
+        ~CurlHeaderList() {
+            curl_slist_free_all(headers_);
+        }
+
+        CurlHeaderList(const CurlHeaderList&)            = delete;
+        CurlHeaderList& operator=(const CurlHeaderList&) = delete;
+
+        bool Append(const std::string& header) {
+            auto* updated = curl_slist_append(headers_, header.c_str());
+            if (updated == nullptr) {
+                LOG_ERRO("{}", "curl_slist_append failed");
+                return false;
+            }
+            headers_ = updated;
+            return true;
+        }
+
+        curl_slist* Get() const {
+            return headers_;
+        }
+
+    private:
+        curl_slist* headers_{nullptr};
+    };
+
+    bool ConfigureRequestMethod(CURL* curl, HttpRequestMethod method, bool has_body) {
+        switch (method) {
+            case HttpRequestMethod::kUnspecified:
+                return true;
+            case HttpRequestMethod::kGet:
+                if (!has_body) {
+                    return SetCurlOption(curl, CURLOPT_HTTPGET, 1L, "CURLOPT_HTTPGET");
+                }
+                return SetCurlOption(curl, CURLOPT_CUSTOMREQUEST, "GET", "CURLOPT_CUSTOMREQUEST");
+            case HttpRequestMethod::kPost:
+                if (has_body) {
+                    return true;
+                }
+                return SetCurlOption(curl, CURLOPT_POST, 1L, "CURLOPT_POST") &&
+                       SetCurlOption(curl, CURLOPT_POSTFIELDS, "", "CURLOPT_POSTFIELDS") &&
+                       SetCurlOption(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(0),
+                                     "CURLOPT_POSTFIELDSIZE_LARGE");
+            default: {
+                const auto* method_name = GetMethodString(method);
+                if (method_name == nullptr) {
+                    LOG_ERRO("{}", "Unsupported HTTP request method");
+                    return false;
+                }
+                return SetCurlOption(curl, CURLOPT_CUSTOMREQUEST, method_name, "CURLOPT_CUSTOMREQUEST");
+            }
+        }
+    }
+
     size_t PostCallback(char* ptr, size_t size, size_t nmemb, void* data) {
-        auto len = size * nmemb;
+        if (size != 0 && nmemb > std::numeric_limits<size_t>::max() / size) {
+            return 0;
+        }
+        const auto len = size * nmemb;
         if (!data) {
             LOG_INFO("{}", "curl callback data is NULL");
             return len;
@@ -160,9 +243,9 @@ void HttpRequest::SetContentType(const std::string& contentType) {
 }
 
 long HttpRequest::Submit(HttpRequestMethod method) {
-    CURL* curl = curl_easy_init();
-    [[maybe_unused]] std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> curl_easy_init_ptr(
-        curl, curl_easy_cleanup);
+    result_content_type_.clear();
+    std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> curl_handle(curl_easy_init(), curl_easy_cleanup);
+    auto* curl = curl_handle.get();
     if (!curl) {
         LOG_ERRO("{}", "curl easy init fail");
         return -1;
@@ -172,109 +255,98 @@ long HttpRequest::Submit(HttpRequestMethod method) {
         return -1;
     }
 
-    CURLcode res = curl_easy_setopt(curl, CURLOPT_URL, url_.c_str());
-    if (res != CURLE_OK) {
-        LOG_ERRO("CURLOPT_URL fail : [{}]", curl_easy_strerror(res));
+    if (!SetCurlOption(curl, CURLOPT_URL, url_.c_str(), "CURLOPT_URL") ||
+        !SetCurlOption(curl, CURLOPT_WRITEFUNCTION, PostCallback, "CURLOPT_WRITEFUNCTION") ||
+        !SetCurlOption(curl, CURLOPT_WRITEDATA, result_handler_, "CURLOPT_WRITEDATA") ||
+        !SetCurlOption(curl, CURLOPT_IPRESOLVE, static_cast<long>(CURL_IPRESOLVE_V4), "CURLOPT_IPRESOLVE") ||
+        !SetCurlOption(curl, CURLOPT_CONNECTTIMEOUT, connect_timeout_, "CURLOPT_CONNECTTIMEOUT") ||
+        !SetCurlOption(curl, CURLOPT_TIMEOUT, timeout_, "CURLOPT_TIMEOUT") ||
+        !SetCurlOption(curl, CURLOPT_VERBOSE, 0L, "CURLOPT_VERBOSE") ||
+        !SetCurlOption(curl, CURLOPT_FOLLOWLOCATION, kFollowLocation, "CURLOPT_FOLLOWLOCATION") ||
+        !SetCurlOption(curl, CURLOPT_MAXREDIRS, kMaxRedirects, "CURLOPT_MAXREDIRS") ||
+        !SetCurlOption(curl, CURLOPT_NOSIGNAL, 1L, "CURLOPT_NOSIGNAL")) {
         return -1;
     }
-
-    res = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, PostCallback);
-    if (res != CURLE_OK) {
-        LOG_ERRO("CURLOPT_WRITEFUNCTION fail : [{}]", curl_easy_strerror(res));
-        return -1;
-    }
-
-    res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, result_handler_);
-    if (res != CURLE_OK) {
-        LOG_ERRO("CURLOPT_WRITEDATA fail : [{}]", curl_easy_strerror(res));
-        return -1;
-    }
-
-    auto method_str = GetMethodString(method);
-    if (method_str != nullptr) {
-        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method_str);
-    }
-
-    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, connect_timeout_);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_);
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, 0L);
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, follow_location_);
-    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 
 #if LIBCURL_VERSION_NUM >= 0x075500
-    res = curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https");
-#else
-    res = curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-#endif
-    if (res != CURLE_OK) {
-        LOG_ERRO("Failed to restrict request protocols: [{}]", curl_easy_strerror(res));
+    if (!SetCurlOption(curl, CURLOPT_PROTOCOLS_STR, "http,https", "CURLOPT_PROTOCOLS_STR")) {
         return -1;
     }
-#if LIBCURL_VERSION_NUM >= 0x075500
-    res = curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
 #else
-    res = curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+    if (!SetCurlOption(curl, CURLOPT_PROTOCOLS, static_cast<long>(CURLPROTO_HTTP | CURLPROTO_HTTPS),
+                       "CURLOPT_PROTOCOLS")) {
+        return -1;
+    }
 #endif
-    if (res != CURLE_OK) {
-        LOG_ERRO("Failed to restrict redirect protocols: [{}]", curl_easy_strerror(res));
+#if LIBCURL_VERSION_NUM >= 0x075500
+    if (!SetCurlOption(curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https", "CURLOPT_REDIR_PROTOCOLS_STR")) {
+        return -1;
+    }
+#else
+    if (!SetCurlOption(curl, CURLOPT_REDIR_PROTOCOLS, static_cast<long>(CURLPROTO_HTTP | CURLPROTO_HTTPS),
+                       "CURLOPT_REDIR_PROTOCOLS")) {
+        return -1;
+    }
+#endif
+
+    if (!SetCurlOption(curl, CURLOPT_SSL_VERIFYPEER, 1L, "CURLOPT_SSL_VERIFYPEER") ||
+        !SetCurlOption(curl, CURLOPT_SSL_VERIFYHOST, 2L, "CURLOPT_SSL_VERIFYHOST")) {
+        return -1;
+    }
+    if (!ca_bundle_path_.empty() &&
+        !SetCurlOption(curl, CURLOPT_CAINFO, ca_bundle_path_.c_str(), "CURLOPT_CAINFO")) {
         return -1;
     }
 
-    res = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
-    if (res != CURLE_OK) {
-        LOG_ERRO("CURLOPT_SSL_VERIFYPEER fail : [{}]", curl_easy_strerror(res));
+    if (!interface_name_.empty() &&
+        !SetCurlOption(curl, CURLOPT_INTERFACE, interface_name_.c_str(), "CURLOPT_INTERFACE")) {
         return -1;
     }
-    res = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
-    if (res != CURLE_OK) {
-        LOG_ERRO("CURLOPT_SSL_VERIFYHOST fail : [{}]", curl_easy_strerror(res));
-        return -1;
+
+    std::string proxy_credentials;
+    if (!proxy_.empty()) {
+        if (!SetCurlOption(curl, CURLOPT_PROXY, proxy_.c_str(), "CURLOPT_PROXY") ||
+            !SetCurlOption(curl, CURLOPT_PROXYTYPE, static_cast<long>(CURLPROXY_HTTP), "CURLOPT_PROXYTYPE") ||
+            !SetCurlOption(curl, CURLOPT_HTTPPROXYTUNNEL, 1L, "CURLOPT_HTTPPROXYTUNNEL")) {
+            return -1;
+        }
+        if (!proxy_username_.empty()) {
+            proxy_credentials = proxy_username_ + ":" + proxy_password_;
+            if (!SetCurlOption(curl, CURLOPT_PROXYUSERPWD, proxy_credentials.c_str(),
+                               "CURLOPT_PROXYUSERPWD")) {
+                return -1;
+            }
+        }
     }
-    if (!ca_bundle_path_.empty()) {
-        res = curl_easy_setopt(curl, CURLOPT_CAINFO, ca_bundle_path_.c_str());
-        if (res != CURLE_OK) {
-            LOG_ERRO("CURLOPT_CAINFO fail : [{}]", curl_easy_strerror(res));
+
+    CurlHeaderList headers;
+    if (!data_.empty() && mime_parts_.empty()) {
+        if (!headers.Append("Content-Type: " + post_content_type_) ||
+            !headers.Append("Content-Length: " + std::to_string(data_.size()))) {
             return -1;
         }
     }
 
-    if (!interface_name_.empty()) {
-        curl_easy_setopt(curl, CURLOPT_INTERFACE, interface_name_.c_str());
-    }
-
-    if (!proxy_.empty()) {
-        curl_easy_setopt(curl, CURLOPT_PROXY, proxy_.c_str());
-        curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-        curl_easy_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
-        if (!proxy_username_.empty()) {
-            curl_easy_setopt(curl, CURLOPT_PROXYUSERPWD, (proxy_username_ + ":" + proxy_password_).c_str());
+    for (const auto& header : header_) {
+        if (!headers.Append(header)) {
+            return -1;
         }
     }
 
-    struct curl_slist* headers = nullptr;
-    if (!data_.empty() && mime_parts_.empty()) {
-        std::string type_header = "Content-Type: " + post_content_type_;
-        headers                 = curl_slist_append(headers, type_header.c_str());
-        std::string size_header = "Content-Length: " + std::to_string(data_.size());
-        headers                 = curl_slist_append(headers, size_header.c_str());
-    }
-
-    for (auto& header : header_) {
-        headers = curl_slist_append(headers, header.c_str());
-    }
-
-    [[maybe_unused]] std::unique_ptr<curl_slist, decltype(&curl_slist_free_all)> curl_header_free(
-        headers, curl_slist_free_all);
-    res = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    if (res != CURLE_OK) {
-        LOG_ERRO("CURLOPT_HTTPHEADER fail : [{}]", curl_easy_strerror(res));
+    if (!SetCurlOption(curl, CURLOPT_HTTPHEADER, headers.Get(), "CURLOPT_HTTPHEADER")) {
         return -1;
     }
     if (!data_.empty()) {
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data_.c_str());
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, data_.size());
+        if (static_cast<std::uintmax_t>(data_.size()) >
+            static_cast<std::uintmax_t>(std::numeric_limits<curl_off_t>::max())) {
+            LOG_ERRO("HTTP request body exceeds curl_off_t capacity: {} bytes", data_.size());
+            return -1;
+        }
+        if (!SetCurlOption(curl, CURLOPT_POSTFIELDS, data_.c_str(), "CURLOPT_POSTFIELDS") ||
+            !SetCurlOption(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(data_.size()),
+                           "CURLOPT_POSTFIELDSIZE_LARGE")) {
+            return -1;
+        }
     }
 
     std::unique_ptr<curl_mime, decltype(&curl_mime_free)> mime(nullptr, curl_mime_free);
@@ -331,50 +403,72 @@ long HttpRequest::Submit(HttpRequestMethod method) {
 
         for (const auto& part : mime_parts_) {
             curl_mimepart* curl_part = curl_mime_addpart(mime.get());
-            if (curl_part == nullptr || curl_mime_name(curl_part, part->name.c_str()) != CURLE_OK) {
+            if (curl_part == nullptr) {
+                LOG_ERRO("{}", "curl_mime_addpart failed");
+                return -1;
+            }
+            if (!CurlSucceeded(curl_mime_name(curl_part, part->name.c_str()), "curl_mime_name")) {
                 return -1;
             }
             if (part->fd >= 0) {
                 part->position = 0;
-                if (part->size > static_cast<std::uint64_t>(std::numeric_limits<curl_off_t>::max()) ||
-                    curl_mime_filename(curl_part, part->filename.c_str()) != CURLE_OK ||
-                    (!part->content_type.empty() &&
-                     curl_mime_type(curl_part, part->content_type.c_str()) != CURLE_OK) ||
-                    curl_mime_data_cb(curl_part, static_cast<curl_off_t>(part->size), read_file, seek_file,
-                                      nullptr, part.get()) != CURLE_OK) {
+                if (part->size > static_cast<std::uint64_t>(std::numeric_limits<curl_off_t>::max())) {
+                    LOG_ERRO("Multipart file exceeds curl_off_t capacity: {} bytes", part->size);
                     return -1;
                 }
-            } else if (curl_mime_data(curl_part, part->value.data(), part->value.size()) != CURLE_OK) {
+                if (!CurlSucceeded(curl_mime_filename(curl_part, part->filename.c_str()),
+                                   "curl_mime_filename") ||
+                    (!part->content_type.empty() &&
+                     !CurlSucceeded(curl_mime_type(curl_part, part->content_type.c_str()),
+                                    "curl_mime_type")) ||
+                    !CurlSucceeded(curl_mime_data_cb(curl_part, static_cast<curl_off_t>(part->size),
+                                                     read_file, seek_file, nullptr, part.get()),
+                                   "curl_mime_data_cb")) {
+                    return -1;
+                }
+            } else if (!CurlSucceeded(curl_mime_data(curl_part, part->value.data(), part->value.size()),
+                                      "curl_mime_data")) {
                 return -1;
             }
         }
-        if (curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime.get()) != CURLE_OK) {
+        if (!SetCurlOption(curl, CURLOPT_MIMEPOST, mime.get(), "CURLOPT_MIMEPOST")) {
             return -1;
         }
     }
 
-    res = curl_easy_perform(curl);
-    if (res != CURLE_OK) {
-        LOG_ERRO("curl perform fail : [{}]", curl_easy_strerror(res));
+    if (!ConfigureRequestMethod(curl, method, !data_.empty() || !mime_parts_.empty())) {
         return -1;
     }
 
-    if (result_handler_) {
-        result_handler_->Flush();
+    if (!CurlSucceeded(curl_easy_perform(curl), "curl_easy_perform")) {
+        return -1;
     }
 
-    char* ct = nullptr;
-    curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &ct);
-    if (ct) {
-        result_content_type_.assign(ct);
+    if (result_handler_ != nullptr && !result_handler_->Finalize()) {
+        LOG_ERRO("{}", "HTTP response handler finalization failed");
+        return -1;
     }
 
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_);
-    if (method_str)
-        LOG_INFO("HTTP Submit [{}][{}]", method_str, status_);
-    else
-        LOG_INFO("HTTP Submit [{}]", status_);
-    return status_;
+    char* content_type = nullptr;
+    if (!GetCurlInfo(curl, CURLINFO_CONTENT_TYPE, &content_type, "CURLINFO_CONTENT_TYPE")) {
+        return -1;
+    }
+    if (content_type != nullptr) {
+        result_content_type_.assign(content_type);
+    }
+
+    long status = 0;
+    if (!GetCurlInfo(curl, CURLINFO_RESPONSE_CODE, &status, "CURLINFO_RESPONSE_CODE")) {
+        return -1;
+    }
+
+    const auto* method_name = GetMethodString(method);
+    if (method_name != nullptr) {
+        LOG_INFO("HTTP Submit [{}][{}]", method_name, status);
+    } else {
+        LOG_INFO("HTTP Submit [{}]", status);
+    }
+    return status;
 }
 
 void HttpRequest::SetTimeout(long seconds) {

--- a/src/network/http/HttpRequest.h
+++ b/src/network/http/HttpRequest.h
@@ -69,10 +69,8 @@ private:
     HttpRequestHandler* result_handler_;
     std::vector<std::string> header_;
     std::vector<std::unique_ptr<MimePart>> mime_parts_;
-    long status_;
     long timeout_;
     long connect_timeout_;
-    long follow_location_;
 };
 
 }  // namespace cosmo::network::http

--- a/src/network/http/HttpRequestHandler.cc
+++ b/src/network/http/HttpRequestHandler.cc
@@ -2,9 +2,16 @@
 
 #include "network/http/HttpRequestHandler.h"
 
+#include <limits>
+
 #include "util/Log.h"
 
 namespace cosmo::network::http {
+
+bool HttpRequestHandler::Finalize() {
+    Flush();
+    return true;
+}
 
 size_t HttpStringHandler::AppendData(const char* data, size_t size) {
     if (size > max_size_ || data_.size() > max_size_ - size) {
@@ -18,15 +25,21 @@ size_t HttpStringHandler::AppendData(const char* data, size_t size) {
 HttpFileHandler::HttpFileHandler(const std::string& filename) : file_(filename) {}
 
 size_t HttpFileHandler::AppendData(const char* data, size_t size) {
-    if (file_.is_open()) {
-        file_.write(data, size);
-        return size;
+    if (!file_.is_open() || (data == nullptr && size != 0) ||
+        size > static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
+        return 0;
     }
-    return 0;
+    file_.write(data, static_cast<std::streamsize>(size));
+    return file_.good() ? size : 0;
 }
 
 void HttpFileHandler::Flush() {
     file_.flush();
+}
+
+bool HttpFileHandler::Finalize() {
+    Flush();
+    return file_.is_open() && file_.good();
 }
 
 size_t HttpImageHandler::AppendData(const char* data, size_t size) {

--- a/src/network/http/HttpRequestHandler.h
+++ b/src/network/http/HttpRequestHandler.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <fstream>
+#include <string>
 #include <vector>
 
 namespace cosmo::network::http {
@@ -18,6 +20,13 @@ public:
      * @return: flush buffered content
      */
     virtual void Flush() {};
+
+    /**
+     * Finalize the response sink after a completed transfer.
+     * Existing handlers remain compatible through the default Flush-based
+     * implementation.
+     */
+    virtual bool Finalize();
 };
 
 class HttpStringHandler : public HttpRequestHandler {
@@ -40,6 +49,7 @@ public:
     explicit HttpFileHandler(const std::string& filename);
     size_t AppendData(const char* data, size_t size) override;
     void Flush() override;
+    bool Finalize() override;
 
 private:
     std::ofstream file_;

--- a/src/service/network/impl/HttpClientImpl.cc
+++ b/src/service/network/impl/HttpClientImpl.cc
@@ -22,7 +22,7 @@ HttpResponse HttpClientImpl::Post(const std::string& url, const std::string& dat
     httpReq.SetTimeout(timeoutSec);
 
     HttpResponse response;
-    response.statusCode = httpReq.Submit();
+    response.statusCode = httpReq.Submit(cosmo::network::http::HttpRequestMethod::kPost);
     response.body       = handler.GetData();
     return response;
 }

--- a/test/LoopbackHttpServer.h
+++ b/test/LoopbackHttpServer.h
@@ -1,0 +1,213 @@
+#pragma once
+
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cerrno>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+namespace cosmo::test {
+
+class LoopbackHttpServer final {
+public:
+    LoopbackHttpServer() = default;
+
+    ~LoopbackHttpServer() {
+        CloseListener();
+    }
+
+    LoopbackHttpServer(const LoopbackHttpServer&)            = delete;
+    LoopbackHttpServer& operator=(const LoopbackHttpServer&) = delete;
+
+    bool Start() {
+        CloseListener();
+        listener_ = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        if (listener_ < 0) {
+            return false;
+        }
+
+        int reuse = 1;
+        if (setsockopt(listener_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0) {
+            CloseListener();
+            return false;
+        }
+
+        sockaddr_in address{};
+        address.sin_family      = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        address.sin_port        = 0;
+        if (bind(listener_, reinterpret_cast<const sockaddr*>(&address), sizeof(address)) != 0 ||
+            listen(listener_, 1) != 0) {
+            CloseListener();
+            return false;
+        }
+
+        socklen_t address_size = sizeof(address);
+        if (getsockname(listener_, reinterpret_cast<sockaddr*>(&address), &address_size) != 0) {
+            CloseListener();
+            return false;
+        }
+        port_ = ntohs(address.sin_port);
+        return true;
+    }
+
+    std::uint16_t Port() const {
+        return port_;
+    }
+
+    bool ServeOnce(std::size_t response_body_size, char response_fill,
+                   std::string* captured_request = nullptr) {
+        if (listener_ < 0) {
+            return false;
+        }
+
+        pollfd descriptor{listener_, POLLIN, 0};
+        if (poll(&descriptor, 1, static_cast<int>(std::chrono::seconds(5).count() * 1000)) != 1 ||
+            (descriptor.revents & POLLIN) == 0) {
+            CloseListener();
+            return false;
+        }
+
+        const int listener = listener_;
+        listener_          = -1;
+        const int client   = accept4(listener, nullptr, nullptr, SOCK_CLOEXEC);
+        close(listener);
+        if (client < 0) {
+            return false;
+        }
+
+        timeval receive_timeout{};
+        receive_timeout.tv_sec = 5;
+        if (setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &receive_timeout, sizeof(receive_timeout)) != 0 ||
+            setsockopt(client, SOL_SOCKET, SO_SNDTIMEO, &receive_timeout, sizeof(receive_timeout)) != 0) {
+            close(client);
+            return false;
+        }
+
+        std::string request;
+        bool success = ReadRequest(client, request);
+        if (success && captured_request != nullptr) {
+            *captured_request = request;
+        }
+
+        const auto response_header =
+            "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: " +
+            std::to_string(response_body_size) + "\r\nConnection: close\r\n\r\n";
+        success = success && SendAll(client, response_header.data(), response_header.size());
+
+        std::array<char, 64 * 1024> response_buffer{};
+        response_buffer.fill(response_fill);
+        std::size_t remaining = response_body_size;
+        while (success && remaining > 0) {
+            const auto bytes = std::min(remaining, response_buffer.size());
+            success          = SendAll(client, response_buffer.data(), bytes);
+            remaining -= bytes;
+        }
+
+        shutdown(client, SHUT_RDWR);
+        close(client);
+        return success;
+    }
+
+private:
+    static bool SendAll(int socket_fd, const char* data, std::size_t size) {
+        std::size_t sent = 0;
+        while (sent < size) {
+            const auto result = send(socket_fd, data + sent, size - sent, MSG_NOSIGNAL);
+            if (result < 0 && errno == EINTR) {
+                continue;
+            }
+            if (result <= 0) {
+                return false;
+            }
+            sent += static_cast<std::size_t>(result);
+        }
+        return true;
+    }
+
+    static bool ParseContentLength(const std::string& request, std::size_t header_end,
+                                   std::size_t& content_length) {
+        std::string lower_headers = request.substr(0, header_end + 2);
+        std::transform(lower_headers.begin(), lower_headers.end(), lower_headers.begin(),
+                       [](unsigned char value) { return static_cast<char>(std::tolower(value)); });
+
+        constexpr char kHeaderName[] = "\r\ncontent-length:";
+        const auto header_position   = lower_headers.find(kHeaderName);
+        if (header_position == std::string::npos) {
+            content_length = 0;
+            return true;
+        }
+
+        auto value_begin = header_position + sizeof(kHeaderName) - 1;
+        while (value_begin < header_end &&
+               (lower_headers[value_begin] == ' ' || lower_headers[value_begin] == '\t')) {
+            ++value_begin;
+        }
+        const auto value_end = lower_headers.find("\r\n", value_begin);
+        if (value_end == std::string::npos) {
+            return false;
+        }
+
+        std::size_t parsed_length = 0;
+        const auto parse_result   = std::from_chars(lower_headers.data() + value_begin,
+                                                    lower_headers.data() + value_end, parsed_length);
+        if (parse_result.ec != std::errc{} || parse_result.ptr != lower_headers.data() + value_end) {
+            return false;
+        }
+        content_length = parsed_length;
+        return true;
+    }
+
+    static bool ReadRequest(int socket_fd, std::string& request) {
+        constexpr std::size_t kMaxHeaderSize = 64 * 1024;
+        constexpr std::size_t kMaxBodySize   = 4 * 1024 * 1024;
+        std::array<char, 4096> buffer{};
+        while (true) {
+            const auto header_end = request.find("\r\n\r\n");
+            if (header_end != std::string::npos) {
+                std::size_t content_length = 0;
+                if (!ParseContentLength(request, header_end, content_length) ||
+                    content_length > kMaxBodySize) {
+                    return false;
+                }
+                const auto expected_size = header_end + 4 + content_length;
+                if (request.size() >= expected_size) {
+                    request.resize(expected_size);
+                    return true;
+                }
+            } else if (request.size() >= kMaxHeaderSize) {
+                return false;
+            }
+
+            const auto received = recv(socket_fd, buffer.data(), buffer.size(), 0);
+            if (received < 0 && errno == EINTR) {
+                continue;
+            }
+            if (received <= 0) {
+                return false;
+            }
+            request.append(buffer.data(), static_cast<std::size_t>(received));
+        }
+    }
+
+    void CloseListener() {
+        if (listener_ >= 0) {
+            close(listener_);
+            listener_ = -1;
+        }
+        port_ = 0;
+    }
+
+    int listener_{-1};
+    std::uint16_t port_{0};
+};
+
+}  // namespace cosmo::test

--- a/test/test_file_service_impl.cc
+++ b/test/test_file_service_impl.cc
@@ -5,8 +5,6 @@
  * Strategy: Keep external platform services mocked, and use a one-shot
  * loopback HTTP server for deterministic transfer-boundary coverage.
  */
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -14,10 +12,13 @@
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <future>
 #include <string>
 #include <thread>
+#include <utility>
 
+#include "LoopbackHttpServer.h"
 #include "mock/MockServiceRegistry.h"
 #include "network/http/HttpRequest.h"
 #include "network/http/HttpRequestHandler.h"
@@ -29,82 +30,38 @@ using namespace cosmo::service;
 
 namespace {
 
-int OpenLoopbackServer(std::uint16_t& port) {
-    const int server = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
-    if (server < 0) {
-        return -1;
-    }
-    int reuse = 1;
-    if (setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0) {
-        close(server);
-        return -1;
-    }
-    sockaddr_in address{};
-    address.sin_family      = AF_INET;
-    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    address.sin_port        = 0;
-    if (bind(server, reinterpret_cast<const sockaddr*>(&address), sizeof(address)) != 0 ||
-        listen(server, 1) != 0) {
-        close(server);
-        return -1;
-    }
-    socklen_t address_size = sizeof(address);
-    if (getsockname(server, reinterpret_cast<sockaddr*>(&address), &address_size) != 0) {
-        close(server);
-        return -1;
-    }
-    port = ntohs(address.sin_port);
-    return server;
-}
+class ScopedFileRemoval {
+public:
+    explicit ScopedFileRemoval(std::filesystem::path path) : path_(std::move(path)) {}
 
-bool SendAll(int socket, const char* data, std::size_t size) {
-    std::size_t sent = 0;
-    while (sent < size) {
-        const auto result = send(socket, data + sent, size - sent, MSG_NOSIGNAL);
-        if (result <= 0) {
-            return false;
-        }
-        sent += static_cast<std::size_t>(result);
+    ~ScopedFileRemoval() {
+        std::error_code error;
+        std::filesystem::remove(path_, error);
     }
-    return true;
-}
 
-bool ServeHttpBodyOnce(int server, std::size_t body_size, char fill) {
-    const int client = accept4(server, nullptr, nullptr, SOCK_CLOEXEC);
-    if (client < 0) {
-        close(server);
+    ScopedFileRemoval(const ScopedFileRemoval&)            = delete;
+    ScopedFileRemoval& operator=(const ScopedFileRemoval&) = delete;
+
+private:
+    std::filesystem::path path_;
+};
+
+bool FileContainsOnly(const std::filesystem::path& path, char expected) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
         return false;
     }
 
-    std::string request;
-    std::array<char, 4096> request_buffer{};
-    while (request.find("\r\n\r\n") == std::string::npos && request.size() < 64 * 1024) {
-        const auto received = recv(client, request_buffer.data(), request_buffer.size(), 0);
-        if (received <= 0) {
-            close(client);
-            close(server);
+    std::array<char, 64 * 1024> buffer{};
+    while (input) {
+        input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        const auto bytes = input.gcount();
+        if (!std::all_of(buffer.begin(), buffer.begin() + bytes,
+                         [expected](char value) { return value == expected; })) {
             return false;
         }
-        request.append(request_buffer.data(), static_cast<std::size_t>(received));
     }
-
-    const auto header =
-        "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\n"
-        "Content-Length: " +
-        std::to_string(body_size) + "\r\nConnection: close\r\n\r\n";
-    bool success = SendAll(client, header.data(), header.size());
-    std::array<char, 64 * 1024> body_buffer{};
-    body_buffer.fill(fill);
-    std::size_t remaining = body_size;
-    while (success && remaining > 0) {
-        const auto bytes = std::min(remaining, body_buffer.size());
-        success          = SendAll(client, body_buffer.data(), bytes);
-        remaining -= bytes;
-    }
-    shutdown(client, SHUT_RDWR);
-    close(client);
-    close(server);
-    return success;
+    return input.eof();
 }
 
 }  // namespace
@@ -262,17 +219,16 @@ TEST_CASE("FileServiceImpl: download rejects non-HTTP URLs and clears stale outp
 TEST_CASE("FileServiceImpl: resource budget permits HTTP images beyond the legacy 16 MiB cap",
           "[FileService][http][boundary]") {
     constexpr std::size_t kBodySize = 17U * 1024 * 1024 + 123;
-    std::uint16_t port              = 0;
-    const int server                = OpenLoopbackServer(port);
-    REQUIRE(server >= 0);
+    cosmo::test::LoopbackHttpServer server;
+    REQUIRE(server.Start());
+    const auto url = "http://127.0.0.1:" + std::to_string(server.Port()) + "/large-image";
 
     std::atomic<bool> served{false};
     std::thread server_thread(
-        [&]() { served.store(ServeHttpBodyOnce(server, kBodySize, 'I'), std::memory_order_release); });
+        [&]() { served.store(server.ServeOnce(kBodySize, 'I'), std::memory_order_release); });
     FileServiceImpl sut;
     std::vector<std::uint8_t> data;
-    const bool downloaded =
-        sut.DownloadFile("http://127.0.0.1:" + std::to_string(port) + "/large-image", data);
+    const bool downloaded = sut.DownloadFile(url, data);
     server_thread.join();
 
     REQUIRE(served.load(std::memory_order_acquire));
@@ -285,29 +241,71 @@ TEST_CASE("FileServiceImpl: resource budget permits HTTP images beyond the legac
 TEST_CASE("HttpFileHandler: HTTP video-sized responses stream to disk beyond 16 MiB",
           "[FileService][http][streaming]") {
     constexpr std::size_t kBodySize = 32U * 1024 * 1024 + 321;
-    std::uint16_t port              = 0;
-    const int server                = OpenLoopbackServer(port);
-    REQUIRE(server >= 0);
+    cosmo::test::LoopbackHttpServer server;
+    REQUIRE(server.Start());
+    const auto url = "http://127.0.0.1:" + std::to_string(server.Port()) + "/large-video";
 
     const auto output =
         std::filesystem::path("/tmp") / ("cosmo-http-video-" + std::to_string(getpid()) + ".mp4");
+    [[maybe_unused]] ScopedFileRemoval output_cleanup(output);
     std::error_code error;
     std::filesystem::remove(output, error);
     std::atomic<bool> served{false};
     std::thread server_thread(
-        [&]() { served.store(ServeHttpBodyOnce(server, kBodySize, 'V'), std::memory_order_release); });
+        [&]() { served.store(server.ServeOnce(kBodySize, 'V'), std::memory_order_release); });
 
     cosmo::network::http::HttpFileHandler handler(output.string());
-    cosmo::network::http::HttpRequest request("http://127.0.0.1:" + std::to_string(port) + "/large-video",
-                                              &handler);
+    cosmo::network::http::HttpRequest request(url, &handler);
     request.SetTimeout(30);
     const auto status = request.Submit(cosmo::network::http::HttpRequestMethod::kGet);
-    handler.Flush();
     server_thread.join();
 
     REQUIRE(served.load(std::memory_order_acquire));
     REQUIRE(static_cast<int>(status) == 200);
     REQUIRE(std::filesystem::file_size(output, error) == kBodySize);
     REQUIRE_FALSE(error);
-    std::filesystem::remove(output, error);
+    REQUIRE(FileContainsOnly(output, 'V'));
+}
+
+TEST_CASE("HttpFileHandler: unopened destination aborts the HTTP transfer", "[FileService][http][boundary]") {
+    const auto missing_parent =
+        std::filesystem::path("/tmp") / ("cosmo-http-missing-parent-" + std::to_string(getpid()));
+    const auto output = missing_parent / "response.bin";
+    std::error_code error;
+    std::filesystem::remove_all(missing_parent, error);
+    REQUIRE_FALSE(std::filesystem::exists(missing_parent));
+
+    cosmo::test::LoopbackHttpServer server;
+    REQUIRE(server.Start());
+    const auto url = "http://127.0.0.1:" + std::to_string(server.Port()) + "/write-failure";
+    std::atomic<bool> served{false};
+    std::thread server_thread([&]() { served.store(server.ServeOnce(1, 'F'), std::memory_order_release); });
+
+    cosmo::network::http::HttpFileHandler handler(output.string());
+    cosmo::network::http::HttpRequest request(url, &handler);
+    const auto status = request.Submit(cosmo::network::http::HttpRequestMethod::kGet);
+    server_thread.join();
+
+    REQUIRE(served.load(std::memory_order_acquire));
+    REQUIRE(status == -1);
+    REQUIRE_FALSE(std::filesystem::exists(output));
+}
+
+TEST_CASE("HttpFileHandler: final flush failure rejects an HTTP 200 response",
+          "[FileService][http][boundary]") {
+    REQUIRE(std::filesystem::exists("/dev/full"));
+
+    cosmo::test::LoopbackHttpServer server;
+    REQUIRE(server.Start());
+    const auto url = "http://127.0.0.1:" + std::to_string(server.Port()) + "/flush-failure";
+    std::atomic<bool> served{false};
+    std::thread server_thread([&]() { served.store(server.ServeOnce(1, 'F'), std::memory_order_release); });
+
+    cosmo::network::http::HttpFileHandler handler("/dev/full");
+    cosmo::network::http::HttpRequest request(url, &handler);
+    const auto status = request.Submit(cosmo::network::http::HttpRequestMethod::kGet);
+    server_thread.join();
+
+    REQUIRE(served.load(std::memory_order_acquire));
+    REQUIRE(status == -1);
 }

--- a/test/test_http_client_impl.cc
+++ b/test/test_http_client_impl.cc
@@ -2,10 +2,13 @@
 /*
  * test_http_client_impl.cc — HttpClientImpl unit tests (DEBT-T01)
  *
- * Strategy: HttpClientImpl delegates to libcurl. Network tests are
- * tagged [.network]. We can safely test construction.
+ * Strategy: HttpClientImpl delegates to libcurl. External network tests are
+ * tagged [.network], while method-selection coverage uses a loopback server.
  */
-#include "mock/MockServiceRegistry.h"
+#include <string>
+#include <thread>
+
+#include "LoopbackHttpServer.h"
 #include "service/network/impl/HttpClientImpl.h"
 
 using namespace cosmo::service;
@@ -21,8 +24,31 @@ TEST_CASE("HttpClientImpl: Post to invalid URL returns error", "[HttpClient][.ne
     REQUIRE(resp.statusCode != 200);
 }
 
-TEST_CASE("HttpClientImpl: Post with empty data", "[HttpClient][.network]") {
+TEST_CASE("HttpClientImpl: Post sends POST for empty and non-empty bodies", "[HttpClient][http]") {
+    std::string body;
+    SECTION("empty body") {
+        body.clear();
+    }
+    SECTION("non-empty body") {
+        body = R"({"event":"ready"})";
+    }
+
+    cosmo::test::LoopbackHttpServer server;
+    REQUIRE(server.Start());
+    const auto url = "http://127.0.0.1:" + std::to_string(server.Port()) + "/submit";
+
+    bool served = false;
+    std::string request;
+    std::thread server_thread([&]() { served = server.ServeOnce(0, '\0', &request); });
+
     HttpClientImpl sut;
-    auto resp = sut.Post("http://192.0.2.1:1/test", "", "text/plain", 1, 1);
-    REQUIRE(resp.statusCode != 200);
+    const auto response = sut.Post(url, body, "application/json", 2, 2);
+    server_thread.join();
+
+    REQUIRE(served);
+    REQUIRE(response.statusCode == 200);
+    REQUIRE(request.rfind("POST /submit HTTP/", 0) == 0);
+    const auto header_end = request.find("\r\n\r\n");
+    REQUIRE(header_end != std::string::npos);
+    REQUIRE(request.substr(header_end + 4) == body);
 }


### PR DESCRIPTION
## Summary

Make HTTP client transfers report local response-sink failures and make project-owned POST callers select POST explicitly, including empty request bodies.

## Related issue

Closes #92

## Root cause

Request method selection partly depended on libcurl body side effects, so an empty `HttpClientImpl::Post()` could be sent as GET. `HttpFileHandler` also returned successful callback lengths without checking stream state, while `Flush()` could not report finalization errors. Several curl setup and response-info results were ignored.

## Scope

### In scope

- Add a backward-compatible response-handler finalization result.
- Propagate file write and final flush failures through `HttpRequest::Submit()`.
- Preserve libcurl body modes while explicitly selecting GET/POST behavior.
- Check curl options, header-list construction, MIME setup, transfer, and response-info results.
- Add deterministic loopback tests for empty/non-empty POST and file transfer success/failure paths.

### Out of scope

- Server-side Range or response-buffering changes.
- File-server token refresh and manager URL configuration.
- HTTP worker queue or event-loop lifecycle redesign.
- Removal of legacy public HTTP APIs.

## Risk tags

- [x] Runtime / lifecycle
- [ ] Thread / memory safety
- [x] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [ ] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build / deployment
- [ ] Refactor
- [x] Test

## Area

- [x] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [x] API / MQTT / WebSocket
- [ ] Media / streaming
- [ ] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `f7eae5cd02a28ee570002a5debace992243dcdc7`
- Candidate commit: `af36d17b95af11cb28998ec740318f8628b616ad`
- Candidate tree: `39906b4d67a355adbd4b09046aca2e3fb3830331`
- Package SHA-256: `9f70db68abcc7a233412b23e1d3a65053e07abc784aefde7bd3aa0aa7f5d9971`
- Test binary SHA-256: `f5527bbc2a42956d6a30aa6a42b432993d65dadee0858393aac6a16df8e4832b`

The commit was rebased onto the listed base before final evidence collection. No source, commit, rebase, or merge change occurred after the evidence below was collected.

## Verification

### Parent baseline

`BLOCKED` — the parent had no deterministic empty-body POST or response-finalization regression tests to execute. Static inspection showed that empty requests did not install a POST option and that `Flush()` returned no result.

### Candidate checks

```text
PASS  pre-commit clang-format 18 check: 9 staged C++ files
PASS  pre-commit cppcheck: no error-level issues
PASS  git diff --check origin/main...HEAD
PASS  docker-compose -f docker-compose.sophon.yml run --rm cosmo-sophon-package
PASS  device: "[HttpClient][http],HttpFileHandler:*" — 4 cases, 27 assertions
PASS  device: "[HttpClient],[HttpPost],[http-lifecycle],[http-server],[auth-service],[AuthHandler]" — 37 cases, 411 assertions
```

### Risk-based evidence

- API/network: empty and non-empty loopback calls were observed as POST; invalid URL, credentials, HTTP server security, invalid-input, and lifecycle suites passed.
- Media/streaming: N/A.
- Sophon/device: final aarch64 test binary hash matched the candidate manifest and both focused filters passed on an authorized device.
- Frontend/UI: N/A.
- Package/deployment: canonical Sophon package build passed; no application binary was deployed or replaced.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [x] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

`HttpRequestHandler::Finalize()` has a default `Flush()`-based implementation, so existing source-level handlers remain valid. Consumers must use rebuilt artifacts, as with other C++ interface changes.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: `N/A — awaiting review`
- Device test filter: `[HttpClient][http],HttpFileHandler:*`
- Device backup state: `N/A — application files were not replaced`
- Temporary-data cleanup: `complete`
- Final Git status: `clean`
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

An exploratory broad-tag device run also selected the existing `FileServiceImpl: resource budget permits HTTP images beyond the legacy 16 MiB cap` test. It observed a device-state-dependent failure when the live image budget fell below the test payload. The same test had passed earlier with the identical test-binary SHA-256. The candidate-bound work-item and risk suites above exclude that unrelated live-budget assertion and pass in full.
