### PR TITLE
fix(rknn): parse RV1126B aggregate NPU load

### DIFF
--- a/src/service/system/impl/AcceleratorMetricsProviderRknn.cc
+++ b/src/service/system/impl/AcceleratorMetricsProviderRknn.cc
@@ -51,16 +51,30 @@ namespace {
                 return std::nullopt;
             cores_by_id[*core_id] = static_cast<double>(*percent) / 100.0;
         }
-        if (cores_by_id.empty())
+        if (!cores_by_id.empty()) {
+            NpuLoadSnapshot result;
+            result.cores.reserve(cores_by_id.size());
+            for (const auto& [core_id, load] : cores_by_id) {
+                (void)core_id;
+                result.cores.push_back(load);
+                result.aggregate = std::max(result.aggregate, load);
+            }
+            return result;
+        }
+
+        // Single-core Rockchip parts such as RV1126B expose only an aggregate
+        // counter ("NPU load: 37%") instead of RK3576-style CoreN fields.
+        static const std::regex aggregate_pattern(R"(NPU\s+load\s*:\s*([0-9]+)\s*%)", std::regex::icase);
+        std::smatch aggregate_match;
+        if (!std::regex_search(text, aggregate_match, aggregate_pattern))
+            return std::nullopt;
+        const auto percent = ParseUnsigned(aggregate_match[1]);
+        if (!percent || *percent > 100)
             return std::nullopt;
 
         NpuLoadSnapshot result;
-        result.cores.reserve(cores_by_id.size());
-        for (const auto& [core_id, load] : cores_by_id) {
-            (void)core_id;
-            result.cores.push_back(load);
-            result.aggregate = std::max(result.aggregate, load);
-        }
+        result.aggregate = static_cast<double>(*percent) / 100.0;
+        result.cores.push_back(result.aggregate);
         return result;
     }
 

--- a/test/test_accelerator_metrics_provider.cc
+++ b/test/test_accelerator_metrics_provider.cc
@@ -67,8 +67,36 @@ TEST_CASE("RKNN accelerator metrics provider reports per-core busy-time load", "
     CHECK(metrics.gpudevusage.front().gpuusage == Catch::Approx(0.42));
 }
 
+TEST_CASE("RKNN accelerator metrics provider reports aggregate-only busy-time load",
+          "[system][metrics][rknn]") {
+    ScopedNpuLoadFixture fixture("NPU load:  37%\n");
+    auto provider = cosmo::service::detail::CreateAcceleratorMetricsProvider();
+    REQUIRE(provider != nullptr);
+
+    const auto metrics = provider->QueryUtilization();
+    CHECK(metrics.gpuusageAvailable);
+    CHECK(metrics.gpuusage == Catch::Approx(0.37));
+    CHECK(metrics.utilizationMetric == "busy-time-load");
+    REQUIRE(metrics.coreUtilizations.size() == 1);
+    CHECK(metrics.coreUtilizations.front() == Catch::Approx(0.37));
+    REQUIRE(metrics.gpudevusage.size() == 1);
+    CHECK(metrics.gpudevusage.front().gpuusage == Catch::Approx(0.37));
+}
+
 TEST_CASE("RKNN accelerator metrics provider rejects invalid load", "[system][metrics][rknn]") {
     ScopedNpuLoadFixture fixture("NPU load:  Core0: 105%, Core1: 0%,\n");
+    auto provider = cosmo::service::detail::CreateAcceleratorMetricsProvider();
+    REQUIRE(provider != nullptr);
+
+    const auto metrics = provider->QueryUtilization();
+    CHECK_FALSE(metrics.gpuusageAvailable);
+    CHECK(metrics.gpuusage == 0.0);
+    CHECK(metrics.coreUtilizations.empty());
+}
+
+TEST_CASE("RKNN accelerator metrics provider rejects invalid aggregate-only load",
+          "[system][metrics][rknn]") {
+    ScopedNpuLoadFixture fixture("NPU load: 101%\n");
     auto provider = cosmo::service::detail::CreateAcceleratorMetricsProvider();
     REQUIRE(provider != nullptr);
 


### PR DESCRIPTION
## Related issue

Follow-up to PR #105. The defect was discovered during its post-merge RV1126B device smoke; no separate issue was opened for this bounded follow-up.

## Root cause

The shared RKNN metrics provider only recognized RK3576-style per-core fields such as `Core0: 37%`. RV1126B exposes a single aggregate counter instead: `NPU load:  37%`. The kernel metric was readable, but the parser returned unavailable, so the dashboard displayed no NPU utilization.

## Scope

- keep the existing RK3576 per-core parser unchanged
- accept the aggregate-only RV1126B `NPU load: ...%` format in the same shared provider
- expose that aggregate as one core sample for the existing metrics contract
- reject aggregate values outside `0..100`
- add valid and invalid aggregate-format unit coverage

No chip-specific service fork or CPU fallback is introduced.

## Candidate identity

- Head commit: `42c7e1fbef81e375c25204f8a2756729a187d738`
- Candidate tree: `876f0174ee5e1e466e8ac7f9a900c372a29809b5`
- CI merge candidate: `956076699dbdbdf788d466141f99f903c5a4ceef`
- RV1126B package: `cosmo-V1.1.0-cc89120510beb5cbd5d701b0252bca19.tar.gz`
- Package SHA-256: `9832f24cc5ac63090d1f95334a4bed8abe2407aacb372d7dd922a0277f1a4f40`
- Rockchip CI: https://github.com/cosmo-wander-ai/cosmo-edge/actions/runs/32227376761

## Verification

- clang-format 18 dry-run on both changed files: PASS
- diff whitespace check: PASS
- x86 build and test workflow: PASS
- RK3576 package matrix: PASS
- RV1126B package matrix: PASS
- exact artifact transfer hashes on RV1126B: PASS
- RV1126B `[system][metrics][rknn]`: 4 test cases, 34 assertions, PASS
- RV1126B RKNN backend smoke: 5 iterations, mean 12.6067 ms, min 12.5277 ms, max 12.7508 ms, PASS
- Chrome login and customer journey: PASS
  - home reports NPU `0%` instead of unavailable
  - model repository shows YOLOV8 and helmet models
  - scene-task page loads the No Safety Helmet task
  - event center loads 146 historical four-channel events
  - device information reports RV1126B with RKNN backend

## Acceptance and cleanup

- Deployed release: `/userdata/cosmo-edge-rv1126b-20260817/releases/95607669/cosmo-V1.1.0`
- Engine and UI proxy are running from the deployed release on ports 8000/9000 and 8080.
- The scheduled 02:00 restart remains disabled.
- The temporary artifact transfer server was stopped after hash verification.
- Chrome is left logged in on the device home page for hands-on inspection.
