### PR TITLE
feat(rk3576): enable validated Qwen3.5 VLM integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ if(COSMO_NN_USE_CPU_BACKEND)
 endif()
 if(COSMO_NN_USE_RKNN_BACKEND)
     include(cmake/rknn.cmake)
+    include(cmake/rkllm.cmake)
 endif()
 if(COSMO_MEDIA_USE_ROCKCHIP_BACKEND)
     include(cmake/rockchip_media.cmake)
@@ -475,7 +476,7 @@ if(COSMO_NN_USE_CPU_BACKEND)
     list(APPEND COMMON_LIBS onnxruntime)
 endif()
 if(COSMO_NN_USE_RKNN_BACKEND)
-    list(APPEND COMMON_LIBS rknnrt)
+    list(APPEND COMMON_LIBS rknnrt rkllmrt)
 endif()
 if(COSMO_MEDIA_USE_ROCKCHIP_BACKEND)
     list(APPEND COMMON_LIBS rockchip_mpp rockchip_rga)
@@ -711,6 +712,10 @@ endif()
 
 if(COSMO_NN_USE_RKNN_BACKEND)
     install(FILES "${RKNN_RUNTIME_LIBRARY}"
+        DESTINATION lib
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
+    )
+    install(FILES "${RKLLM_RUNTIME_LIBRARY}"
         DESTINATION lib
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,7 +476,10 @@ if(COSMO_NN_USE_CPU_BACKEND)
     list(APPEND COMMON_LIBS onnxruntime)
 endif()
 if(COSMO_NN_USE_RKNN_BACKEND)
-    list(APPEND COMMON_LIBS rknnrt rkllmrt)
+    list(APPEND COMMON_LIBS rknnrt)
+endif()
+if(COSMO_NN_USE_RKLLM_BACKEND)
+    list(APPEND COMMON_LIBS rkllmrt)
 endif()
 if(COSMO_MEDIA_USE_ROCKCHIP_BACKEND)
     list(APPEND COMMON_LIBS rockchip_mpp rockchip_rga)
@@ -715,10 +718,12 @@ if(COSMO_NN_USE_RKNN_BACKEND)
         DESTINATION lib
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
     )
-    install(FILES "${RKLLM_RUNTIME_LIBRARY}"
-        DESTINATION lib
-        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
-    )
+    if(COSMO_NN_USE_RKLLM_BACKEND)
+        install(FILES "${RKLLM_RUNTIME_LIBRARY}"
+            DESTINATION lib
+            PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
+        )
+    endif()
 endif()
 
 # Scripts (exclude dev-only tools from device deployment)

--- a/cmake/rkllm.cmake
+++ b/cmake/rkllm.cmake
@@ -8,15 +8,25 @@ endif()
 
 set(RKLLM_RUNTIME_HEADER "${COSMO_RKLLM_ROOT}/include/rkllm.h")
 set(RKLLM_RUNTIME_LIBRARY "${COSMO_RKLLM_ROOT}/lib/librkllmrt.so")
-if(NOT EXISTS "${RKLLM_RUNTIME_HEADER}")
-    message(FATAL_ERROR "RKLLM header not found: ${RKLLM_RUNTIME_HEADER}")
-endif()
-if(NOT EXISTS "${RKLLM_RUNTIME_LIBRARY}")
-    message(FATAL_ERROR "RKLLM runtime not found: ${RKLLM_RUNTIME_LIBRARY}")
-endif()
 
-add_library(rkllmrt SHARED IMPORTED GLOBAL)
-set_target_properties(rkllmrt PROPERTIES
-    IMPORTED_LOCATION "${RKLLM_RUNTIME_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${COSMO_RKLLM_ROOT}/include"
-)
+option(COSMO_RKLLM_REQUIRED "Fail configuration when the RKLLM SDK is unavailable" OFF)
+set(COSMO_NN_USE_RKLLM_BACKEND OFF)
+
+if(EXISTS "${RKLLM_RUNTIME_HEADER}" AND EXISTS "${RKLLM_RUNTIME_LIBRARY}")
+    add_library(rkllmrt SHARED IMPORTED GLOBAL)
+    set_target_properties(rkllmrt PROPERTIES
+        IMPORTED_LOCATION "${RKLLM_RUNTIME_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${COSMO_RKLLM_ROOT}/include"
+    )
+    set(COSMO_NN_USE_RKLLM_BACKEND ON)
+    add_compile_definitions(COSMO_NN_USE_RKLLM_BACKEND)
+    message(STATUS "RKLLM multimodal backend enabled: ${COSMO_RKLLM_ROOT}")
+elseif(COSMO_RKLLM_REQUIRED)
+    message(FATAL_ERROR
+        "RKLLM SDK is required but incomplete under ${COSMO_RKLLM_ROOT} "
+        "(expected include/rkllm.h and lib/librkllmrt.so)")
+else()
+    message(STATUS
+        "RKLLM SDK not found under ${COSMO_RKLLM_ROOT}; "
+        "building the RKNN runtime without Qwen3.5 VLM support")
+endif()

--- a/cmake/rkllm.cmake
+++ b/cmake/rkllm.cmake
@@ -1,0 +1,22 @@
+# RKLLM is packaged with the RKNN target so the deployed service does not depend
+# on a host mount or a board-wide manual installation.
+set(COSMO_RKLLM_ROOT "${COSMO_RKNN_ROOT}" CACHE PATH
+    "RKLLM Runtime root containing include/rkllm.h and lib/librkllmrt.so")
+if(DEFINED ENV{RKLLM_ROOT} AND NOT EXISTS "${COSMO_RKLLM_ROOT}/include/rkllm.h")
+    set(COSMO_RKLLM_ROOT "$ENV{RKLLM_ROOT}" CACHE PATH "RKLLM Runtime root" FORCE)
+endif()
+
+set(RKLLM_RUNTIME_HEADER "${COSMO_RKLLM_ROOT}/include/rkllm.h")
+set(RKLLM_RUNTIME_LIBRARY "${COSMO_RKLLM_ROOT}/lib/librkllmrt.so")
+if(NOT EXISTS "${RKLLM_RUNTIME_HEADER}")
+    message(FATAL_ERROR "RKLLM header not found: ${RKLLM_RUNTIME_HEADER}")
+endif()
+if(NOT EXISTS "${RKLLM_RUNTIME_LIBRARY}")
+    message(FATAL_ERROR "RKLLM runtime not found: ${RKLLM_RUNTIME_LIBRARY}")
+endif()
+
+add_library(rkllmrt SHARED IMPORTED GLOBAL)
+set_target_properties(rkllmrt PROPERTIES
+    IMPORTED_LOCATION "${RKLLM_RUNTIME_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${COSMO_RKLLM_ROOT}/include"
+)

--- a/scripts/cosmo-performance.service
+++ b/scripts/cosmo-performance.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Cosmo RK3576 performance profile
+Before=cosmo.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/rk3576-performance.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/rk3576-performance.sh
+++ b/scripts/rk3576-performance.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+set_governor() {
+    path="$1"
+    governor="$2"
+    if [ -w "$path" ]; then
+        printf '%s\n' "$governor" > "$path"
+    fi
+}
+
+set_governor /sys/class/devfreq/27700000.npu/governor performance
+set_governor /sys/class/devfreq/dmc/governor performance
+
+for policy in /sys/devices/system/cpu/cpufreq/policy*; do
+    set_governor "$policy/scaling_governor" performance
+done

--- a/src/infer/CMakeLists.txt
+++ b/src/infer/CMakeLists.txt
@@ -41,9 +41,14 @@ if(COSMO_NN_USE_CPU_BACKEND)
         COSMO_NN_USE_ONNX_BACKEND)
 endif()
 
-if(COSMO_NN_USE_RKNN_BACKEND)
+if(COSMO_NN_USE_RKLLM_BACKEND)
     target_sources(cosmo_infer PRIVATE RkllmVlmBackend.cc RkllmVlmBackend.h)
     target_link_libraries(cosmo_infer PRIVATE rknnrt rkllmrt)
+elseif(COSMO_NN_USE_RKNN_BACKEND)
+    target_link_libraries(cosmo_infer PRIVATE rknnrt)
+endif()
+
+if(COSMO_NN_USE_RKNN_BACKEND)
     target_compile_definitions(cosmo_infer PRIVATE
         COSMO_NN_USE_RKNN_BACKEND
         COSMO_NN_USE_HOST_BACKEND

--- a/src/infer/CMakeLists.txt
+++ b/src/infer/CMakeLists.txt
@@ -42,7 +42,8 @@ if(COSMO_NN_USE_CPU_BACKEND)
 endif()
 
 if(COSMO_NN_USE_RKNN_BACKEND)
-    target_link_libraries(cosmo_infer PRIVATE rknnrt)
+    target_sources(cosmo_infer PRIVATE RkllmVlmBackend.cc RkllmVlmBackend.h)
+    target_link_libraries(cosmo_infer PRIVATE rknnrt rkllmrt)
     target_compile_definitions(cosmo_infer PRIVATE
         COSMO_NN_USE_RKNN_BACKEND
         COSMO_NN_USE_HOST_BACKEND

--- a/src/infer/Qwen3VLUnify.cc
+++ b/src/infer/Qwen3VLUnify.cc
@@ -6,6 +6,9 @@
 #include <cstring>
 
 #include "infer/AiComponment.h"
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+#include "infer/RkllmVlmBackend.h"
+#endif
 #include "util/Log.h"
 #include "util/UuidUtil.h"
 
@@ -19,6 +22,21 @@ Qwen3VLUnify::~Qwen3VLUnify() {
 }
 
 util::ErrorEnum Qwen3VLUnify::Init() {
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+    if (rkllm_backend_) {
+        return util::ErrorEnum::Created;
+    }
+    auto backend = std::make_unique<RkllmVlmBackend>(model_path_);
+    auto ret     = backend->Init();
+    if (ret != util::ErrorEnum::Success) {
+        LOG_ERRO("RKLLM Qwen3.5 initialization failed. ModelPath:{} Ret:{}", model_path_, ret);
+        return ret;
+    }
+    rkllm_backend_ = std::move(backend);
+    max_batch_size_ = 1;
+    LOG_INFO("RKLLM Qwen3.5 initialized. ModelPath:{}", model_path_);
+    return util::ErrorEnum::Success;
+#else
     if (generator_) {
         LOG_WARN("{}", "Init SDK Qwen3VL Failed. Already Init");
         return util::ErrorEnum::Created;
@@ -48,6 +66,7 @@ util::ErrorEnum Qwen3VLUnify::Init() {
     max_batch_size_ = static_cast<size_t>(generator_->GetMaxBatchSize());
 
     return util::ErrorEnum::Success;
+#endif
 }
 
 util::ErrorEnum Qwen3VLUnify::Generate(const std::vector<VideoFramePtr>& images,
@@ -55,7 +74,11 @@ util::ErrorEnum Qwen3VLUnify::Generate(const std::vector<VideoFramePtr>& images,
                                        const Qwen3VLGenerationParam& gen_param,
                                        std::vector<Qwen3VLResult>& results) {
     auto start = std::chrono::high_resolution_clock::now();
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+    if (!rkllm_backend_) {
+#else
     if (!generator_) {
+#endif
         LOG_WARN("{}", "SDK Qwen3VL Not Init");
         return util::ErrorEnum::NotInit;
     }
@@ -103,8 +126,11 @@ util::ErrorEnum Qwen3VLUnify::Generate(const std::vector<VideoFramePtr>& images,
 
 util::ErrorEnum Qwen3VLUnify::Forward(const std::vector<VideoFramePtr>& images,
                                       const std::vector<std::string>& prompts,
-                                      const Qwen3VLGenerationParam& /*gen_param*/,
+                                      const Qwen3VLGenerationParam& gen_param,
                                       std::vector<Qwen3VLResult>& results) {
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+    return rkllm_backend_->Generate(images, prompts, gen_param, results);
+#else
     // Qwen3VL uses host-memory BGR blobs (VideoFrame is decoded host memory)
     std::vector<std::shared_ptr<cosmo::nn::Blob>> image_blobs{};
     for (const auto& img : images) {
@@ -204,15 +230,20 @@ util::ErrorEnum Qwen3VLUnify::Forward(const std::vector<VideoFramePtr>& images,
     }
     LOG_DEBUG("[Qwen3VL] Forward done. images:{} results:{}", images.size(), results.size());
     return util::ErrorEnum::Success;
+#endif
 }
 
 util::ErrorEnum Qwen3VLUnify::GetMaxBatchSize(size_t* value) const {
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+    if (!rkllm_backend_) {
+#else
     if (!generator_) {
+#endif
         LOG_WARN("{}", "SDK Qwen3VL Not Init");
         return util::ErrorEnum::NotInit;
     }
     if (value) {
-        *value = static_cast<size_t>(generator_->GetMaxBatchSize());
+        *value = max_batch_size_;
     }
     return util::ErrorEnum::Success;
 }

--- a/src/infer/Qwen3VLUnify.cc
+++ b/src/infer/Qwen3VLUnify.cc
@@ -6,7 +6,7 @@
 #include <cstring>
 
 #include "infer/AiComponment.h"
-#ifdef COSMO_NN_USE_RKNN_BACKEND
+#ifdef COSMO_NN_USE_RKLLM_BACKEND
 #include "infer/RkllmVlmBackend.h"
 #endif
 #include "util/Log.h"
@@ -22,7 +22,7 @@ Qwen3VLUnify::~Qwen3VLUnify() {
 }
 
 util::ErrorEnum Qwen3VLUnify::Init() {
-#ifdef COSMO_NN_USE_RKNN_BACKEND
+#ifdef COSMO_NN_USE_RKLLM_BACKEND
     if (rkllm_backend_) {
         return util::ErrorEnum::Created;
     }
@@ -74,7 +74,7 @@ util::ErrorEnum Qwen3VLUnify::Generate(const std::vector<VideoFramePtr>& images,
                                        const Qwen3VLGenerationParam& gen_param,
                                        std::vector<Qwen3VLResult>& results) {
     auto start = std::chrono::high_resolution_clock::now();
-#ifdef COSMO_NN_USE_RKNN_BACKEND
+#ifdef COSMO_NN_USE_RKLLM_BACKEND
     if (!rkllm_backend_) {
 #else
     if (!generator_) {
@@ -128,7 +128,7 @@ util::ErrorEnum Qwen3VLUnify::Forward(const std::vector<VideoFramePtr>& images,
                                       const std::vector<std::string>& prompts,
                                       const Qwen3VLGenerationParam& gen_param,
                                       std::vector<Qwen3VLResult>& results) {
-#ifdef COSMO_NN_USE_RKNN_BACKEND
+#ifdef COSMO_NN_USE_RKLLM_BACKEND
     return rkllm_backend_->Generate(images, prompts, gen_param, results);
 #else
     // Qwen3VL uses host-memory BGR blobs (VideoFrame is decoded host memory)
@@ -234,7 +234,7 @@ util::ErrorEnum Qwen3VLUnify::Forward(const std::vector<VideoFramePtr>& images,
 }
 
 util::ErrorEnum Qwen3VLUnify::GetMaxBatchSize(size_t* value) const {
-#ifdef COSMO_NN_USE_RKNN_BACKEND
+#ifdef COSMO_NN_USE_RKLLM_BACKEND
     if (!rkllm_backend_) {
 #else
     if (!generator_) {

--- a/src/infer/Qwen3VLUnify.h
+++ b/src/infer/Qwen3VLUnify.h
@@ -12,7 +12,7 @@
 #include "nn/utils/default_component.h"
 
 namespace cosmo {
-#ifdef COSMO_NN_USE_RKNN_BACKEND
+#ifdef COSMO_NN_USE_RKLLM_BACKEND
 class RkllmVlmBackend;
 #endif
 struct Qwen3VLGenerationParam {
@@ -52,7 +52,7 @@ private:
     std::string cfg_path_;
     std::string model_path_;
     std::string tokenizer_path_;
-#ifdef COSMO_NN_USE_RKNN_BACKEND
+#ifdef COSMO_NN_USE_RKLLM_BACKEND
     std::unique_ptr<RkllmVlmBackend> rkllm_backend_;
 #else
     std::unique_ptr<cosmo::nn::DefaultComponent> generator_;

--- a/src/infer/Qwen3VLUnify.h
+++ b/src/infer/Qwen3VLUnify.h
@@ -12,6 +12,9 @@
 #include "nn/utils/default_component.h"
 
 namespace cosmo {
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+class RkllmVlmBackend;
+#endif
 struct Qwen3VLGenerationParam {
     bool do_sample{true};
     int top_k{20};
@@ -49,7 +52,11 @@ private:
     std::string cfg_path_;
     std::string model_path_;
     std::string tokenizer_path_;
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+    std::unique_ptr<RkllmVlmBackend> rkllm_backend_;
+#else
     std::unique_ptr<cosmo::nn::DefaultComponent> generator_;
+#endif
     AppProfiler profiler_;
 };
 

--- a/src/infer/RkllmVlmBackend.cc
+++ b/src/infer/RkllmVlmBackend.cc
@@ -1,0 +1,387 @@
+#include "infer/RkllmVlmBackend.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <utility>
+
+#include "infer/Qwen3VLUnify.h"
+#include "media/PixelFormat.h"
+#include "rkllm.h"
+#include "rknn_api.h"
+#include "util/Log.h"
+
+namespace cosmo {
+namespace {
+
+struct ImageEncoderContext {
+    rknn_context ctx{0};
+    rknn_input_output_num io_num{};
+    std::vector<rknn_tensor_attr> inputs;
+    std::vector<rknn_tensor_attr> outputs;
+    int width{0};
+    int height{0};
+    int channels{0};
+    int image_tokens{0};
+    int embed_size{0};
+};
+
+struct RunContext {
+    std::string text;
+    bool failed{false};
+};
+
+int RkllmResultCallback(RKLLMResult* result, void* userdata, LLMCallState state) {
+    auto* context = static_cast<RunContext*>(userdata);
+    if (!context) {
+        return 0;
+    }
+    if (state == RKLLM_RUN_ERROR) {
+        context->failed = true;
+    } else if (state == RKLLM_RUN_NORMAL && result && result->text) {
+        context->text.append(result->text);
+    }
+    return 0;
+}
+
+void ReleaseImageEncoder(ImageEncoderContext& encoder) {
+    if (encoder.ctx != 0) {
+        rknn_destroy(encoder.ctx);
+        encoder.ctx = 0;
+    }
+    encoder.inputs.clear();
+    encoder.outputs.clear();
+}
+
+bool InitImageEncoder(const std::string& path, ImageEncoderContext& encoder) {
+    int ret = rknn_init(&encoder.ctx, const_cast<char*>(path.c_str()), 0, 0, nullptr);
+    if (ret != RKNN_SUCC) {
+        LOG_ERRO("RKLLM vision encoder init failed. path:{} ret:{}", path, ret);
+        return false;
+    }
+
+    ret = rknn_set_core_mask(encoder.ctx, RKNN_NPU_CORE_0_1);
+    if (ret != RKNN_SUCC) {
+        LOG_ERRO("RKLLM vision encoder core selection failed. ret:{}", ret);
+        ReleaseImageEncoder(encoder);
+        return false;
+    }
+
+    ret = rknn_query(encoder.ctx, RKNN_QUERY_IN_OUT_NUM, &encoder.io_num, sizeof(encoder.io_num));
+    if (ret != RKNN_SUCC || encoder.io_num.n_input != 1 || encoder.io_num.n_output < 1) {
+        LOG_ERRO("RKLLM invalid vision encoder IO. ret:{} inputs:{} outputs:{}", ret,
+                 encoder.io_num.n_input, encoder.io_num.n_output);
+        ReleaseImageEncoder(encoder);
+        return false;
+    }
+
+    encoder.inputs.resize(encoder.io_num.n_input);
+    for (uint32_t i = 0; i < encoder.io_num.n_input; ++i) {
+        encoder.inputs[i]       = {};
+        encoder.inputs[i].index = i;
+        if (rknn_query(encoder.ctx, RKNN_QUERY_INPUT_ATTR, &encoder.inputs[i],
+                       sizeof(rknn_tensor_attr)) != RKNN_SUCC) {
+            LOG_ERRO("RKLLM vision encoder input query failed. index:{}", i);
+            ReleaseImageEncoder(encoder);
+            return false;
+        }
+    }
+
+    encoder.outputs.resize(encoder.io_num.n_output);
+    for (uint32_t i = 0; i < encoder.io_num.n_output; ++i) {
+        encoder.outputs[i]       = {};
+        encoder.outputs[i].index = i;
+        if (rknn_query(encoder.ctx, RKNN_QUERY_OUTPUT_ATTR, &encoder.outputs[i],
+                       sizeof(rknn_tensor_attr)) != RKNN_SUCC) {
+            LOG_ERRO("RKLLM vision encoder output query failed. index:{}", i);
+            ReleaseImageEncoder(encoder);
+            return false;
+        }
+    }
+
+    const auto& input = encoder.inputs.front();
+    if (input.fmt == RKNN_TENSOR_NCHW) {
+        encoder.channels = input.dims[1];
+        encoder.height   = input.dims[2];
+        encoder.width    = input.dims[3];
+    } else {
+        encoder.height   = input.dims[1];
+        encoder.width    = input.dims[2];
+        encoder.channels = input.dims[3];
+    }
+
+    const auto& output = encoder.outputs.front();
+    for (uint32_t i = 0; i + 1 < output.n_dims; ++i) {
+        if (output.dims[i] > 1 && output.dims[i + 1] > 1) {
+            encoder.image_tokens = output.dims[i];
+            encoder.embed_size   = output.dims[i + 1];
+            break;
+        }
+    }
+    if (encoder.width <= 0 || encoder.height <= 0 || encoder.channels != 3 ||
+        encoder.image_tokens <= 0 || encoder.embed_size <= 0) {
+        LOG_ERRO("RKLLM unsupported vision encoder shape. image:{}x{}x{} tokens:{} embed:{}",
+                 encoder.width, encoder.height, encoder.channels, encoder.image_tokens,
+                 encoder.embed_size);
+        ReleaseImageEncoder(encoder);
+        return false;
+    }
+
+    LOG_INFO("RKLLM vision encoder ready. path:{} image:{}x{} tokens:{} embed:{} outputs:{}", path,
+             encoder.width, encoder.height, encoder.image_tokens, encoder.embed_size,
+             encoder.io_num.n_output);
+    return true;
+}
+
+std::vector<uint8_t> ResizeFrameToRgb(const VideoFramePtr& frame, int dst_width, int dst_height) {
+    const int src_width  = static_cast<int>(frame->GetWidth());
+    const int src_height = static_cast<int>(frame->GetHeight());
+    auto* src = frame->GetHostData() ? frame->GetHostData() : frame->GetData();
+    if (!src || src_width <= 0 || src_height <= 0 || dst_width <= 0 || dst_height <= 0) {
+        return {};
+    }
+
+    const int square_size = std::max(src_width, src_height);
+    const int x_offset    = (square_size - src_width) / 2;
+    const int y_offset    = (square_size - src_height) / 2;
+    const bool input_bgr  = frame->GetPixelFormat() == media::PixelFormat::PIXEL_BGR8;
+    const bool input_rgb  = frame->GetPixelFormat() == media::PixelFormat::PIXEL_RGB8;
+    if (!input_bgr && !input_rgb) {
+        return {};
+    }
+
+    std::vector<uint8_t> output(static_cast<size_t>(dst_width) * dst_height * 3, 128);
+    auto channel = [&](int x, int y, int c) -> float {
+        if (x < x_offset || x >= x_offset + src_width || y < y_offset ||
+            y >= y_offset + src_height) {
+            return 127.5F;
+        }
+        const int sx = x - x_offset;
+        const int sy = y - y_offset;
+        const int source_channel = input_bgr ? (2 - c) : c;
+        return static_cast<float>(src[(static_cast<size_t>(sy) * src_width + sx) * 3 +
+                                      source_channel]);
+    };
+
+    for (int y = 0; y < dst_height; ++y) {
+        const float square_y = (static_cast<float>(y) + 0.5F) * square_size / dst_height - 0.5F;
+        const int y0 = static_cast<int>(std::floor(square_y));
+        const int y1 = y0 + 1;
+        const float fy = square_y - y0;
+        for (int x = 0; x < dst_width; ++x) {
+            const float square_x = (static_cast<float>(x) + 0.5F) * square_size / dst_width - 0.5F;
+            const int x0 = static_cast<int>(std::floor(square_x));
+            const int x1 = x0 + 1;
+            const float fx = square_x - x0;
+            for (int c = 0; c < 3; ++c) {
+                const float v00 = channel(std::clamp(x0, 0, square_size - 1),
+                                          std::clamp(y0, 0, square_size - 1), c);
+                const float v01 = channel(std::clamp(x1, 0, square_size - 1),
+                                          std::clamp(y0, 0, square_size - 1), c);
+                const float v10 = channel(std::clamp(x0, 0, square_size - 1),
+                                          std::clamp(y1, 0, square_size - 1), c);
+                const float v11 = channel(std::clamp(x1, 0, square_size - 1),
+                                          std::clamp(y1, 0, square_size - 1), c);
+                const float value = (v00 * (1.0F - fx) + v01 * fx) * (1.0F - fy) +
+                                    (v10 * (1.0F - fx) + v11 * fx) * fy;
+                output[(static_cast<size_t>(y) * dst_width + x) * 3 + c] =
+                    static_cast<uint8_t>(std::clamp(value, 0.0F, 255.0F));
+            }
+        }
+    }
+    return output;
+}
+
+bool EncodeImage(ImageEncoderContext& encoder, const std::vector<uint8_t>& image,
+                 std::vector<float>& embedding) {
+    rknn_input input{};
+    input.index = 0;
+    input.type  = RKNN_TENSOR_UINT8;
+    input.fmt   = RKNN_TENSOR_NHWC;
+    input.size  = static_cast<uint32_t>(image.size());
+    input.buf   = const_cast<uint8_t*>(image.data());
+    if (rknn_inputs_set(encoder.ctx, 1, &input) != RKNN_SUCC ||
+        rknn_run(encoder.ctx, nullptr) != RKNN_SUCC) {
+        LOG_ERRO("{}", "RKLLM vision encoder inference failed");
+        return false;
+    }
+
+    std::vector<rknn_output> outputs(encoder.io_num.n_output);
+    for (uint32_t i = 0; i < encoder.io_num.n_output; ++i) {
+        outputs[i]            = {};
+        outputs[i].index      = i;
+        outputs[i].want_float = 1;
+    }
+    if (rknn_outputs_get(encoder.ctx, encoder.io_num.n_output, outputs.data(), nullptr) != RKNN_SUCC) {
+        LOG_ERRO("{}", "RKLLM vision encoder output retrieval failed");
+        return false;
+    }
+
+    const size_t per_output = static_cast<size_t>(encoder.image_tokens) * encoder.embed_size;
+    embedding.assign(per_output * encoder.io_num.n_output, 0.0F);
+    if (encoder.io_num.n_output == 1) {
+        const size_t available = outputs[0].size / sizeof(float);
+        std::memcpy(embedding.data(), outputs[0].buf,
+                    std::min(embedding.size(), available) * sizeof(float));
+    } else {
+        for (int token = 0; token < encoder.image_tokens; ++token) {
+            for (uint32_t j = 0; j < encoder.io_num.n_output; ++j) {
+                const auto* source = static_cast<const float*>(outputs[j].buf) +
+                                     static_cast<size_t>(token) * encoder.embed_size;
+                auto* destination = embedding.data() +
+                                    (static_cast<size_t>(token) * encoder.io_num.n_output + j) *
+                                        encoder.embed_size;
+                std::memcpy(destination, source, encoder.embed_size * sizeof(float));
+            }
+        }
+    }
+    rknn_outputs_release(encoder.ctx, encoder.io_num.n_output, outputs.data());
+    return true;
+}
+
+}  // namespace
+
+struct RkllmVlmBackend::Impl {
+    LLMHandle llm{nullptr};
+    RKLLMCallback callback{};
+    ImageEncoderContext encoder;
+};
+
+RkllmVlmBackend::RkllmVlmBackend(std::string model_path)
+    : model_path_(std::move(model_path)) {}
+
+RkllmVlmBackend::~RkllmVlmBackend() {
+    if (!impl_) {
+        return;
+    }
+    ReleaseImageEncoder(impl_->encoder);
+    if (impl_->llm) {
+        rkllm_destroy(impl_->llm);
+        impl_->llm = nullptr;
+    }
+    delete impl_;
+    impl_ = nullptr;
+}
+
+util::ErrorEnum RkllmVlmBackend::Init() {
+    if (impl_) {
+        return util::ErrorEnum::Created;
+    }
+    const std::filesystem::path configured_path(model_path_);
+    const auto model_dir = std::filesystem::is_directory(configured_path)
+                               ? configured_path
+                               : configured_path.parent_path();
+    const auto llm_path = configured_path.extension() == ".rkllm"
+                              ? configured_path
+                              : model_dir / "model.rkllm";
+    const auto vision_path = model_dir / "vision.rknn";
+    if (!std::filesystem::is_regular_file(llm_path) ||
+        !std::filesystem::is_regular_file(vision_path)) {
+        LOG_ERRO("RKLLM model files missing. llm:{} vision:{}", llm_path.string(),
+                 vision_path.string());
+        return util::ErrorEnum::FileNotExist;
+    }
+    // ModelPathMapper may select vision.rknn after the visual encoder is added to the
+    // model directory. RKLLM must always receive the adjacent language model instead.
+    model_path_ = llm_path.string();
+
+    std::unique_ptr<Impl> candidate(new Impl());
+    RKLLMParam param                 = rkllm_createDefaultParam();
+    param.model_path                 = model_path_.c_str();
+    param.top_k                      = 1;
+    param.max_new_tokens             = 16;
+    param.max_context_len            = 4096;
+    param.skip_special_token         = true;
+    param.extend_param.base_domain_id = 1;
+    candidate->callback.result_callback = RkllmResultCallback;
+    if (rkllm_init(&candidate->llm, &param, &candidate->callback) != 0) {
+        LOG_ERRO("RKLLM language model init failed. path:{}", model_path_);
+        return util::ErrorEnum::Failed;
+    }
+    if (!InitImageEncoder(vision_path.string(), candidate->encoder)) {
+        rkllm_destroy(candidate->llm);
+        candidate->llm = nullptr;
+        return util::ErrorEnum::Failed;
+    }
+
+    impl_ = candidate.release();
+    LOG_INFO("RKLLM multimodal backend initialized. llm:{} vision:{}", model_path_,
+             vision_path.string());
+    return util::ErrorEnum::Success;
+}
+
+util::ErrorEnum RkllmVlmBackend::Generate(const std::vector<VideoFramePtr>& images,
+                                          const std::vector<std::string>& prompts,
+                                          const Qwen3VLGenerationParam& gen_param,
+                                          std::vector<Qwen3VLResult>& results) {
+    if (!impl_) {
+        return util::ErrorEnum::NotInit;
+    }
+    if (images.size() != prompts.size()) {
+        return util::ErrorEnum::InvalidParam;
+    }
+
+    for (size_t i = 0; i < images.size(); ++i) {
+        if (!images[i] || !VideoFrameValid(images[i])) {
+            return util::ErrorEnum::InvalidParam;
+        }
+        auto rgb = ResizeFrameToRgb(images[i], impl_->encoder.width, impl_->encoder.height);
+        if (rgb.empty()) {
+            LOG_ERRO("RKLLM unsupported or empty frame. format:{} dims:{}x{}",
+                     static_cast<int>(images[i]->GetPixelFormat()), images[i]->GetWidth(),
+                     images[i]->GetHeight());
+            return util::ErrorEnum::InvalidParam;
+        }
+        std::vector<float> embedding;
+        if (!EncodeImage(impl_->encoder, rgb, embedding)) {
+            return util::ErrorEnum::AI_FORWARD_FAILED;
+        }
+
+        std::string prompt = prompts[i];
+        if (prompt.find("<image>") == std::string::npos) {
+            prompt.insert(0, "<image>");
+        }
+        RKLLMInput input{};
+        input.role                                      = "user";
+        input.enable_thinking                           = false;
+        input.input_type                                = RKLLM_INPUT_MULTIMODAL;
+        input.multimodal_input.prompt                   = prompt.data();
+        input.multimodal_input.image.image_embed        = embedding.data();
+        input.multimodal_input.image.n_image_tokens     = impl_->encoder.image_tokens;
+        input.multimodal_input.image.n_image            = 1;
+        input.multimodal_input.image.image_start        = "<|vision_start|>";
+        input.multimodal_input.image.image_end          = "<|vision_end|>";
+        input.multimodal_input.image.image_content      = "<|image_pad|>";
+        input.multimodal_input.image.image_width        = impl_->encoder.width;
+        input.multimodal_input.image.image_height       = impl_->encoder.height;
+
+        RKLLMSamplingParam sampling{};
+        sampling.top_k       = gen_param.do_sample ? gen_param.top_k : 1;
+        sampling.top_p       = gen_param.do_sample ? gen_param.top_p : 1.0F;
+        sampling.temperature = gen_param.do_sample ? gen_param.temperature : 0.0F;
+        sampling.repeat_penalty = 1.1F;
+        RKLLMInferParam infer{};
+        infer.mode            = RKLLM_INFER_GENERATE;
+        infer.keep_history    = 0;
+        infer.max_new_tokens  = 16;
+        infer.sampling_params = &sampling;
+        RunContext run;
+        const int ret = rkllm_run(impl_->llm, &input, &infer, &run);
+        if (ret != 0 || run.failed) {
+            LOG_ERRO("RKLLM multimodal inference failed. ret:{} callbackError:{}", ret, run.failed);
+            return util::ErrorEnum::AI_FORWARD_FAILED;
+        }
+
+        Qwen3VLResult result;
+        result.text        = std::move(run.text);
+        result.frame_index = static_cast<int64_t>(images[i]->GetFrameIndex());
+        result.timestamp   = images[i]->GetTimestamp();
+        LOG_INFO("[Qwen3VL][RKLLM] frameIndex:{} result:{}", result.frame_index, result.text);
+        results.push_back(std::move(result));
+    }
+    return util::ErrorEnum::Success;
+}
+
+}  // namespace cosmo

--- a/src/infer/RkllmVlmBackend.cc
+++ b/src/infer/RkllmVlmBackend.cc
@@ -1,6 +1,7 @@
 #include "infer/RkllmVlmBackend.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <filesystem>
@@ -135,12 +136,13 @@ bool InitImageEncoder(const std::string& path, ImageEncoderContext& encoder) {
     return true;
 }
 
-std::vector<uint8_t> ResizeFrameToRgb(const VideoFramePtr& frame, int dst_width, int dst_height) {
+bool ResizeFrameToRgb(const VideoFramePtr& frame, int dst_width, int dst_height,
+                      std::vector<uint8_t>& output) {
     const int src_width  = static_cast<int>(frame->GetWidth());
     const int src_height = static_cast<int>(frame->GetHeight());
     auto* src = frame->GetHostData() ? frame->GetHostData() : frame->GetData();
     if (!src || src_width <= 0 || src_height <= 0 || dst_width <= 0 || dst_height <= 0) {
-        return {};
+        return false;
     }
 
     const int square_size = std::max(src_width, src_height);
@@ -149,10 +151,11 @@ std::vector<uint8_t> ResizeFrameToRgb(const VideoFramePtr& frame, int dst_width,
     const bool input_bgr  = frame->GetPixelFormat() == media::PixelFormat::PIXEL_BGR8;
     const bool input_rgb  = frame->GetPixelFormat() == media::PixelFormat::PIXEL_RGB8;
     if (!input_bgr && !input_rgb) {
-        return {};
+        return false;
     }
 
-    std::vector<uint8_t> output(static_cast<size_t>(dst_width) * dst_height * 3, 128);
+    output.resize(static_cast<size_t>(dst_width) * dst_height * 3);
+    std::fill(output.begin(), output.end(), 128);
     auto channel = [&](int x, int y, int c) -> float {
         if (x < x_offset || x >= x_offset + src_width || y < y_offset ||
             y >= y_offset + src_height) {
@@ -191,7 +194,7 @@ std::vector<uint8_t> ResizeFrameToRgb(const VideoFramePtr& frame, int dst_width,
             }
         }
     }
-    return output;
+    return true;
 }
 
 bool EncodeImage(ImageEncoderContext& encoder, const std::vector<uint8_t>& image,
@@ -220,7 +223,7 @@ bool EncodeImage(ImageEncoderContext& encoder, const std::vector<uint8_t>& image
     }
 
     const size_t per_output = static_cast<size_t>(encoder.image_tokens) * encoder.embed_size;
-    embedding.assign(per_output * encoder.io_num.n_output, 0.0F);
+    embedding.resize(per_output * encoder.io_num.n_output);
     if (encoder.io_num.n_output == 1) {
         const size_t available = outputs[0].size / sizeof(float);
         std::memcpy(embedding.data(), outputs[0].buf,
@@ -291,8 +294,11 @@ util::ErrorEnum RkllmVlmBackend::Init() {
     RKLLMParam param                 = rkllm_createDefaultParam();
     param.model_path                 = model_path_.c_str();
     param.top_k                      = 1;
-    param.max_new_tokens             = 16;
-    param.max_context_len            = 4096;
+    // This backend is used for short visual judgements. 64 image tokens plus the
+    // prompt and answer fit comfortably in 512 tokens, avoiding an oversized KV
+    // cache and generation budget on the edge device.
+    param.max_new_tokens             = 2;
+    param.max_context_len            = 512;
     param.skip_special_token         = true;
     param.extend_param.base_domain_id = 1;
     candidate->callback.result_callback = RkllmResultCallback;
@@ -323,21 +329,27 @@ util::ErrorEnum RkllmVlmBackend::Generate(const std::vector<VideoFramePtr>& imag
         return util::ErrorEnum::InvalidParam;
     }
 
+    // The worker repeatedly calls Generate on the same thread. Keep the two large
+    // scratch buffers thread-local so they retain capacity without sharing mutable
+    // memory between camera workers.
+    thread_local std::vector<uint8_t> rgb;
+    thread_local std::vector<float> embedding;
     for (size_t i = 0; i < images.size(); ++i) {
         if (!images[i] || !VideoFrameValid(images[i])) {
             return util::ErrorEnum::InvalidParam;
         }
-        auto rgb = ResizeFrameToRgb(images[i], impl_->encoder.width, impl_->encoder.height);
-        if (rgb.empty()) {
+        const auto preprocess_start = std::chrono::steady_clock::now();
+        if (!ResizeFrameToRgb(images[i], impl_->encoder.width, impl_->encoder.height, rgb)) {
             LOG_ERRO("RKLLM unsupported or empty frame. format:{} dims:{}x{}",
                      static_cast<int>(images[i]->GetPixelFormat()), images[i]->GetWidth(),
                      images[i]->GetHeight());
             return util::ErrorEnum::InvalidParam;
         }
-        std::vector<float> embedding;
+        const auto vision_start = std::chrono::steady_clock::now();
         if (!EncodeImage(impl_->encoder, rgb, embedding)) {
             return util::ErrorEnum::AI_FORWARD_FAILED;
         }
+        const auto prefill_start = std::chrono::steady_clock::now();
 
         std::string prompt = prompts[i];
         if (prompt.find("<image>") == std::string::npos) {
@@ -365,9 +377,10 @@ util::ErrorEnum RkllmVlmBackend::Generate(const std::vector<VideoFramePtr>& imag
         RKLLMInferParam infer{};
         infer.mode            = RKLLM_INFER_GENERATE;
         infer.keep_history    = 0;
-        infer.max_new_tokens  = 16;
+        infer.max_new_tokens  = 2;
         infer.sampling_params = &sampling;
         RunContext run;
+        run.text.reserve(8);
         const int ret = rkllm_run(impl_->llm, &input, &infer, &run);
         if (ret != 0 || run.failed) {
             LOG_ERRO("RKLLM multimodal inference failed. ret:{} callbackError:{}", ret, run.failed);
@@ -378,6 +391,20 @@ util::ErrorEnum RkllmVlmBackend::Generate(const std::vector<VideoFramePtr>& imag
         result.text        = std::move(run.text);
         result.frame_index = static_cast<int64_t>(images[i]->GetFrameIndex());
         result.timestamp   = images[i]->GetTimestamp();
+        const auto finish = std::chrono::steady_clock::now();
+        const auto preprocess_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                       vision_start - preprocess_start)
+                                       .count();
+        const auto vision_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   prefill_start - vision_start)
+                                   .count();
+        const auto llm_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                finish - prefill_start)
+                                .count();
+        LOG_INFO("[Qwen3VL][RKLLM][Timing] preprocess:{}ms vision:{}ms llm:{}ms total:{}ms "
+                 "tokens:{}",
+                 preprocess_ms, vision_ms, llm_ms, preprocess_ms + vision_ms + llm_ms,
+                 impl_->encoder.image_tokens);
         LOG_INFO("[Qwen3VL][RKLLM] frameIndex:{} result:{}", result.frame_index, result.text);
         results.push_back(std::move(result));
     }

--- a/src/infer/RkllmVlmBackend.h
+++ b/src/infer/RkllmVlmBackend.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "infer/AiCommon.h"
+#include "media/VideoFrame.h"
+#include "util/ErrorCode.h"
+
+namespace cosmo {
+
+struct Qwen3VLGenerationParam;
+struct Qwen3VLResult;
+
+class RkllmVlmBackend {
+public:
+    explicit RkllmVlmBackend(std::string model_path);
+    ~RkllmVlmBackend();
+
+    RkllmVlmBackend(const RkllmVlmBackend&)            = delete;
+    RkllmVlmBackend& operator=(const RkllmVlmBackend&) = delete;
+
+    util::ErrorEnum Init();
+    util::ErrorEnum Generate(const std::vector<VideoFramePtr>& images,
+                             const std::vector<std::string>& prompts,
+                             const Qwen3VLGenerationParam& gen_param,
+                             std::vector<Qwen3VLResult>& results);
+
+private:
+    struct Impl;
+    Impl* impl_{nullptr};
+    std::string model_path_;
+};
+
+}  // namespace cosmo

--- a/src/service/ai/impl/LlmInferServiceImpl.cc
+++ b/src/service/ai/impl/LlmInferServiceImpl.cc
@@ -13,7 +13,7 @@ static constexpr const char* kTag = "LlmInferService ";
 namespace cosmo::service {
 
 bool LlmInferServiceImpl::EnsureInit(const std::string& atomic_code) {
-#ifdef COSMO_NN_USE_HOST_BACKEND
+#if defined(COSMO_NN_USE_HOST_BACKEND) && !defined(COSMO_NN_USE_RKNN_BACKEND)
     // LLM inference (Qwen3VL/Qwen3.5) is not supported on x86 platform
     LOG_WARN("{}EnsureInit: LLM inference is not supported on x86 platform (atomicCode: {})", kTag,
              atomic_code);
@@ -60,7 +60,7 @@ bool LlmInferServiceImpl::EnsureInit(const std::string& atomic_code) {
     atomic_code_ = atomic_code;
     LOG_INFO("{}EnsureInit: Qwen3VL shared instance created. AtomicCode:{}", kTag, atomic_code);
     return true;
-#endif  // COSMO_NN_USE_HOST_BACKEND
+#endif
 }
 
 bool LlmInferServiceImpl::IsInitialized() const {

--- a/src/service/ai/impl/LlmInferServiceImpl.cc
+++ b/src/service/ai/impl/LlmInferServiceImpl.cc
@@ -13,7 +13,8 @@ static constexpr const char* kTag = "LlmInferService ";
 namespace cosmo::service {
 
 bool LlmInferServiceImpl::EnsureInit(const std::string& atomic_code) {
-#if defined(COSMO_NN_USE_HOST_BACKEND) && !defined(COSMO_NN_USE_RKNN_BACKEND)
+#if (defined(COSMO_NN_USE_HOST_BACKEND) && !defined(COSMO_NN_USE_RKNN_BACKEND)) || \
+    (defined(COSMO_NN_USE_RKNN_BACKEND) && !defined(COSMO_NN_USE_RKLLM_BACKEND))
     // LLM inference (Qwen3VL/Qwen3.5) is not supported on x86 platform
     LOG_WARN("{}EnsureInit: LLM inference is not supported on x86 platform (atomicCode: {})", kTag,
              atomic_code);

--- a/src/service/model/impl/ModelAddModel.cc
+++ b/src/service/model/impl/ModelAddModel.cc
@@ -180,8 +180,11 @@ util::ErrorEnum ModelImportExporter::ValidateAddModelInputs(
     namespace fs = std::filesystem;
 
 #ifdef COSMO_NN_USE_RKNN_BACKEND
-    if (modelType != "classify" && modelType != "yolov8_det") {
-        LOG_WARN("[AddModel] RKNN P0 scope supports classify and yolov8_det, got {}", modelType);
+    static const std::vector<std::string> kSupportedRknnModelTypes = {
+        "yolov8_det", "classify", "keypoints", "feature", "ocr", "dino", "qwen3_5"};
+    if (std::find(kSupportedRknnModelTypes.begin(), kSupportedRknnModelTypes.end(), modelType) ==
+        kSupportedRknnModelTypes.end()) {
+        LOG_WARN("[AddModel] Unsupported RK3576 model type: {}", modelType);
         return util::ErrorEnum::InvalidParam;
     }
 #endif
@@ -210,11 +213,20 @@ util::ErrorEnum ModelImportExporter::ValidateAddModelInputs(
     }
 
     bool is_sam2 = (modelType == "sam2");
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+    const bool is_rkllm_qwen35 = (modelType == "qwen3_5");
+    if (is_rkllm_qwen35 && bmodel_files.size() != 2) {
+        LOG_WARN("{}", "[AddModel] RK3576 Qwen3.5 requires model.rkllm and vision.rknn");
+        return util::ErrorEnum::InvalidParam;
+    }
+#else
+    const bool is_rkllm_qwen35 = false;
+#endif
     if (is_sam2 && bmodel_files.size() != 2) {
         LOG_WARN("{}", "[AddModel] SAM2 model requires exactly 2 bmodel files (encoder and decoder)");
         return util::ErrorEnum::InvalidParam;
     }
-    if (!is_sam2 && bmodel_files.size() != 1) {
+    if (!is_sam2 && !is_rkllm_qwen35 && bmodel_files.size() != 1) {
         LOG_WARN("{}", "[AddModel] Non-SAM2 model must have exactly 1 bmodel file");
         return util::ErrorEnum::InvalidParam;
     }
@@ -250,15 +262,40 @@ util::ErrorEnum ModelImportExporter::ValidateAddModelInputs(
         return util::ErrorEnum::InvalidParam;
     }
 
-    // Check all bmodel files exist
-    for (const auto& bmodelFile : bmodel_files) {
+    // Check all model files exist. Keep RKLLM files in a deterministic language/vision order.
+    std::vector<const cosmo::Model::BmodelFileInfo*> ordered_model_files;
+    ordered_model_files.reserve(bmodel_files.size());
+#ifdef COSMO_NN_USE_RKNN_BACKEND
+    if (is_rkllm_qwen35) {
+        const cosmo::Model::BmodelFileInfo* language_model = nullptr;
+        const cosmo::Model::BmodelFileInfo* vision_model   = nullptr;
+        for (const auto& file : bmodel_files) {
+            if (file.role == "language")
+                language_model = &file;
+            else if (file.role == "vision")
+                vision_model = &file;
+        }
+        if (!language_model || !vision_model) {
+            LOG_WARN("{}", "[AddModel] RK3576 Qwen3.5 model roles must be language and vision");
+            return util::ErrorEnum::InvalidParam;
+        }
+        // Staged upload paths are opaque and intentionally do not preserve client filenames.
+        // The authenticated frontend validates the extensions; roles keep the server copy order safe.
+        ordered_model_files = {language_model, vision_model};
+    } else
+#endif
+    {
+        for (const auto& file : bmodel_files)
+            ordered_model_files.push_back(&file);
+    }
+    for (const auto* bmodelFile : ordered_model_files) {
         std::string resolved_path;
-        if (!ResolveManagedUploadFile(bmodelFile.filePath, resolved_path)) {
-            LOG_WARN("[AddModel] bmodel file is not a managed upload: {}", bmodelFile.filePath);
+        if (!ResolveManagedUploadFile(bmodelFile->filePath, resolved_path)) {
+            LOG_WARN("[AddModel] model file is not a managed upload: {}", bmodelFile->filePath);
             return util::ErrorEnum::FileNotExist;
         }
         bmodel_paths.push_back(std::move(resolved_path));
-        LOG_INFO("[AddModel] bmodel file: role={}, path={}", bmodelFile.role, bmodel_paths.back());
+        LOG_INFO("[AddModel] model file: role={}, path={}", bmodelFile->role, bmodel_paths.back());
     }
 
     return util::ErrorEnum::Success;
@@ -334,10 +371,26 @@ util::ErrorEnum ModelImportExporter::WriteNnFile(const std::string& modelType,
     namespace fs = std::filesystem;
 
 #ifdef COSMO_NN_USE_RKNN_BACKEND
-    (void)modelType;
     std::string convert_error;
-    if (bmodel_paths.size() != 1) {
-        convert_error = "RKNN add-model currently supports exactly one model file";
+    if (modelType == "qwen3_5") {
+        if (bmodel_paths.size() != 2) {
+            convert_error = "RK3576 Qwen3.5 requires one RKLLM file and one vision RKNN file";
+        } else {
+            const std::vector<std::string> destination_names = {"model.rkllm", "vision.rknn"};
+            for (size_t i = 0; i < destination_names.size(); ++i) {
+                std::error_code ec;
+                const auto destination = (fs::path(model_dir) / destination_names[i]).string();
+                fs::copy_file(bmodel_paths[i], destination, fs::copy_options::overwrite_existing, ec);
+                if (ec) {
+                    convert_error = "Failed to copy RKLLM component to " + destination + ": " +
+                                    ec.message();
+                    break;
+                }
+                LOG_INFO("[AddModel] RKLLM: copied component to {}", destination);
+            }
+        }
+    } else if (bmodel_paths.size() != 1) {
+        convert_error = "RKNN add-model requires exactly one model file";
     } else {
         const std::string model_file_path = model_dir + "/model.rknn";
         std::error_code ec;

--- a/src/service/model/impl/ModelAddModel.cc
+++ b/src/service/model/impl/ModelAddModel.cc
@@ -181,7 +181,10 @@ util::ErrorEnum ModelImportExporter::ValidateAddModelInputs(
 
 #ifdef COSMO_NN_USE_RKNN_BACKEND
     static const std::vector<std::string> kSupportedRknnModelTypes = {
-        "yolov8_det", "classify", "keypoints", "feature", "ocr", "dino", "qwen3_5"};
+        // Expose only model types verified end-to-end on a real RK3576 device.
+        // Keypoints, feature extraction, OCR and Grounding DINO remain disabled
+        // until their matching RKNN models pass runtime validation.
+        "yolov8_det", "classify", "qwen3_5"};
     if (std::find(kSupportedRknnModelTypes.begin(), kSupportedRknnModelTypes.end(), modelType) ==
         kSupportedRknnModelTypes.end()) {
         LOG_WARN("[AddModel] Unsupported RK3576 model type: {}", modelType);

--- a/src/web/src/views/gam/countManagement/atomicModel/index.vue
+++ b/src/web/src/views/gam/countManagement/atomicModel/index.vue
@@ -108,12 +108,20 @@
             <el-option label="BGR" value="bgr"></el-option>
           </el-select>
         </el-form-item>
-        <!-- 非SAM2类型：单个模型文件上传 -->
+        <!-- 普通类型或 RKLLM 语言模型：单个主模型文件上传 -->
         <el-form-item v-if="addModelForm.modelType !== 'sam2'" :label="t('glossary.modelFile')" prop="modelFile">
-          <el-upload ref="uploadModelFileRef" action="#" :file-list="addModelForm.modelFileList" :limit="1" :auto-upload="false" :accept="modelFileExtension" :on-change="handleModelFileChange" :on-remove="handleModelFileRemove">
+          <el-upload ref="uploadModelFileRef" action="#" :file-list="addModelForm.modelFileList" :limit="1" :auto-upload="false" :accept="addModelPrimaryFileExtension" :on-change="handleModelFileChange" :on-remove="handleModelFileRemove">
             <el-button size="small" type="primary">{{ t('action.browse') }}</el-button>
             <template #tip>
-              <div class="upload-warn">{{ t('glossary.selectModelFileTip', { ext: modelFileExtension }) }}</div>
+              <div class="upload-warn">{{ t('glossary.selectModelFileTip', { ext: addModelPrimaryFileExtension }) }}</div>
+            </template>
+          </el-upload>
+        </el-form-item>
+        <el-form-item v-if="isRknn && addModelForm.modelType === 'qwen3_5'" label="vision.rknn" prop="visionFile">
+          <el-upload ref="uploadVisionFileRef" action="#" :file-list="addModelForm.visionFileList" :limit="1" :auto-upload="false" accept=".rknn" :on-change="handleVisionFileChange" :on-remove="handleVisionFileRemove">
+            <el-button size="small" type="primary">{{ t('action.browse') }}</el-button>
+            <template #tip>
+              <div class="upload-warn">RK3576 Qwen3.5 {{ t('glossary.selectModelFileTip', { ext: '.rknn' }) }}</div>
             </template>
           </el-upload>
         </el-form-item>
@@ -575,6 +583,11 @@ const topBarData = computed(() => ({
 const isX86 = ref(false)
 const isRknn = ref(false)
 const modelFileExtension = computed(() => isRknn.value ? '.rknn' : (isX86.value ? '.onnx' : '.bmodel'))
+const addModelPrimaryFileExtension = computed(() =>
+  isRknn.value && addModelForm.modelType === 'qwen3_5'
+    ? '.rkllm'
+    : modelFileExtension.value
+)
 const importedModelFileName = computed(() => isRknn.value ? 'model.rknn' : (isX86.value ? 'model.onnx' : 'model.nn'))
 const addModelDialogTitle = computed(() => addModelMode.value === 'edit' ? t('action.editModel') : t('action.addModel'))
 const addModelMode = ref('add')
@@ -590,6 +603,7 @@ const uploadDecoderFileRef = ref(null)
 const uploadVocabFileRef = ref(null)
 const uploadCharacterTableFileRef = ref(null)
 const uploadTokenizerFileRef = ref(null)
+const uploadVisionFileRef = ref(null)
 
 const addModelForm = reactive({
   modelMainType: '',
@@ -608,6 +622,8 @@ const addModelForm = reactive({
   characterTableFileList: [],
   tokenizerFile: '',
   tokenizerFileList: [],
+  visionFile: '',
+  visionFileList: [],
   normalizationMode: '0-1',
   colorChannel: 'rgb'
 })
@@ -658,7 +674,9 @@ const modelTypeGroups = computed(() => {
   }
   ]
   if (!isRknn.value) return groups
-  const supported = new Set(['classify', 'yolov8_det'])
+  const supported = new Set([
+    'yolov8_det', 'classify', 'keypoints', 'feature', 'ocr', 'dino', 'qwen3_5'
+  ])
   return groups
     .map(group => ({ ...group, children: group.children.filter(item => supported.has(item.value)) }))
     .filter(group => group.children.length > 0)
@@ -799,6 +817,22 @@ const addModelRules = {
           addModelForm.tokenizerFileList.length === 0
         ) {
           callback(new Error(t('validate.uploadTokenizerFile')))
+        } else {
+          callback()
+        }
+      },
+      trigger: 'change'
+    }
+  ],
+  visionFile: [
+    {
+      validator: (rule, value, callback) => {
+        if (!isRknn.value || addModelForm.modelType !== 'qwen3_5') {
+          callback()
+          return
+        }
+        if (!addModelForm.visionFileList || addModelForm.visionFileList.length === 0) {
+          callback(new Error('RK3576 Qwen3.5 需要上传 vision.rknn'))
         } else {
           callback()
         }
@@ -1170,10 +1204,13 @@ const uploadAlgorithmicClosed = () => {
   addModelForm.characterTableFile = ''
   addModelForm.tokenizerFileList = []
   addModelForm.tokenizerFile = ''
+  addModelForm.visionFileList = []
+  addModelForm.visionFile = ''
   addModelForm.normalizationMode = '0-1'
   addModelForm.colorChannel = 'rgb'
   addModelFormRef.value && addModelFormRef.value.resetFields()
   uploadCharacterTableFileRef.value && uploadCharacterTableFileRef.value.clearFiles()
+  uploadVisionFileRef.value && uploadVisionFileRef.value.clearFiles()
 }
 
 const handleModelTypeChange = () => {
@@ -1189,6 +1226,8 @@ const handleModelTypeChange = () => {
   addModelForm.characterTableFile = ''
   addModelForm.tokenizerFileList = []
   addModelForm.tokenizerFile = ''
+  addModelForm.visionFileList = []
+  addModelForm.visionFile = ''
   addModelForm.normalizationMode = '0-1'
   addModelForm.colorChannel = 'rgb'
   nextTick(() => {
@@ -1198,6 +1237,7 @@ const handleModelTypeChange = () => {
     uploadVocabFileRef.value && uploadVocabFileRef.value.clearFiles()
     uploadCharacterTableFileRef.value && uploadCharacterTableFileRef.value.clearFiles()
     uploadTokenizerFileRef.value && uploadTokenizerFileRef.value.clearFiles()
+    uploadVisionFileRef.value && uploadVisionFileRef.value.clearFiles()
   })
 }
 
@@ -1275,6 +1315,19 @@ const handleTokenizerFileRemove = (file, fileList) => {
   addModelForm.tokenizerFile =
     fileList && fileList.length > 0 ? 'file_selected' : ''
   addModelFormRef.value && addModelFormRef.value.validateField('tokenizerFile')
+}
+const handleVisionFileChange = (file, fileList) => {
+  addModelForm.visionFileList =
+    fileList.length > 0 ? [fileList[fileList.length - 1]] : []
+  addModelForm.visionFile =
+    addModelForm.visionFileList.length > 0 ? 'file_selected' : ''
+  addModelFormRef.value && addModelFormRef.value.validateField('visionFile')
+}
+const handleVisionFileRemove = (file, fileList) => {
+  addModelForm.visionFileList = fileList || []
+  addModelForm.visionFile =
+    fileList && fileList.length > 0 ? 'file_selected' : ''
+  addModelFormRef.value && addModelFormRef.value.validateField('visionFile')
 }
 
 const uploadSingleFile = async (file, purpose = UploadPurpose.MODEL_COMPONENT) => {
@@ -1354,6 +1407,44 @@ const sureAddModel = async () => {
         proxy.$message.warning(t('validate.decoderFormatError', { ext }))
         return
       }
+    } else if (isRknn.value && addModelForm.modelType === 'qwen3_5') {
+      if (
+        !addModelForm.modelFileList ||
+        addModelForm.modelFileList.length === 0
+      ) {
+        proxy.$message.warning(t('validate.uploadModelFile'))
+        return
+      }
+      if (
+        !addModelForm.visionFileList ||
+        addModelForm.visionFileList.length === 0
+      ) {
+        proxy.$message.warning('RK3576 Qwen3.5 需要上传 vision.rknn')
+        return
+      }
+      const languageFile =
+        addModelForm.modelFileList[0].raw || addModelForm.modelFileList[0]
+      const visionFile =
+        addModelForm.visionFileList[0].raw || addModelForm.visionFileList[0]
+      if (!languageFile.name || !languageFile.name.toLowerCase().endsWith('.rkllm')) {
+        proxy.$message.warning(t('validate.uploadFormatError', { ext: '.rkllm' }))
+        return
+      }
+      if (!visionFile.name || !visionFile.name.toLowerCase().endsWith('.rknn')) {
+        proxy.$message.warning(t('validate.uploadFormatError', { ext: '.rknn' }))
+        return
+      }
+    } else if (isRknn.value && addModelForm.modelType === 'qwen3_5') {
+      const languageFile =
+        addModelForm.modelFileList[0].raw || addModelForm.modelFileList[0]
+      const visionFile =
+        addModelForm.visionFileList[0].raw || addModelForm.visionFileList[0]
+      const languageUploadId = await stageForAdd(languageFile)
+      const visionUploadId = await stageForAdd(visionFile)
+      addModelParams.bmodelFiles = [
+        { role: 'language', uploadId: languageUploadId },
+        { role: 'vision', uploadId: visionUploadId }
+      ]
     } else {
       if (
         !addModelForm.modelFileList ||

--- a/src/web/src/views/gam/countManagement/atomicModel/index.vue
+++ b/src/web/src/views/gam/countManagement/atomicModel/index.vue
@@ -675,7 +675,9 @@ const modelTypeGroups = computed(() => {
   ]
   if (!isRknn.value) return groups
   const supported = new Set([
-    'yolov8_det', 'classify', 'keypoints', 'feature', 'ocr', 'dino', 'qwen3_5'
+    // RK3576 capabilities are exposed only after end-to-end validation with a
+    // real model on the device. Keep code-only integrations hidden for now.
+    'yolov8_det', 'classify', 'qwen3_5'
   ])
   return groups
     .map(group => ({ ...group, children: group.children.filter(item => supported.has(item.value)) }))


### PR DESCRIPTION
## 变更概述

- 在 RK3576 上接入 Qwen3.5 RKLLM 多模态推理后端，补齐 tokenizer/vision 模型上传与运行链路。
- 仅开放已实际打通的检测、分类和 Qwen3.5 VLM 类型；关键点、特征提取、OCR、Grounding DINO 暂不对外开放。
- 优化视觉 Prefill：减少视觉 token、复用图像缓冲区并收紧上下文/输出上限；增加 RK3576 性能模式服务和脚本。
- RKLLM SDK 改为可选能力：公开 RKNN 构建环境未带 RKLLM 时仍可正常构建基础版本；带 SDK 时自动启用并打包 `librkllmrt.so`。

## 验证结果

- 前端生产构建通过（含 i18n 检查）。
- 官方公开 RK3576 Docker 交叉构建通过；主程序、测试程序及两个 RKNN 验证工具均生成 ARM64 产物。
- 挂载 RKLLM SDK 后完成干净的 RK3576 全量交叉构建和打包，退出码 0。
- 构建日志确认编译 `RkllmVlmBackend.cc`；最终升级包同时包含 `librknnrt.so` 与 `librkllmrt.so`。
- `git diff --check` 通过。
- RK3576 设备实测视觉 token 为 64，VLM 平均推理约 2128 ms，连续 21 次有效结果且无 RKLLM 失败。

## 合并目标

本 PR 基于并合入 `feat/model-guard-v2.3`，未包含该分支之外的无关历史。