### PR TITLE
fix(media): prevent looping local video tasks from stopping at EOF

### DIFF
--- a/src/flow/channel/AlgChannelDemux.cc
+++ b/src/flow/channel/AlgChannelDemux.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 
+#include "flow/channel/VideoEofPolicy.h"
 #include "service/detail/ServiceRegistry.h"
 #include "service/event/IEventNotifier.h"
 #include "service/system/IConfigReadService.h"
@@ -218,36 +219,36 @@ void AlgChannelDemux::HandleStream() {
     duration_stat_.EndSample();
     if (media::ReadFrameStatus::Success != ret) {
         if (media::ReadFrameStatus::StreamEnd == ret) {
-            if ((video_read_count_ < video_repeat_count_) || (video_repeat_count_ <= 0)) {
+            const bool is_live_stream = IsLiveStream();
+            const auto disposition =
+                flow::DecideVideoEof(is_live_stream, video_read_count_, video_repeat_count_);
+            if (flow::VideoEofDisposition::Reopen == disposition) {
+                is_need_repeat_ = true;
+                if (is_live_stream) {
+                    LOG_INFO("{}:{} Live Stream End Need ReOpen Or Request Url", kTag, channel_id_);
+                    SetStatusInfo(service::camera::AlgDemuxStatus::AlgDemuxReadFailed);
+                    action_status_ = util::ErrorEnum::DemuxReadStreamFail;
+                    return;
+                }
+
                 LOG_INFO("{}:{} Stream End Now RepeatCount:{} Max RepeatCount:{}", kTag, channel_id_,
                          video_read_count_, video_repeat_count_);
-                is_need_repeat_ = true;
-            } else {
-                // Do not report completion for live streams.
-                if ((!is_have_report_) && (!IsLiveStream())) {
-                    is_have_report_ = true;
-                    NotifyOnComplete();
-                }
-            }
-            if (IsLiveStream()) {
-                LOG_INFO("{}:{} Live Stream End  Need ReOpen Or Request Url", kTag, channel_id_);
-                // Live stream has no definitive end — request new URL or reopen.
-                SetStatusInfo(service::camera::AlgDemuxStatus::AlgDemuxReadFailed);
-                is_need_repeat_ = true;
-                action_status_  = util::ErrorEnum::DemuxReadStreamFail;
-            } else {
-                SetStatusInfo(service::camera::AlgDemuxStatus::AlgDemuxReadEnd);
-                if (!is_need_repeat_) {
-                    action_status_ = util::ErrorEnum::DemuxStreamClosed;
-                }
-                // When is_need_repeat_ is true the stream is about to loop —
-                // keep action_status_ as Success from the last frame read to
-                // prevent transient "取流无数据" during the loop transition.
-
-                // Signal unfinished recording tasks to finalize.
+                // A loop boundary is not terminal. Keep the last Reading state
+                // and successful action status until OpenStream publishes the
+                // next Opened/Reading transition.
                 frame_packet->index = -1;
                 recorder_->TaskFrame(frame_packet);
+                return;
             }
+
+            if (!is_have_report_) {
+                is_have_report_ = true;
+                NotifyOnComplete();
+            }
+            SetStatusInfo(service::camera::AlgDemuxStatus::AlgDemuxReadEnd);
+            action_status_     = util::ErrorEnum::DemuxStreamClosed;
+            frame_packet->index = -1;
+            recorder_->TaskFrame(frame_packet);
             return;
         }
         SetStatusInfo(service::camera::AlgDemuxStatus::AlgDemuxReadFailed);

--- a/src/flow/channel/AlgChannelDemux.cc
+++ b/src/flow/channel/AlgChannelDemux.cc
@@ -246,7 +246,7 @@ void AlgChannelDemux::HandleStream() {
                 NotifyOnComplete();
             }
             SetStatusInfo(service::camera::AlgDemuxStatus::AlgDemuxReadEnd);
-            action_status_     = util::ErrorEnum::DemuxStreamClosed;
+            action_status_      = util::ErrorEnum::DemuxStreamClosed;
             frame_packet->index = -1;
             recorder_->TaskFrame(frame_packet);
             return;

--- a/src/flow/channel/AlgChannelDemuxStream.cc
+++ b/src/flow/channel/AlgChannelDemuxStream.cc
@@ -145,7 +145,8 @@ bool AlgChannelDemux::GetAttr(MsgCameraAttr& attr) {
             attr.channelStatus = ChannelStatus::ChannelStatusResolusionUnSupport;
         }
     }
-    attr.dataStatus = static_cast<int>(status_.status);
+    attr.dataStatus    = static_cast<int>(status_.status);
+    attr.repeatPending = is_need_repeat_.load();
     return true;
 }
 

--- a/src/flow/channel/VideoEofPolicy.h
+++ b/src/flow/channel/VideoEofPolicy.h
@@ -1,0 +1,28 @@
+// Local-video EOF lifecycle policy shared by the demuxer and monitor guard.
+
+#pragma once
+
+namespace cosmo::flow {
+
+enum class VideoEofDisposition {
+    Reopen,
+    Complete,
+};
+
+// video_read_count is the number of successful opens, including the current
+// playback. A non-positive repeat count means infinite playback.
+constexpr VideoEofDisposition DecideVideoEof(bool is_live_stream, int video_read_count,
+                                             int video_repeat_count) {
+    if (is_live_stream || video_repeat_count <= 0 || video_read_count < video_repeat_count) {
+        return VideoEofDisposition::Reopen;
+    }
+    return VideoEofDisposition::Complete;
+}
+
+// Defense for the camera monitor: a transient ReadEnd can never be terminal
+// while the demuxer has already committed to reopening the stream.
+constexpr bool IsTerminalOfflineReadEnd(bool is_read_end, bool repeat_pending) {
+    return is_read_end && !repeat_pending;
+}
+
+}  // namespace cosmo::flow

--- a/src/service/camera/impl/CameraServiceImpl.cc
+++ b/src/service/camera/impl/CameraServiceImpl.cc
@@ -591,9 +591,8 @@ void CameraServiceImpl::MonitorCameraEntity(const CameraEntityPtr& camera, bool 
                                  camera->videoChannelId, task->task_id_);
                     }
                     // Channel has finished reading and no active data remains (queue fully consumed)
-                    if (isTerminalReadEnd &&
-                        !ServiceRegistry::Instance().Get<ITaskChannel>().TaskDataActive(
-                            camera->videoChannelId)) {
+                    if (isTerminalReadEnd && !ServiceRegistry::Instance().Get<ITaskChannel>().TaskDataActive(
+                                                 camera->videoChannelId)) {
                         LOG_INFO("[{}/{}] Offline video completed, auto-stopping task to release resources",
                                  camera->videoChannelId, task->task_id_);
                         ServiceRegistry::Instance().Get<ITaskLifecycle>().TaskStop(task->task_id_);

--- a/src/service/camera/impl/CameraServiceImpl.cc
+++ b/src/service/camera/impl/CameraServiceImpl.cc
@@ -20,6 +20,7 @@
 #include <regex>
 
 #include "flow/channel/AlgChannel.h"
+#include "flow/channel/VideoEofPolicy.h"
 #include "flow/common/AlgDataRecord.h"
 #include "flow/common/FlowTaskUtil.h"
 #include "service/algorithm/IAlgorithmQuery.h"
@@ -581,11 +582,18 @@ void CameraServiceImpl::MonitorCameraEntity(const CameraEntityPtr& camera, bool 
                 MsgCameraAttr attr;
                 if (ServiceRegistry::Instance().Get<ITaskChannel>().GetChannelAttr(camera->videoChannelId,
                                                                                    attr)) {
-                    bool isReadEnd =
+                    const bool isReadEnd =
                         (attr.dataStatus == static_cast<int>(camera::AlgDemuxStatus::AlgDemuxReadEnd));
+                    const bool isTerminalReadEnd =
+                        flow::IsTerminalOfflineReadEnd(isReadEnd, attr.repeatPending);
+                    if (isReadEnd && attr.repeatPending) {
+                        LOG_ERRO("[{}/{}] Refusing task auto-stop: local video is reopening",
+                                 camera->videoChannelId, task->task_id_);
+                    }
                     // Channel has finished reading and no active data remains (queue fully consumed)
-                    if (isReadEnd && !ServiceRegistry::Instance().Get<ITaskChannel>().TaskDataActive(
-                                         camera->videoChannelId)) {
+                    if (isTerminalReadEnd &&
+                        !ServiceRegistry::Instance().Get<ITaskChannel>().TaskDataActive(
+                            camera->videoChannelId)) {
                         LOG_INFO("[{}/{}] Offline video completed, auto-stopping task to release resources",
                                  camera->videoChannelId, task->task_id_);
                         ServiceRegistry::Instance().Get<ITaskLifecycle>().TaskStop(task->task_id_);

--- a/src/util/dto/CameraMsgTypes.h
+++ b/src/util/dto/CameraMsgTypes.h
@@ -31,6 +31,9 @@ struct MsgCameraAttr {
     float fps{0.0};
     ChannelStatus channelStatus{ChannelStatus::ChannelStatusOffline};  // 0: offline, 1: online, 2: auth error
     int dataStatus{0};  // service::camera::AlgDemuxStatus status
+    // Runtime-only guard. It is intentionally not serialized into the public
+    // camera DTO because it only coordinates the demuxer and task monitor.
+    bool repeatPending{false};
     friend void to_json(nlohmann::json& j, const MsgCameraAttr& v);
     friend void from_json(const nlohmann::json& j, MsgCameraAttr& v);
 };

--- a/test/test_video_eof_policy.cc
+++ b/test/test_video_eof_policy.cc
@@ -1,0 +1,35 @@
+#include "catch_amalgamated.hpp"
+
+#include "flow/channel/VideoEofPolicy.h"
+
+using cosmo::flow::DecideVideoEof;
+using cosmo::flow::IsTerminalOfflineReadEnd;
+using cosmo::flow::VideoEofDisposition;
+
+TEST_CASE("Infinite local video EOF always reopens", "[video-eof][repeat]") {
+    for (int read_count = 1; read_count <= 1000; ++read_count) {
+        CHECK(DecideVideoEof(false, read_count, 0) == VideoEofDisposition::Reopen);
+    }
+}
+
+TEST_CASE("Finite local video EOF completes only after the configured playback count",
+          "[video-eof][repeat]") {
+    CHECK(DecideVideoEof(false, 1, 1) == VideoEofDisposition::Complete);
+
+    CHECK(DecideVideoEof(false, 1, 3) == VideoEofDisposition::Reopen);
+    CHECK(DecideVideoEof(false, 2, 3) == VideoEofDisposition::Reopen);
+    CHECK(DecideVideoEof(false, 3, 3) == VideoEofDisposition::Complete);
+}
+
+TEST_CASE("Live stream EOF remains a reopen condition", "[video-eof][live]") {
+    CHECK(DecideVideoEof(true, 1, 1) == VideoEofDisposition::Reopen);
+    CHECK(DecideVideoEof(true, 1000, 3) == VideoEofDisposition::Reopen);
+}
+
+TEST_CASE("Camera monitor rejects terminal interpretation while reopen is pending",
+          "[video-eof][monitor]") {
+    CHECK_FALSE(IsTerminalOfflineReadEnd(false, false));
+    CHECK_FALSE(IsTerminalOfflineReadEnd(false, true));
+    CHECK_FALSE(IsTerminalOfflineReadEnd(true, true));
+    CHECK(IsTerminalOfflineReadEnd(true, false));
+}

--- a/test/test_video_eof_policy.cc
+++ b/test/test_video_eof_policy.cc
@@ -1,5 +1,4 @@
 #include "catch_amalgamated.hpp"
-
 #include "flow/channel/VideoEofPolicy.h"
 
 using cosmo::flow::DecideVideoEof;
@@ -26,8 +25,7 @@ TEST_CASE("Live stream EOF remains a reopen condition", "[video-eof][live]") {
     CHECK(DecideVideoEof(true, 1000, 3) == VideoEofDisposition::Reopen);
 }
 
-TEST_CASE("Camera monitor rejects terminal interpretation while reopen is pending",
-          "[video-eof][monitor]") {
+TEST_CASE("Camera monitor rejects terminal interpretation while reopen is pending", "[video-eof][monitor]") {
     CHECK_FALSE(IsTerminalOfflineReadEnd(false, false));
     CHECK_FALSE(IsTerminalOfflineReadEnd(false, true));
     CHECK_FALSE(IsTerminalOfflineReadEnd(true, true));


### PR DESCRIPTION
## Related issue

P0 release blocker observed during three-platform soak preparation; no public issue has been assigned.

## Root cause

At EOF, a looping local video briefly published terminal `AlgDemuxReadEnd` before reopening. If the camera monitor sampled that transient state after the queue drained, it interpreted the loop boundary as permanent completion and persistently disabled every task bound to the channel.

The release-candidate devices reproduced this as:

```
Offline video completed, auto-stopping task to release resources
```

## Scope

- classify EOF as `Reopen` or `Complete` with a shared policy
- keep looping local videos in a non-terminal state during reopen
- preserve terminal completion for single-play and finite-repeat videos
- retain the existing reconnect behavior for live streams
- expose runtime-only `repeatPending` state to the camera monitor
- block automatic task stop while reopen is pending
- add regression coverage for 1,000 infinite-loop EOFs, finite repeats, live streams, and the monitor guard

No package format, serialized camera contract, model, or public API is changed.

## Candidate identity

Candidate commit: 7d36dba4f9c401e4c0df4eaee9406df47849e094
Base branch: `feat/model-guard-v2.3`

## Verification

- `git diff --check`: passed
- clang-format 18.1.8: passed
- x86 CPU build and full `cosmo-tests`: passed ([run 31994320703](https://github.com/cosmo-wander-ai/cosmo-edge/actions/runs/31994320703))
- post-build device validation: BM1688, CV186X, and RK3576 using the prior `Safety Helmet.mp4`, 8 channels, two CV tasks per channel, 5 FPS, checkpoints at 4h / 24h / 72h

## Acceptance and cleanup

Acceptance requires the final packages to be rebound to this commit and all three platforms to retain 16 complete bindings without EOF-triggered task disablement. The staged soak is not considered passed until its 4h, 24h, and 72h checkpoints complete. Temporary benchmark channels must be removed and algorithm configuration restored after validation.