### PR TITLE
fix(build): enable parallel openssl compilation

### DIFF
--- a/cmake/openssl.cmake
+++ b/cmake/openssl.cmake
@@ -20,6 +20,9 @@ set(OPENSSL_REPRODUCIBLE_ENV
     ${CMAKE_COMMAND} -E env
     SOURCE_DATE_EPOCH=${COSMO_REPRODUCIBLE_BUILD_EPOCH}
 )
+set(OPENSSL_REPRODUCIBLE_MAKE_ARGS
+    SOURCE_DATE_EPOCH=${COSMO_REPRODUCIBLE_BUILD_EPOCH}
+)
 
 if(COSMO_TARGET_ARCH STREQUAL "x86_64")
     set(OPENSSL_SOURCE_DIR ${CMAKE_BINARY_DIR}/openssl_source)
@@ -66,9 +69,12 @@ ExternalProject_Add(
     CONFIGURE_COMMAND ${OPENSSL_REPRODUCIBLE_ENV}
         ${OPENSSL_CONFIGURE_COMMAND}
     
-    BUILD_COMMAND ${OPENSSL_REPRODUCIBLE_ENV} ${CMAKE_MAKE_PROGRAM}
-    INSTALL_COMMAND ${OPENSSL_REPRODUCIBLE_ENV}
-        ${CMAKE_MAKE_PROGRAM} install_sw
+    # Keep $(MAKE) literal so the generated parent recipe forwards GNU Make's
+    # jobserver to OpenSSL's recursive _build_sw invocation. Passing the epoch
+    # as a make variable preserves the reproducible-build environment without
+    # inserting a process wrapper that closes the jobserver file descriptors.
+    BUILD_COMMAND $(MAKE) ${OPENSSL_REPRODUCIBLE_MAKE_ARGS}
+    INSTALL_COMMAND $(MAKE) ${OPENSSL_REPRODUCIBLE_MAKE_ARGS} install_sw
     
     UPDATE_COMMAND ""
     BUILD_ALWAYS OFF


### PR DESCRIPTION
## Summary

Fix OpenSSL cross-build parallelism by preserving GNU Make's jobserver across the CMake ExternalProject boundary.

## Related issue

N/A — focused single-file build fix.

## Root cause

The OpenSSL build command was wrapped with `cmake -E env`. The outer make retained the textual `-j36 --jobserver-auth` flags, but the wrapper closed the jobserver file descriptors before OpenSSL recursively invoked `_build_sw`. GNU Make therefore emitted `jobserver unavailable` and forced the actual compilation to `-j1`.

## Scope

### In scope

- Preserve GNU Make jobserver propagation into OpenSSL's recursive build.
- Preserve `SOURCE_DATE_EPOCH` for deterministic OpenSSL artifacts.
- Validate the fix in the Sophon BM1688 build container.

### Out of scope

- Other third-party ExternalProject definitions.
- Runtime, device deployment, frontend, API, or model behavior.

## Risk tags

- [ ] Runtime / lifecycle
- [ ] Thread / memory safety
- [ ] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [ ] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Build / deployment
- [ ] Refactor
- [ ] Test

## Area

- [ ] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [x] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `10d9517214388f1d172135a21728fbb28f26e604`
- Candidate commit: `c621ea261f2d64f1eee53fbb578620442b0f7d42`
- Candidate tree: `51986133df194b399085ae4f3d035094e3fc511e`
- Package SHA-256: `N/A`
- Test binary SHA-256: `da85b555cd97aa3242abd05c013ca9d72b9936bb6465d4bf3cee81c60cfa162a`

The candidate was not amended, rebased, or merged after collecting the candidate-bound evidence below.

## Verification

### Parent baseline

```text
Environment: Sophon BM1688 build container, GNU Make 4.3, CMake 3.22.1, 36 logical CPUs
Method: clean OpenSSL ExternalProject rebuild through scripts/build_sophon_package.sh --chip bm1688 with process sampling
FAIL: OpenSSL _build_sw MAKEFLAGS=s -j1
FAIL: maximum concurrent OpenSSL cc1 processes=1
FAIL: gmake reported "jobserver unavailable: using -j1"
```

### Candidate checks

```text
PASS: candidate c621ea261f2d64f1eee53fbb578620442b0f7d42
PASS: OpenSSL _build_sw MAKEFLAGS=s -j36 --jobserver-auth=3,4 -- SOURCE_DATE_EPOCH=1784776233
PASS: maximum concurrent OpenSSL cc1 processes=21
PASS: no "jobserver unavailable" or "using -j1" warning in OpenSSL build/install logs
PASS: generated libssl.so.3 and libcrypto.so.3 are AArch64 ELF shared objects
PASS: OpenSSL BuildIDs remained unchanged from the baseline rebuild
PASS: git diff --check
PASS: ./scripts/format_check.sh --staged --check (no applicable C/C++ files)
```

### Risk-based evidence

- API/network: N/A
- Media/streaming: N/A
- Sophon/device: BM1688 cross-build container verified; no device operation.
- Frontend/UI: N/A
- Package/deployment: OpenSSL build and install steps completed with the shared 36-job GNU Make jobserver.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [ ] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: `N/A`
- Device test filter: `N/A`
- Device backup state: `N/A`
- Temporary-data cleanup: `complete`
- Final Git status: `clean`
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

Using literal `$(MAKE)` marks the generated ExternalProject recipe as recursive, so CMake 3.22 keeps GNU Make's jobserver descriptors open. Passing `SOURCE_DATE_EPOCH` as a make command-line variable preserves the reproducible-build environment without adding a wrapper process.
