### PR TITLE
refactor(linkage): simplify runtime task handling

### DIFF
--- a/src/linkage/LinkAgeAlarm.cc
+++ b/src/linkage/LinkAgeAlarm.cc
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 
 #include "linkage/LinkAgeAudioDevice.h"
+#include "util/JsonFieldOpt.h"
 #include "util/JsonStructUtil.h"
 #include "util/Keys.h"
 #include "util/LimitedTypeJson.h"
@@ -13,7 +14,8 @@
 namespace cosmo::linkage {
 LinkAgeAlarm::LinkAgeAlarm(LinkAgeParamNode& action) : LinkAgeBase(action) {
     for (const auto& param : action.config_object.params) {
-        if (kKeyStrageAlgs == param.key.ToString() || kKeyLinkageAlgs == param.key.ToString()) {
+        const auto& key = param.key.ToRefString();
+        if (IsAlarmAlgorithmsKey(key)) {
             AnalysisTasks(param.value);
         }
     }
@@ -50,10 +52,8 @@ bool LinkAgeAlarm::DoAlarm(const std::string& channel_id, const std::string& alg
 // Auto-generated JSON serialization
 namespace cosmo::linkage {
 void from_json(const nlohmann::json& j, LinkAgeAlarmTaskUnit& v) {
-    if (j.contains("channelId") && !j["channelId"].is_null())
-        j.at("channelId").get_to(v.channel_id);
-    if (j.contains("algorithmId") && !j["algorithmId"].is_null())
-        j.at("algorithmId").get_to(v.algorithm_id);
+    JSON_OPT_KEY(j, v, "channelId", channel_id);
+    JSON_OPT_KEY(j, v, "algorithmId", algorithm_id);
 }
 
 void to_json(nlohmann::json& j, const LinkAgeAlarmTaskUnit& v) {

--- a/src/linkage/LinkAgeAudioDevice.cc
+++ b/src/linkage/LinkAgeAudioDevice.cc
@@ -15,57 +15,56 @@ LinkAgeAudioDevice::LinkAgeAudioDevice(LinkAgeParamNode& action) : LinkAgeBase(a
     std::string audio_data;
     std::string text_data;
     for (const auto& param : action.config_object.params) {
-        if (kKeyStrageAudioDeviceId == param.key.ToString() ||
-            kKeyLinkageAudioDeviceId == param.key.ToString()) {
+        const auto& key = param.key.ToRefString();
+        if (IsAudioDeviceIdKey(key)) {
             param_.dev_id = param.value;
-        } else if (kKeyStrageAudioDeviceOperation == param.key.ToString()) {
+        } else if (kKeyStrageAudioDeviceOperation == key) {
             auto value = util::ParseInt(param.value);
             if (IsValidOperation(value)) {
                 param_.operation = static_cast<LinkAgeAudioDeviceOperation>(value);
             } else {
                 LOG_WARN("{} Set {} To {} Invalid", GetFlowActionId(), param.key, param.value);
             }
-        } else if (kKeyStrageAudioDeviceData == param.key.ToString()) {
+        } else if (kKeyStrageAudioDeviceData == key) {
             audio_data = param.value;
-        } else if (kKeyStrageAudioDeviceText == param.key.ToString() ||
-                   kKeyLinkageAudioDeviceText == param.key.ToString()) {
+        } else if (IsAudioTextKey(key)) {
             text_data = param.value;
-        } else if (kKeyStrageAudioDeviceTone == param.key.ToString()) {
+        } else if (kKeyStrageAudioDeviceTone == key) {
             auto value = util::ParseInt(param.value);
             if (IsValidTone(value)) {
                 param_.tone = static_cast<LinkAgeAudioDeviceTone>(value);
             } else {
                 LOG_WARN("{} Set {} To {} Invalid", GetFlowActionId(), param.key, param.value);
             }
-        } else if (kKeyStrageAudioDeviceSpeed == param.key.ToString()) {
+        } else if (kKeyStrageAudioDeviceSpeed == key) {
             auto value = util::ParseInt(param.value);
             if (IsValidSpeed(value)) {
                 param_.speed = value;
             } else {
                 LOG_WARN("{} Set {} To {} Invalid", GetFlowActionId(), param.key, param.value);
             }
-        } else if (kKeyStrageAudioDeviceVolume == param.key.ToString()) {
+        } else if (kKeyStrageAudioDeviceVolume == key) {
             auto value = util::ParseInt(param.value);
             if (IsValidVolume(value)) {
                 param_.volume = value;
             } else {
                 LOG_WARN("{} Set {} To {} Invalid", GetFlowActionId(), param.key, param.value);
             }
-        } else if (kKeyStrageAudioDeviceDuration == param.key.ToString()) {
+        } else if (kKeyStrageAudioDeviceDuration == key) {
             auto value = util::ParseInt(param.value);
             if (IsValidDuration(value)) {
                 param_.duration = value;
             } else {
                 LOG_WARN("{} Set {} To {} Invalid", GetFlowActionId(), param.key, param.value);
             }
-        } else if (kKeyStrageAudioDeviceTimes == param.key.ToString()) {
+        } else if (kKeyStrageAudioDeviceTimes == key) {
             auto value = util::ParseInt(param.value);
             if (IsValidTimes(value)) {
                 param_.times = value;
             } else {
                 LOG_WARN("{} Set {} To {} Invalid", GetFlowActionId(), param.key, param.value);
             }
-        } else if (kKeyStrageAudioDeviceGap == param.key.ToString()) {
+        } else if (kKeyStrageAudioDeviceGap == key) {
             auto value = util::ParseInt(param.value);
             if (IsValidGap(value)) {
                 param_.gap = value;

--- a/src/linkage/LinkAgeBase.cc
+++ b/src/linkage/LinkAgeBase.cc
@@ -6,7 +6,11 @@
 
 namespace cosmo::linkage {
 
-LinkAgeBase::LinkAgeBase(LinkAgeParamNode& action) : action_(action) {}
+LinkAgeBase::LinkAgeBase(LinkAgeParamNode& action)
+    : action_id_(action.action_id),
+      action_name_(action.action_name),
+      flow_action_id_(action.flowActionId),
+      pre_flow_action_id_(action.preFlowActionId) {}
 
 bool LinkAgeBase::DoAlarm(const std::string& /*channel_id*/, const std::string& /*alg_id*/) {
     return false;

--- a/src/linkage/LinkAgeBase.h
+++ b/src/linkage/LinkAgeBase.h
@@ -10,19 +10,19 @@ public:
     virtual ~LinkAgeBase() = default;
 
     std::string GetActionId() const {
-        return action_.action_id;
+        return action_id_;
     }
 
     std::string GetFlowActionId() const {
-        return action_.flowActionId;
+        return flow_action_id_;
     }
 
     std::string GetPreFlowActionId() const {
-        return action_.preFlowActionId;
+        return pre_flow_action_id_;
     }
 
     std::string GetName() const {
-        return action_.action_name;
+        return action_name_;
     }
 
     virtual bool DoAlarm(const std::string& channel_id, const std::string& alg_id);
@@ -31,7 +31,10 @@ public:
     virtual bool IsAudioFileInUse(const std::string& dev_id) const;
 
 private:
-    LinkAgeParamNode action_;
+    std::string action_id_;
+    std::string action_name_;
+    std::string flow_action_id_;
+    std::string pre_flow_action_id_;
 };
 
 using LinkAgeBasePtr = std::shared_ptr<LinkAgeBase>;

--- a/src/linkage/LinkAgeBaseCommon.cc
+++ b/src/linkage/LinkAgeBaseCommon.cc
@@ -4,6 +4,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "util/JsonFieldOpt.h"
 #include "util/LimitedTypeJson.h"
 
 // Auto-generated JSON serialization
@@ -18,15 +19,12 @@ void to_json(nlohmann::json& j, const LinkAgeParamNode& v) {
 void from_json(const nlohmann::json& j, LinkAgeParamNode& v) {
     from_json(j, static_cast<ActionBase&>(v));
     j.at("actionId").get_to(v.action_id);
-    if (j.contains("actionName") && !j["actionName"].is_null())
-        j.at("actionName").get_to(v.action_name);
-    if (j.contains("configObject") && !j["configObject"].is_null())
-        j.at("configObject").get_to(v.config_object);
+    JSON_OPT_KEY(j, v, "actionName", action_name);
+    JSON_OPT_KEY(j, v, "configObject", config_object);
 }
 
 void from_json(const nlohmann::json& j, LinkageStrategyWorkflow& v) {
-    if (j.contains("workflow") && !j["workflow"].is_null())
-        j.at("workflow").get_to(v.workflow);
+    JSON_OPT(j, v, workflow);
 }
 
 void to_json(nlohmann::json& j, const LinkageStrategyWorkflow& v) {

--- a/src/linkage/LinkAgeBaseCommon.h
+++ b/src/linkage/LinkAgeBaseCommon.h
@@ -15,6 +15,22 @@ inline constexpr std::string_view kLaAudioDeviceCode = "LA_AudioDevice_Code";
 inline constexpr std::string_view kLaAlarmDataLegacyCode   = "EVT_00001";
 inline constexpr std::string_view kLaAudioDeviceLegacyCode = "DA_00001";
 
+enum class LinkAgeActionKind {
+    kUnsupported,
+    kAlarm,
+    kAudioDevice,
+};
+
+constexpr LinkAgeActionKind ClassifyLinkAgeActionId(std::string_view action_id) {
+    if (action_id == kLaAlarmDataCode || action_id == kLaAlarmDataLegacyCode) {
+        return LinkAgeActionKind::kAlarm;
+    }
+    if (action_id == kLaAudioDeviceCode || action_id == kLaAudioDeviceLegacyCode) {
+        return LinkAgeActionKind::kAudioDevice;
+    }
+    return LinkAgeActionKind::kUnsupported;
+}
+
 inline constexpr std::string_view kKeyStrageAlgs                 = "strageAlgorithms";
 inline constexpr std::string_view kKeyLinkageAlgs                = "algs";
 inline constexpr std::string_view kKeyStrageAudioDeviceId        = "deviceSN";
@@ -29,6 +45,18 @@ inline constexpr std::string_view kKeyStrageAudioDeviceVolume    = "volume";
 inline constexpr std::string_view kKeyStrageAudioDeviceDuration  = "duration";
 inline constexpr std::string_view kKeyStrageAudioDeviceTimes     = "times";
 inline constexpr std::string_view kKeyStrageAudioDeviceGap       = "gap";
+
+constexpr bool IsAlarmAlgorithmsKey(std::string_view key) {
+    return key == kKeyStrageAlgs || key == kKeyLinkageAlgs;
+}
+
+constexpr bool IsAudioDeviceIdKey(std::string_view key) {
+    return key == kKeyStrageAudioDeviceId || key == kKeyLinkageAudioDeviceId;
+}
+
+constexpr bool IsAudioTextKey(std::string_view key) {
+    return key == kKeyStrageAudioDeviceText || key == kKeyLinkageAudioDeviceText;
+}
 
 struct LinkAgeParamNode : public ActionBase {
     std::string action_id;

--- a/src/linkage/LinkAgeTask.cc
+++ b/src/linkage/LinkAgeTask.cc
@@ -2,38 +2,58 @@
 
 #include "linkage/LinkAgeTask.h"
 
+#include <algorithm>
+
 #include "linkage/LinkAgeAlarm.h"
 #include "linkage/LinkAgeAudioDevice.h"
 #include "util/Keys.h"
 #include "util/Log.h"
 
 namespace cosmo::linkage {
+namespace {
+
+    LinkAgeBasePtr CreateAction(LinkAgeParamNode& action) {
+        switch (ClassifyLinkAgeActionId(action.action_id)) {
+            case LinkAgeActionKind::kAlarm:
+                return std::make_shared<LinkAgeAlarm>(action);
+            case LinkAgeActionKind::kAudioDevice:
+                return std::make_shared<LinkAgeAudioDevice>(action);
+            case LinkAgeActionKind::kUnsupported:
+                return nullptr;
+        }
+        return nullptr;
+    }
+
+    template <typename Predicate>
+    bool AnyActionMatches(const LinkAgeTaskUnit& unit, const Predicate& predicate) {
+        if (!unit.task) {
+            return false;
+        }
+        if (predicate(*unit.task)) {
+            return true;
+        }
+        return std::any_of(unit.sons.begin(), unit.sons.end(),
+                           [&](const auto& son) { return AnyActionMatches(son, predicate); });
+    }
+
+}  // namespace
+
 LinkAgeTask::LinkAgeTask(const std::string& name, LinkageStrategyWorkflow& strategy) : task_name_(name) {
     std::vector<LinkAgeBasePtr> actions;
     for (auto& workflow : strategy.workflow) {
-        if (kLaAlarmDataCode == workflow.action_id || kLaAlarmDataLegacyCode == workflow.action_id) {
-            auto action_inst = std::make_shared<LinkAgeAlarm>(workflow);
-            if (key::alg::ACTION_ROOT_VALUE == workflow.preFlowActionId) {
-                task_.task = action_inst;
-                LOG_INFO("[]: ROOT IS:{}/{}", task_name_, workflow.action_id, workflow.action_name);
-            } else {
-                actions.push_back(action_inst);
-            }
-
-        } else if (kLaAudioDeviceCode == workflow.action_id ||
-                   kLaAudioDeviceLegacyCode == workflow.action_id) {
-            auto action_inst = std::make_shared<LinkAgeAudioDevice>(workflow);
-            if (key::alg::ACTION_ROOT_VALUE == workflow.preFlowActionId) {
-                task_.task = action_inst;
-                LOG_INFO("[]: ROOT IS:{}/{}", task_name_, workflow.action_id, workflow.action_name);
-            } else {
-                actions.push_back(action_inst);
-            }
-        } else {
+        auto action_inst = CreateAction(workflow);
+        if (!action_inst) {
             LOG_WARN("[{}] {}/{} Not Support", task_name_, workflow.action_id, workflow.action_name);
+            continue;
+        }
+        if (key::alg::ACTION_ROOT_VALUE == workflow.preFlowActionId) {
+            task_.task = action_inst;
+            LOG_INFO("[]: ROOT IS:{}/{}", task_name_, workflow.action_id, workflow.action_name);
+        } else {
+            actions.push_back(action_inst);
         }
     }
-    OrganizeTasks(task_, actions);
+    AttachDescendants(task_, actions);
     LOG_INFO("[{}] Have Tasks:{}", task_name_, strategy.workflow.size());
 }
 
@@ -41,45 +61,29 @@ LinkAgeTask::~LinkAgeTask() {
     LOG_INFO("[{}] LinkAgeTask Delete", task_name_);
 }
 
-std::vector<LinkAgeBasePtr> LinkAgeTask::FindPres(std::vector<LinkAgeBasePtr>& actions,
-                                                  const std::string& flow_action_id) {
-    std::vector<LinkAgeBasePtr> extracted;
-    auto it = actions.begin();
+void LinkAgeTask::AttachDescendants(LinkAgeTaskUnit& unit, std::vector<LinkAgeBasePtr>& actions) {
+    if (!unit.task) {
+        return;
+    }
+
+    const auto flow_action_id = unit.task->GetFlowActionId();
+    auto it                   = actions.begin();
     while (it != actions.end()) {
         if ((*it)->GetPreFlowActionId() == flow_action_id) {
-            extracted.push_back(*it);
-            it = actions.erase(it);  // Erase and return next iterator
+            LinkAgeTaskUnit child;
+            child.task = *it;
+            unit.sons.push_back(std::move(child));
+            it = actions.erase(it);
         } else {
             ++it;
         }
     }
-    return extracted;
-}
-
-void LinkAgeTask::AddSons(LinkAgeTaskUnit& unit, const std::vector<LinkAgeBasePtr>& sons) {
-    if (sons.empty()) {
-        return;
-    }
-
-    for (const auto& son : sons) {
-        LinkAgeTaskUnit task;
-        task.task = son;
-        unit.sons.push_back(task);
-    }
-}
-
-void LinkAgeTask::OrganizeTasks(LinkAgeTaskUnit& unit, std::vector<LinkAgeBasePtr>& actions) {
-    if (!unit.task) {
-        return;
-    }
-    auto extracted = FindPres(actions, unit.task->GetFlowActionId());
-    AddSons(unit, extracted);
     if (actions.empty()) {
         return;
     }
 
     for (auto& son : unit.sons) {
-        OrganizeTasks(son, actions);
+        AttachDescendants(son, actions);
     }
 }
 
@@ -101,41 +105,13 @@ void LinkAgeTask::DoAlarm(const std::string& channel_id, const std::string& alg_
     DoTaskAlarm(task_, channel_id, alg_id);
 }
 
-bool LinkAgeTask::IsAudioDeviceInUse(const LinkAgeTaskUnit& task_unit, const std::string& dev_id) const {
-    if (task_unit.task) {
-        if (task_unit.task->IsAudioDeviceInUse(dev_id)) {
-            return true;
-        }
-        for (const auto& son : task_unit.sons) {
-            if (IsAudioDeviceInUse(son, dev_id)) {
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
-
 bool LinkAgeTask::IsAudioDeviceInUse(const std::string& dev_id) {
-    return IsAudioDeviceInUse(task_, dev_id);
-}
-
-bool LinkAgeTask::IsAudioFileInUse(const LinkAgeTaskUnit& task_unit, const std::string& dev_id) const {
-    if (task_unit.task) {
-        if (task_unit.task->IsAudioFileInUse(dev_id)) {
-            return true;
-        }
-        for (const auto& son : task_unit.sons) {
-            if (IsAudioFileInUse(son, dev_id)) {
-                return true;
-            }
-        }
-    }
-
-    return false;
+    return AnyActionMatches(task_,
+                            [&](const LinkAgeBase& action) { return action.IsAudioDeviceInUse(dev_id); });
 }
 
 bool LinkAgeTask::IsAudioFileInUse(const std::string& dev_id) {
-    return IsAudioFileInUse(task_, dev_id);
+    return AnyActionMatches(task_,
+                            [&](const LinkAgeBase& action) { return action.IsAudioFileInUse(dev_id); });
 }
 }  // namespace cosmo::linkage

--- a/src/linkage/LinkAgeTask.h
+++ b/src/linkage/LinkAgeTask.h
@@ -20,14 +20,9 @@ public:
     bool IsAudioFileInUse(const std::string& dev_id);
 
 private:
-    std::vector<LinkAgeBasePtr> FindPres(std::vector<LinkAgeBasePtr>& actions,
-                                         const std::string& flow_action_id);
-    void AddSons(LinkAgeTaskUnit& unit, const std::vector<LinkAgeBasePtr>& sons);
-    void OrganizeTasks(LinkAgeTaskUnit& unit, std::vector<LinkAgeBasePtr>& actions);
+    void AttachDescendants(LinkAgeTaskUnit& unit, std::vector<LinkAgeBasePtr>& actions);
 
     void DoTaskAlarm(LinkAgeTaskUnit& task_unit, const std::string& channel_id, const std::string& alg_id);
-    bool IsAudioDeviceInUse(const LinkAgeTaskUnit& task_unit, const std::string& dev_id) const;
-    bool IsAudioFileInUse(const LinkAgeTaskUnit& task_unit, const std::string& dev_id) const;
 
     LinkAgeTaskUnit task_;
     std::string task_name_;

--- a/src/service/infra/impl/LinkageCrud.cc
+++ b/src/service/infra/impl/LinkageCrud.cc
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <filesystem>
-#include <initializer_list>
 #include <iterator>
 #include <string_view>
 #include <unordered_map>
@@ -30,20 +29,23 @@ namespace cosmo::service {
 using detail::NormalizeWorkflowJson;
 
 namespace {
-    std::string FindParameter(const cosmo::linkage::LinkAgeParamNode& node,
-                              std::initializer_list<std::string_view> keys) {
+    template <typename Predicate>
+    std::string FindParameter(const cosmo::linkage::LinkAgeParamNode& node, const Predicate& predicate) {
         for (const auto& parameter : node.config_object.params) {
-            const auto key = parameter.key.ToString();
-            if (std::find(keys.begin(), keys.end(), std::string_view(key)) != keys.end()) {
-                return parameter.value.ToString();
+            const auto& key = parameter.key.ToRefString();
+            if (predicate(key)) {
+                return parameter.value.ToRefString();
             }
         }
         return {};
     }
 
+    std::string FindParameter(const cosmo::linkage::LinkAgeParamNode& node, std::string_view key) {
+        return FindParameter(node, [key](std::string_view candidate) { return candidate == key; });
+    }
+
     bool HasValidAlarmBinding(const cosmo::linkage::LinkAgeParamNode& node) {
-        const auto value =
-            FindParameter(node, {cosmo::linkage::kKeyLinkageAlgs, cosmo::linkage::kKeyStrageAlgs});
+        const auto value = FindParameter(node, cosmo::linkage::IsAlarmAlgorithmsKey);
         std::vector<cosmo::linkage::LinkAgeAlarmTaskUnit> tasks;
         return !value.empty() && cosmo::util::DecodeJson(value, tasks) && !tasks.empty() &&
                std::all_of(tasks.begin(), tasks.end(), [](const auto& task) {
@@ -52,19 +54,16 @@ namespace {
     }
 
     bool HasValidAudioBinding(const cosmo::linkage::LinkAgeParamNode& node) {
-        const auto device_id = FindParameter(
-            node, {cosmo::linkage::kKeyLinkageAudioDeviceId, cosmo::linkage::kKeyStrageAudioDeviceId});
+        const auto device_id = FindParameter(node, cosmo::linkage::IsAudioDeviceIdKey);
         const auto operation =
-            cosmo::util::ParseInt(FindParameter(node, {cosmo::linkage::kKeyStrageAudioDeviceOperation}));
+            cosmo::util::ParseInt(FindParameter(node, cosmo::linkage::kKeyStrageAudioDeviceOperation));
         if (device_id.empty() || !cosmo::linkage::IsValidOperation(operation)) {
             return false;
         }
         if (operation == static_cast<int>(cosmo::linkage::LinkAgeAudioDeviceOperation::kAudioPlay)) {
-            return !FindParameter(node, {cosmo::linkage::kKeyStrageAudioDeviceData}).empty();
+            return !FindParameter(node, cosmo::linkage::kKeyStrageAudioDeviceData).empty();
         }
-        return !FindParameter(node, {cosmo::linkage::kKeyLinkageAudioDeviceText,
-                                     cosmo::linkage::kKeyStrageAudioDeviceText})
-                    .empty();
+        return !FindParameter(node, cosmo::linkage::IsAudioTextKey).empty();
     }
 }  // namespace
 
@@ -277,11 +276,10 @@ bool LinkageServiceImpl::ValidateWorkflow(const cosmo::linkage::LinkageStrategyW
     nodes.reserve(strategy.workflow.size());
     size_t root_count = 0;
     for (const auto& node : strategy.workflow) {
-        const bool is_alarm = node.action_id == cosmo::linkage::kLaAlarmDataCode ||
-                              node.action_id == cosmo::linkage::kLaAlarmDataLegacyCode;
-        const bool is_audio = node.action_id == cosmo::linkage::kLaAudioDeviceCode ||
-                              node.action_id == cosmo::linkage::kLaAudioDeviceLegacyCode;
-        if ((!is_alarm && !is_audio) || node.flowActionId.empty() ||
+        const auto action_kind = cosmo::linkage::ClassifyLinkAgeActionId(node.action_id);
+        const bool is_alarm    = action_kind == cosmo::linkage::LinkAgeActionKind::kAlarm;
+        const bool is_audio    = action_kind == cosmo::linkage::LinkAgeActionKind::kAudioDevice;
+        if (action_kind == cosmo::linkage::LinkAgeActionKind::kUnsupported || node.flowActionId.empty() ||
             node.flowActionId == cosmo::key::alg::ACTION_ROOT_VALUE ||
             !nodes.emplace(node.flowActionId, &node).second || (is_alarm && !HasValidAlarmBinding(node)) ||
             (is_audio && !HasValidAudioBinding(node))) {

--- a/test/test_linkage_runtime.cc
+++ b/test/test_linkage_runtime.cc
@@ -1,0 +1,261 @@
+#include <nlohmann/json.hpp>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// clang-format off
+#include "catch_amalgamated.hpp"
+#include "catch2/trompeloeil.hpp"
+// clang-format on
+
+#include "linkage/LinkAgeAlarm.h"
+#include "linkage/LinkAgeBase.h"
+#include "linkage/LinkAgeBaseCommon.h"
+#include "linkage/LinkAgeTask.h"
+#include "mock/MockAudioService.h"
+#include "mock/MockServiceRegistry.h"
+#include "util/Keys.h"
+
+namespace cosmo::linkage {
+namespace {
+
+    using trompeloeil::_;
+
+    MsgDynamicKeyValue MakeParameter(std::string_view key, std::string value) {
+        MsgDynamicKeyValue parameter;
+        parameter.key   = std::string(key);
+        parameter.value = std::move(value);
+        return parameter;
+    }
+
+    LinkAgeParamNode MakeAlarmNode(std::string flow_action_id, std::string pre_flow_action_id,
+                                   std::string_view action_id      = kLaAlarmDataCode,
+                                   std::string_view algorithms_key = kKeyLinkageAlgs) {
+        LinkAgeParamNode node;
+        node.action_id       = action_id;
+        node.action_name     = "alarm";
+        node.flowActionId    = std::move(flow_action_id);
+        node.preFlowActionId = std::move(pre_flow_action_id);
+        node.config_object.params.push_back(
+            MakeParameter(algorithms_key, R"([{"channelId":"channel-1","algorithmId":"algorithm-1"}])"));
+        return node;
+    }
+
+    LinkAgeParamNode MakeAudioNode(std::string flow_action_id, std::string pre_flow_action_id,
+                                   std::string device_id, std::string audio_file_id,
+                                   std::string_view action_id  = kLaAudioDeviceCode,
+                                   std::string_view device_key = kKeyLinkageAudioDeviceId,
+                                   std::string_view text_key   = kKeyLinkageAudioDeviceText) {
+        LinkAgeParamNode node;
+        node.action_id            = action_id;
+        node.action_name          = "audio";
+        node.flowActionId         = std::move(flow_action_id);
+        node.preFlowActionId      = std::move(pre_flow_action_id);
+        node.config_object.params = {
+            MakeParameter(device_key, std::move(device_id)),
+            MakeParameter(kKeyStrageAudioDeviceOperation, "1"),
+            MakeParameter(kKeyStrageAudioDeviceData, std::move(audio_file_id)),
+            MakeParameter(text_key, ""),
+        };
+        return node;
+    }
+
+    LinkageStrategyWorkflow MakeBranchedWorkflow() {
+        LinkageStrategyWorkflow strategy;
+        strategy.workflow.push_back(MakeAlarmNode("alarm-root", std::string(key::alg::ACTION_ROOT_VALUE)));
+        strategy.workflow.push_back(
+            MakeAudioNode("audio-first", "alarm-root", "speaker-first", "file-first"));
+        strategy.workflow.push_back(
+            MakeAudioNode("audio-sibling", "alarm-root", "speaker-sibling", "file-sibling"));
+        strategy.workflow.push_back(
+            MakeAudioNode("audio-grandchild", "audio-first", "speaker-grandchild", "file-grandchild"));
+        return strategy;
+    }
+
+}  // namespace
+
+TEST_CASE("Linkage runtime classifies compatible action and parameter identifiers", "[linkage-runtime]") {
+    REQUIRE(ClassifyLinkAgeActionId(kLaAlarmDataCode) == LinkAgeActionKind::kAlarm);
+    REQUIRE(ClassifyLinkAgeActionId(kLaAlarmDataLegacyCode) == LinkAgeActionKind::kAlarm);
+    REQUIRE(ClassifyLinkAgeActionId(kLaAudioDeviceCode) == LinkAgeActionKind::kAudioDevice);
+    REQUIRE(ClassifyLinkAgeActionId(kLaAudioDeviceLegacyCode) == LinkAgeActionKind::kAudioDevice);
+    REQUIRE(ClassifyLinkAgeActionId("unsupported") == LinkAgeActionKind::kUnsupported);
+
+    REQUIRE(IsAlarmAlgorithmsKey(kKeyLinkageAlgs));
+    REQUIRE(IsAlarmAlgorithmsKey(kKeyStrageAlgs));
+    REQUIRE_FALSE(IsAlarmAlgorithmsKey("unrelated"));
+
+    REQUIRE(IsAudioDeviceIdKey(kKeyLinkageAudioDeviceId));
+    REQUIRE(IsAudioDeviceIdKey(kKeyStrageAudioDeviceId));
+    REQUIRE_FALSE(IsAudioDeviceIdKey("unrelated"));
+
+    REQUIRE(IsAudioTextKey(kKeyLinkageAudioDeviceText));
+    REQUIRE(IsAudioTextKey(kKeyStrageAudioDeviceText));
+    REQUIRE_FALSE(IsAudioTextKey("unrelated"));
+}
+
+TEST_CASE("LinkAgeBase retains a construction-time action snapshot", "[linkage-runtime]") {
+    auto action          = MakeAlarmNode("flow-original", "parent-original");
+    action.action_name   = "name-original";
+    const auto action_id = action.action_id;
+    LinkAgeBase snapshot(action);
+
+    action.action_id       = "changed-action";
+    action.action_name     = "changed-name";
+    action.flowActionId    = "changed-flow";
+    action.preFlowActionId = "changed-parent";
+    action.config_object.params.clear();
+
+    REQUIRE(snapshot.GetActionId() == action_id);
+    REQUIRE(snapshot.GetName() == "name-original");
+    REQUIRE(snapshot.GetFlowActionId() == "flow-original");
+    REQUIRE(snapshot.GetPreFlowActionId() == "parent-original");
+}
+
+TEST_CASE("Linkage JSON preserves optional-field semantics", "[linkage-runtime]") {
+    LinkAgeParamNode action = MakeAlarmNode("old-flow", "old-parent");
+    action.action_name      = "old-name";
+
+    const nlohmann::json missing_optional = {
+        {"actionId", "new-action"}, {"flowActionId", "new-flow"}, {"preFlowActionId", "new-parent"}};
+    missing_optional.get_to(action);
+    REQUIRE(action.action_name == "old-name");
+    REQUIRE(action.config_object.params.size() == 1);
+
+    auto null_optional            = missing_optional;
+    null_optional["actionName"]   = nullptr;
+    null_optional["configObject"] = nullptr;
+    null_optional.get_to(action);
+    REQUIRE(action.action_name == "old-name");
+    REQUIRE(action.config_object.params.size() == 1);
+
+    auto present_optional            = missing_optional;
+    present_optional["actionName"]   = "new-name";
+    present_optional["configObject"] = {
+        {"params", nlohmann::json::array({{{"key", "algs"}, {"value", "[]"}}})}};
+    present_optional.get_to(action);
+    REQUIRE(action.action_name == "new-name");
+    REQUIRE(action.config_object.params.size() == 1);
+    REQUIRE(action.config_object.params.front().key.ToRefString() == "algs");
+
+    auto missing_action_id = missing_optional;
+    missing_action_id.erase("actionId");
+    REQUIRE_THROWS_AS(missing_action_id.get_to(action), nlohmann::json::out_of_range);
+
+    auto missing_flow_action_id = missing_optional;
+    missing_flow_action_id.erase("flowActionId");
+    REQUIRE_THROWS_AS(missing_flow_action_id.get_to(action), nlohmann::json::out_of_range);
+
+    auto missing_pre_flow_action_id = missing_optional;
+    missing_pre_flow_action_id.erase("preFlowActionId");
+    REQUIRE_THROWS_AS(missing_pre_flow_action_id.get_to(action), nlohmann::json::out_of_range);
+
+    LinkAgeAlarmTaskUnit alarm_task{"old-channel", "old-algorithm"};
+    nlohmann::json::object().get_to(alarm_task);
+    REQUIRE(alarm_task.channel_id == "old-channel");
+    REQUIRE(alarm_task.algorithm_id == "old-algorithm");
+    nlohmann::json({{"channelId", nullptr}, {"algorithmId", nullptr}}).get_to(alarm_task);
+    REQUIRE(alarm_task.channel_id == "old-channel");
+    REQUIRE(alarm_task.algorithm_id == "old-algorithm");
+    nlohmann::json({{"channelId", "new-channel"}, {"algorithmId", "new-algorithm"}}).get_to(alarm_task);
+    REQUIRE(alarm_task.channel_id == "new-channel");
+    REQUIRE(alarm_task.algorithm_id == "new-algorithm");
+
+    LinkageStrategyWorkflow workflow;
+    workflow.workflow.push_back(action);
+    nlohmann::json::object().get_to(workflow);
+    REQUIRE(workflow.workflow.size() == 1);
+    nlohmann::json({{"workflow", nullptr}}).get_to(workflow);
+    REQUIRE(workflow.workflow.size() == 1);
+    nlohmann::json({{"workflow", nlohmann::json::array()}}).get_to(workflow);
+    REQUIRE(workflow.workflow.empty());
+}
+
+TEST_CASE("LinkAgeTask queries sibling and grandchild audio actions", "[linkage-runtime]") {
+    auto strategy = MakeBranchedWorkflow();
+    LinkAgeTask task("branched", strategy);
+
+    REQUIRE(task.IsAudioDeviceInUse("speaker-first"));
+    REQUIRE(task.IsAudioDeviceInUse("speaker-sibling"));
+    REQUIRE(task.IsAudioDeviceInUse("speaker-grandchild"));
+    REQUIRE_FALSE(task.IsAudioDeviceInUse("speaker-missing"));
+
+    REQUIRE(task.IsAudioFileInUse("file-first"));
+    REQUIRE(task.IsAudioFileInUse("file-sibling"));
+    REQUIRE(task.IsAudioFileInUse("file-grandchild"));
+    REQUIRE_FALSE(task.IsAudioFileInUse("file-missing"));
+}
+
+TEST_CASE("LinkAgeTask preserves alarm gating and depth-first sibling order", "[linkage-runtime]") {
+    test::MockServiceRegistry mocks;
+    auto strategy = MakeBranchedWorkflow();
+    LinkAgeTask task("ordered", strategy);
+
+    SECTION("matching root executes descendants in order") {
+        std::vector<std::string> played_devices;
+        REQUIRE_CALL(mocks.audioSvc, PlayAudioDevice(_))
+            .LR_SIDE_EFFECT(played_devices.push_back(_1.devId))
+            .RETURN(true)
+            .TIMES(3);
+
+        task.DoAlarm("channel-1", "algorithm-1");
+
+        REQUIRE(played_devices ==
+                std::vector<std::string>{"speaker-first", "speaker-grandchild", "speaker-sibling"});
+    }
+
+    SECTION("non-matching root suppresses all descendants") {
+        FORBID_CALL(mocks.audioSvc, PlayAudioDevice(_));
+        task.DoAlarm("other-channel", "other-algorithm");
+    }
+}
+
+TEST_CASE("Linkage runtime parses legacy text-play parameters", "[linkage-runtime]") {
+    test::MockServiceRegistry mocks;
+    auto alarm = MakeAlarmNode("alarm-root", std::string(key::alg::ACTION_ROOT_VALUE), kLaAlarmDataLegacyCode,
+                               kKeyStrageAlgs);
+    auto audio = MakeAudioNode("audio", "alarm-root", "legacy-speaker", "unused-audio",
+                               kLaAudioDeviceLegacyCode, kKeyStrageAudioDeviceId, kKeyStrageAudioDeviceText);
+    audio.config_object.params[1].value = std::string("2");
+    audio.config_object.params[3].value = std::string("legacy text");
+
+    LinkageStrategyWorkflow strategy;
+    strategy.workflow = {std::move(alarm), std::move(audio)};
+    LinkAgeTask task("legacy-text", strategy);
+
+    AudioDevicePlay captured;
+    REQUIRE_CALL(mocks.audioSvc, PlayAudioDevice(_)).LR_SIDE_EFFECT(captured = _1).RETURN(true);
+    task.DoAlarm("channel-1", "algorithm-1");
+
+    REQUIRE(captured.devId == "legacy-speaker");
+    REQUIRE(captured.playType == AudioDevicePlayType::AudioDevicePlayTypeTextPlay);
+    REQUIRE(captured.data == "legacy text");
+}
+
+TEST_CASE("Linkage runtime keeps last matching compatibility parameter", "[linkage-runtime]") {
+    test::MockServiceRegistry mocks;
+    auto alarm = MakeAlarmNode("alarm-root", std::string(key::alg::ACTION_ROOT_VALUE));
+    alarm.config_object.params.push_back(
+        MakeParameter(kKeyStrageAlgs, R"([{"channelId":"other-channel","algorithmId":"other-algorithm"}])"));
+    auto audio = MakeAudioNode("audio", "alarm-root", "speaker-first", "file-first");
+    audio.config_object.params.push_back(MakeParameter(kKeyStrageAudioDeviceId, "speaker-last"));
+
+    LinkageStrategyWorkflow strategy;
+    strategy.workflow = {std::move(alarm), std::move(audio)};
+    LinkAgeTask task("compatibility-precedence", strategy);
+
+    REQUIRE_FALSE(task.IsAudioDeviceInUse("speaker-first"));
+    REQUIRE(task.IsAudioDeviceInUse("speaker-last"));
+
+    std::vector<std::string> played_devices;
+    REQUIRE_CALL(mocks.audioSvc, PlayAudioDevice(_))
+        .LR_SIDE_EFFECT(played_devices.push_back(_1.devId))
+        .RETURN(true);
+    task.DoAlarm("channel-1", "algorithm-1");
+    REQUIRE(played_devices.empty());
+    task.DoAlarm("other-channel", "other-algorithm");
+    REQUIRE(played_devices == std::vector<std::string>{"speaker-last"});
+}
+
+}  // namespace cosmo::linkage

--- a/test/test_linkage_service_impl.cc
+++ b/test/test_linkage_service_impl.cc
@@ -49,6 +49,24 @@ std::string MakeValidWorkflow(const std::string& audio_device_id = "speaker-1",
     return nlohmann::json::array({std::move(alarm), std::move(audio)}).dump();
 }
 
+std::string MakeLegacyWorkflow(const std::string& audio_device_id = "legacy-speaker",
+                               const std::string& audio_file_id   = "legacy-audio") {
+    auto workflow           = nlohmann::json::parse(MakeValidWorkflow(audio_device_id, audio_file_id));
+    workflow[0]["actionId"] = "EVT_00001";
+    workflow[0]["configObject"]["params"][0]["key"] = "strageAlgorithms";
+    workflow[1]["actionId"]                         = "DA_00001";
+    workflow[1]["configObject"]["params"][0]["key"] = "deviceSN";
+    workflow[1]["configObject"]["params"][3]["key"] = "dataText";
+    return workflow.dump();
+}
+
+std::string MakeLegacyTextWorkflow() {
+    auto workflow = nlohmann::json::parse(MakeLegacyWorkflow("legacy-text-speaker", "unused-audio"));
+    workflow[1]["configObject"]["params"][1]["value"] = "2";
+    workflow[1]["configObject"]["params"][3]["value"] = "legacy text";
+    return workflow.dump();
+}
+
 // Helper to create a temp test directory with required structure
 struct LinkageTestEnv {
     std::string baseDir;
@@ -202,6 +220,48 @@ TEST_CASE("LinkageServiceImpl: CRUD and query operations", "[linkage-service]") 
         REQUIRE(sut.Add("bound", MakeValidWorkflow("speaker-42", "audio-42"), id) == ErrorEnum::Success);
         REQUIRE(sut.IsAudioDeviceInUse("speaker-42"));
         REQUIRE(sut.IsAudioFileInUse("audio-42"));
+    }
+
+    SECTION("Legacy action and parameter IDs validate, persist, and bind to runtime tasks") {
+        std::string id;
+        REQUIRE(sut.Add("legacy", MakeLegacyWorkflow(), id) == ErrorEnum::Success);
+        REQUIRE(sut.IsAudioDeviceInUse("legacy-speaker"));
+        REQUIRE(sut.IsAudioFileInUse("legacy-audio"));
+
+        size_t total       = 0;
+        const auto results = sut.Query(1, 10, "legacy", total);
+        REQUIRE(total == 1);
+        REQUIRE(results.size() == 1);
+        const auto persisted_workflow = nlohmann::json::parse(results.front().workFlow);
+        REQUIRE(persisted_workflow[0]["actionId"] == "EVT_00001");
+        REQUIRE(persisted_workflow[1]["actionId"] == "DA_00001");
+    }
+
+    SECTION("Legacy text parameters validate and bind to a runtime task") {
+        std::string id;
+        REQUIRE(sut.Add("legacy-text", MakeLegacyTextWorkflow(), id) == ErrorEnum::Success);
+        REQUIRE(sut.IsAudioDeviceInUse("legacy-text-speaker"));
+        REQUIRE_FALSE(sut.IsAudioFileInUse("unused-audio"));
+    }
+
+    SECTION("Validation keeps the first matching compatibility parameter") {
+        auto workflow = nlohmann::json::parse(MakeValidWorkflow());
+        workflow[1]["configObject"]["params"].push_back({{"key", "deviceSN"}, {"value", ""}});
+        std::string id;
+        REQUIRE(sut.Add("first-match", workflow.dump(), id) == ErrorEnum::Success);
+        REQUIRE_FALSE(id.empty());
+        REQUIRE_FALSE(sut.IsAudioDeviceInUse("speaker-1"));
+    }
+
+    SECTION("Unknown actions are rejected without persistence") {
+        auto workflow           = nlohmann::json::parse(MakeValidWorkflow());
+        workflow[1]["actionId"] = "unsupported-action";
+        std::string id;
+        REQUIRE(sut.Add("unsupported", workflow.dump(), id) == ErrorEnum::ParameterException);
+        REQUIRE(id.empty());
+        size_t total = 0;
+        REQUIRE(sut.Query(1, 10, "unsupported", total).empty());
+        REQUIRE(total == 0);
     }
 
     SECTION("Dangling workflow nodes are rejected without persistence") {


### PR DESCRIPTION
## Summary

- 将联动运行时节点状态精简为四个字符串快照，同时保持构造函数、getter、服务接口和 JSON 持久化格式不变。
- 统一 canonical/legacy 动作 ID 与参数键的分类逻辑，使运行时解析和 CRUD 校验共享同一契约。
- 合并动作工厂、任务树挂接与查询遍历逻辑，并补充快照、兼容键、深层查询、执行门控及持久化测试。

## Related issue

Closes #94

## Root cause

联动运行时此前保存了完整 workflow 动作对象，但实际只需要四个不可变标识字段；动作类型和兼容参数键又分别在运行时与校验器中重复判断。任务构建、子节点挂接和占用查询也存在单调用方辅助函数及重复遍历框架，增加了状态、分支和兼容规则漂移的风险。

## Scope

### In scope

- 精简 `LinkAgeBase` 常驻状态并保持构造时快照语义。
- 统一动作类型与 canonical/legacy 参数键分类。
- 简化任务工厂、后代挂接、DFS 查询及 JSON 可选字段读取。
- 扩展 linkage runtime/service 聚焦测试。
- Sophon/aarch64 构建、产包、设备测试和启动烟测。

### Out of scope

- 告警绑定排序或二分查找优化。
- 邻接索引、并行子节点或任务执行顺序变更。
- 公共 API、持久化 schema、日志、线程及对象生命周期变更。
- 未经授权的真实音柱播放。

## Risk tags

- [x] Runtime / lifecycle
- [ ] Thread / memory safety
- [ ] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build / deployment
- [x] Refactor
- [x] Test

## Area

- [x] Backend service
- [ ] Frontend web console
- [x] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [ ] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `1a1cab831ddd4dca2faecc8be6bec76f7ba36365`
- Candidate commit: `e54ae4f79c46fd0b6c48ecb096f92ee8ae24e8b9`
- Candidate tree: `be641e8bf1c88021f928b837dae2f7a1fcd00e84`
- Package SHA-256: `6be7648ad4ea1eebb1ac07391c6675b88d2d68d605928f3e0073d9f294b28f13`
- Test binary SHA-256: `52ce4c1272f833bd2e29404e0a075d29b2868a1e8149d36e3bacd49074b5a8a0`

The candidate was not amended, rebased, or merged after evidence collection. `origin/main` advanced afterward to `213f9202` with documentation-only changes; this branch intentionally remains bound to the validated base and CI should revalidate integration with current `main`.

## Verification

### Parent baseline

```text
BLOCKED
Command: N/A
Environment: parent commit 1a1cab831ddd4dca2faecc8be6bec76f7ba36365.
No retained pre-change aarch64 executable/device result was available before production source edits, and no x86/ONNX result was substituted.
```

### Candidate checks

```text
PASS  docker-compose -f docker-compose.sophon.yml run --rm cosmo-sophon-package bash -lc './scripts/build_test.sh'
PASS  ./scripts/format_check.sh --staged --check
      11/11 changed C++ files passed
PASS  ./scripts/static_analysis.sh --staged --cppcheck
      exit 0; only non-failing std::string_view pass-by-value notices
PASS  git diff --cached --check
PASS  ./.codex/validate_candidate.sh --issue 94 --base origin/main
PASS  docker-compose -f docker-compose.sophon.yml run --rm cosmo-sophon-package
PASS  LD_LIBRARY_PATH=/appfs/cosmo_wander/cwai_data/lib /tmp/cosmo-tests "[linkage-runtime],[linkage-service],[LinkageHandler]" --reporter console
      16 test cases, 143 assertions
PASS  ./.codex/validate_candidate.sh --issue 94 --base origin/main --package build/packages/cosmo-V1.0.0-9625cbc0c351d92c29d45343788bb2ad.tar.gz --tests build/cosmo-tests
PASS  git show --check --stat HEAD
```

### Risk-based evidence

- API/network: external HTTP/API contracts, service interfaces and persisted JSON schema are unchanged.
- Media/streaming: no media pipeline change; real speaker playback remains `BLOCKED` because no clearly authorized non-production speaker and repeatable alarm source were available.
- Sophon/device: focused aarch64 tests passed on an authorized Sophon device; candidate engine started successfully with the matching packaged model-guard runtime.
- Frontend/UI: N/A.
- Package/deployment: canonical Sophon package completed; package and test-binary hashes are recorded above. Engine and matching package guard library must be deployed together.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this behavior-preserving refactor.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: automated checks and focused device validation passed for `e54ae4f79c46fd0b6c48ecb096f92ee8ae24e8b9` / package `6be7648ad4ea1eebb1ac07391c6675b88d2d68d605928f3e0073d9f294b28f13`; real audio playback is `BLOCKED` as noted above.
- Device test filter: `[linkage-runtime],[linkage-service],[LinkageHandler]`
- Device backup state: restored
- Temporary-data cleanup: complete
- Final Git status: clean
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

- During the engine-start smoke, deploying only the candidate engine exposed an existing model-guard ABI mismatch on the device. The candidate started with the matching guard library from the same final package; deployment should update the engine and guard runtime as one package.
- The original engine, guard symlink and configuration were restored, services were returned to systemd management, and temporary device files were removed.
- A real alarm-to-speaker playback smoke was not attempted without an explicitly authorized experimental speaker and repeatable alarm source.
- Alarm-binding sorting/binary-search optimization remains intentionally out of scope pending production-scale measurements.
