### PR TITLE
fix(release): close v1.1 upgrade and delivery gaps

### DIFF
--- a/.github/release-notes/v1.1.0.md
+++ b/.github/release-notes/v1.1.0.md
@@ -1,0 +1,90 @@
+<!--
+Maintainer draft. Do not publish this body until every item in "Release freeze"
+is complete and all placeholders have been replaced with the final tag-bound
+identities.
+-->
+
+# CosmoEdge 1.1.0
+
+[简体中文发布说明](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/.github/release-notes/v1.1.0.zh-CN.md)
+
+CosmoEdge 1.1 expands the common video-ingest, visual-orchestration, event, and
+operations workflow across BM1688, CV186X, RK3576, RV1126B, and x86. Apple
+Silicon macOS receives a deliberately scoped Docker Preview.
+
+## What each platform receives
+
+| Platform | v1.1 delivery | Important boundary |
+| --- | --- | --- |
+| Sophon BM1688 | Target-specific Open installation archive, `TARGET_CHIP`, and `SHA256SUMS` | Plain models; no device authorization. A controlled Protected package is a separate commercial-model distribution path. |
+| Sophon CV186X | Independent CV186X Open installation archive, `TARGET_CHIP`, and `SHA256SUMS` | Do not reuse a complete BM1688 package even when selected model bytes happen to match. |
+| Rockchip RK3576 | Target-specific cross-built archive plus `TARGET_CHIP`, `MEDIA_RUNTIME_PROFILE`, and `SHA256SUMS` | Includes the RKNN, MPP/RGA, and required RKLLM runtime path. Models and package must be qualified together. |
+| Rockchip RV1126B | Target-specific cross-build path and the same marker/profile/checksum contract | Does not include RKLLM. A deployable archive requires the platform model overlay; a preserve-model CI package is not a release asset or device acceptance. |
+| x86 Linux / Windows | Source release with the corresponding Docker Compose runtime | Uses ONNX Runtime CPU and persistent named volumes; no device installation archive is promised. |
+| Apple Silicon macOS | `scripts/macos-docker-preview.sh` and the isolated macOS Compose profile | Preview under `linux/amd64` emulation for one local-video workflow; no native macOS/NPU, multi-channel, Model Guard, or production-performance claim. |
+
+RK3576 and RV1126B are in the same v1.1 release tier. Their artifacts, models,
+media profiles, measured evidence, and acceptance records remain target-specific.
+
+## Upgrade from 1.0.0
+
+- BM1688 v1.0.0 uses the matching BM1688 archive for an in-place upgrade.
+- x86 rebuilds the v1.1 Compose service while retaining the existing named data
+  and application-resource volumes. Do not use `docker compose down -v`.
+- CV186X, RK3576, RV1126B, and macOS did not have a public v1.0.0 release
+  baseline; document them as fresh v1.1 installations or Preview startup, not
+  public v1.0.0 in-place upgrades.
+- A device that ran an early Rockchip build migrates durable state from
+  `/data/cwaiuserdata` to `/userdata/cwaiuserdata` transactionally. The old root
+  is retained; ambiguous dual-root persistent state fails closed before the
+  service stops.
+- Complete or cancel v1.0.0 uploads before upgrading. Incomplete v1.0.0 uploads
+  are not migrated as resumable sessions.
+
+Read the bilingual [Deployment Guide](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/docs/en/guide/deployment.md#upgrade-from-100-to-110)
+before installing an archive. Installer success is not post-start health or
+business acceptance; retain the previous package and an independently stored
+data backup until validation finishes.
+
+## Highlights
+
+- Target-specific BMRT and RKNN backends with chip-aware model and package
+  validation.
+- RKNN media and inference paths using the target MPP/RGA profile, with RKLLM
+  available only on RK3576.
+- Persistent staged uploads with restart recovery, cancellation, bounded
+  admission, and deterministic cleanup.
+- Model Guard 2.3 support for protected commercial preset-model distribution on
+  the controlled Sophon packaging path; Open packages retain plaintext user
+  models without device authorization.
+- Multi-platform ScenarioBench material for controlled single workloads,
+  concurrent mixed workloads, and conservative VLM performance display.
+
+## Validation boundary
+
+The [v1.1 ScenarioBench pack](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/docs/benchmarks/scenario-bench/v1.1/README.md)
+records its own source, package, model, environment, threshold, and duration
+boundaries. Short-run capacity and VLM observations do not replace upgrade,
+rollback, accuracy, long-running, or deployment-specific qualification.
+
+## Community and support
+
+[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions)
+is the official searchable English Q&A and support channel for v1.1.
+Reproducible defects belong in
+[GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues), and
+vulnerabilities must follow [SECURITY.md](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/SECURITY.md). No Discord channel
+is operated for this release.
+
+## Release freeze
+
+- [ ] Create tag `v1.1.0` from the approved commit and record commit and tree SHA.
+- [ ] Attach the BM1688 and CV186X Open archives with their chip markers and
+      SHA-256 files.
+- [ ] Attach only Rockchip archives whose required model overlays and target
+      device acceptance are complete.
+- [ ] Replace this checklist with exact asset filenames and SHA-256 values.
+- [ ] Bind upgrade, restart, inference, alarm, and recovery results to the exact
+      final packages.
+- [ ] Confirm required CI, documentation rendering, package audit, and release
+      approval are complete.

--- a/.github/release-notes/v1.1.0.zh-CN.md
+++ b/.github/release-notes/v1.1.0.zh-CN.md
@@ -1,0 +1,73 @@
+<!--
+维护者草稿。完成“发布冻结”全部事项、用最终 tag 对应的真实身份替换所有待定内容前，
+不要把本页直接发布为 GitHub Release 正文。
+-->
+
+# CosmoEdge 1.1.0
+
+[English release notes](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/.github/release-notes/v1.1.0.md)
+
+CosmoEdge 1.1 把统一的视频接入、可视化编排、事件与运维工作流扩展到 BM1688、
+CV186X、RK3576、RV1126B 和 x86；Apple Silicon macOS 提供范围明确的 Docker
+Preview。
+
+## 各平台交付内容
+
+| 平台 | v1.1 交付物 | 重要边界 |
+| --- | --- | --- |
+| Sophon BM1688 | 芯片专属 Open 安装包、`TARGET_CHIP` 和 `SHA256SUMS` | 明文模型，不需要设备授权；受控 Protected 包属于独立的商业模型分发路径。 |
+| Sophon CV186X | 独立的 CV186X Open 安装包、`TARGET_CHIP` 和 `SHA256SUMS` | 即使部分模型字节相同，也不能复用完整 BM1688 包。 |
+| Rockchip RK3576 | 芯片专属交叉构建包、`TARGET_CHIP`、`MEDIA_RUNTIME_PROFILE` 和 `SHA256SUMS` | 包含 RKNN、MPP/RGA 和必需的 RKLLM 运行路径；模型与包必须一起验收。 |
+| Rockchip RV1126B | 芯片专属交叉构建路径，以及相同的芯片标记、媒体档案和校验契约 | 不包含 RKLLM；可部署包必须带平台模型覆盖层，保留模型的 CI 包不是 Release 资产或设备验收。 |
+| x86 Linux / Windows | 源码 Release 与对应的 Docker Compose 运行环境 | 使用 ONNX Runtime CPU 和持久化命名卷，不承诺设备安装包。 |
+| Apple Silicon macOS | `scripts/macos-docker-preview.sh` 与隔离的 macOS Compose 配置 | 在 `linux/amd64` 仿真下覆盖单路本地视频；不宣称原生 macOS/NPU、多路、Model Guard 或生产性能。 |
+
+RK3576 与 RV1126B 保持同档发布，但二者的包、模型、媒体档案、实测证据和验收记录
+仍分别绑定目标平台。
+
+## 从 1.0.0 升级
+
+- BM1688 v1.0.0 使用匹配的 BM1688 包原位升级。
+- x86 保留现有数据卷和应用资源卷，重新构建 v1.1 Compose 服务；不要运行
+  `docker compose down -v`。
+- CV186X、RK3576、RV1126B 与 macOS 没有公开的 v1.0.0 发布基线，应描述为
+  v1.1 全新安装或 Preview 启动，不能描述为公开的 v1.0.0 原位升级。
+- 曾运行早期 Rockchip 构建的设备会把持久化数据从 `/data/cwaiuserdata` 事务迁移到
+  `/userdata/cwaiuserdata`。旧根保留；两个目录都有持久化内容且无法判定权威目录时，
+  会在停服务前失败。
+- 升级前完成或取消 v1.0.0 上传。未完成的 v1.0.0 上传不会作为可恢复会话迁移。
+
+安装前阅读双语[部署指南](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/docs/guide/deployment.md#从-100-升级到-110)。安装器成功
+返回不等于新服务和业务验收通过；验收完成前保留旧包以及存储在独立文件系统的备份。
+
+## 主要更新
+
+- 面向 BMRT 和 RKNN 的目标专属后端，以及芯片感知的模型和安装包校验。
+- 使用目标 MPP/RGA 档案的 RKNN 媒体与推理路径；RKLLM 仅用于 RK3576。
+- 支持重启恢复、取消、资源准入和确定性清理的持久化 staged upload。
+- Sophon 受控打包路径支持 Model Guard 2.3 商业预置模型保护；Open 包继续支持无需
+  设备授权的明文用户模型。
+- 覆盖受控单任务、并发混合任务和保守 VLM 性能展示的多平台 ScenarioBench 材料。
+
+## 验证边界
+
+[v1.1 ScenarioBench 包](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/docs/benchmarks/scenario-bench/v1.1/README.zh-CN.md)记录了
+各自的源码、安装包、模型、环境、阈值和时长边界。短时容量和 VLM 观测不能替代升级、
+回滚、精度、长稳和实际部署资格验证。
+
+## 社区与支持
+
+[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) 是 v1.1
+官方、可检索的英文问答与支持渠道；可复现缺陷进入
+[GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues)，安全问题按
+[SECURITY.md](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/SECURITY.md) 私密报告。本次发布不运营 Discord。中文实时交流入口
+见中文版 README 的微信群说明，群内可复用结论继续回流 Discussions 或 Issues。
+
+## 发布冻结
+
+- [ ] 从批准的 commit 创建 `v1.1.0` tag，并记录 commit SHA 与 tree SHA。
+- [ ] 附加 BM1688、CV186X Open 安装包以及对应芯片标记和 SHA-256 文件。
+- [ ] 仅附加已经具备所需模型覆盖层并完成目标设备验收的 Rockchip 包。
+- [ ] 用准确的资产文件名和 SHA-256 替换本清单。
+- [ ] 把升级、重启、推理、告警和恢复结果绑定到最终包。
+- [ ] 确认必需 CI、文档渲染、包审计和发布审批全部完成。

--- a/.github/workflows/ci-build-rockchip.yml
+++ b/.github/workflows/ci-build-rockchip.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Validate Rockchip package policy tooling
         run: |
           bash -n scripts/build_rknn.sh scripts/build_rockchip_package.sh
+          bash test/test_runtime_paths.sh
+          bash test/test_legacy_migration_installer.sh
+          bash test/test_upgrade_start_fallback.sh
           python3 -m unittest discover -s test -p 'test_package_profile.py'
           python3 -m unittest discover -s test/agent \
             -p 'test_rknn_media_sysroot_lock.py'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ packages, environments, thresholds, and durations recorded in their linked evide
 - Unified Sophon package upgrades on the legacy-compatible permanent-MD5 lifecycle, including
   legacy installer invocation, safe internal symlinks, upgrade recovery, and Open/Protected model
   lifecycle checks. Application archives themselves remain unsigned.
+- Added a fail-closed Rockchip data-root bridge for prerelease installations: durable state is
+  transactionally copied from `/data/cwaiuserdata` to `/userdata/cwaiuserdata`, the source remains
+  available for recovery, transient upload/runtime data is excluded, and ambiguous dual-root
+  persistent state is rejected before service shutdown. A rejected installation resumes the
+  previously active application instead of leaving the service in an upgrade retry loop.
 - Simplified linkage runtime task handling and made task saves atomic under resource pressure.
 - Hardened change validation, sharded Sophon tests, and aligned ScenarioBench capacity, VLM
   throughput, preview-load, report, and cleanup behavior with the current staging protocol.
@@ -115,6 +120,8 @@ packages, environments, thresholds, and durations recorded in their linked evide
   descriptors, release manifest, and file checksums.
 - Added the agent-assisted development entry, environment and model-conversion guidance, and a
   contributor pre-commit hook guide.
+- Added the bilingual v1.0.0-to-v1.1.0 upgrade and recovery guide, maintainer-ready per-platform
+  v1.1.0 release-note drafts, and an explicit GitHub Discussions English-support boundary.
 
 ## [1.0.0] - 2026-07-03
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ One build selects one inference backend. Model artifacts are generated for the t
 
 Certified devices add preconfigured acceleration, validated commercial model packages, and dedicated deployment support; they do not unlock separate software features. Devices are available in mainland China from the [Taobao store](https://item.taobao.com/item.htm?id=1066672051450); contact <hello@cosmowander.ai> for other regions or project support.
 
-Contributions are welcome through scoped bug reports, documentation improvements, scenarios, and integration notes. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Community support is available through [GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) and [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues); report vulnerabilities through [SECURITY.md](SECURITY.md).
+Contributions are welcome through scoped bug reports, documentation improvements, scenarios, and integration notes. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+
+[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) is the official searchable English Q&A and community-support channel for v1.1. Send reproducible defects to [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues), use [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues) for the mainland China mirror, and report vulnerabilities privately through [SECURITY.md](SECURITY.md). No Discord channel is operated for this release.
 
 ## FAQ
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -228,7 +228,9 @@ VLM 原始运行没有启用 FPS PASS/FAIL。统一按“全路最低 FPS 达到
 
 认证设备提供预配置加速、经过验证的商业模型包和专属部署支持，但不解锁另一套软件功能。中国大陆可通过[淘宝购买认证设备](https://item.taobao.com/item.htm?id=1066672051450)；其他地区或项目部署支持请联系 <hello@cosmowander.ai>。
 
-欢迎提交范围明确的 bug 报告、文档改进、场景示例和集成说明。提交 pull request 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。社区支持入口为 [GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) 和 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues)；安全问题请按 [SECURITY.md](SECURITY.md) 私密报告。
+欢迎提交范围明确的 bug 报告、文档改进、场景示例和集成说明。提交 pull request 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) 是 v1.1 官方、可检索的英文问答与社区支持渠道；可复现缺陷请提交到 [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues)，中国大陆镜像问题可使用 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues)，安全问题请按 [SECURITY.md](SECURITY.md) 私密报告。本次发布不运营 Discord。
 
 中文实时交流可加入 [CosmoEdge 微信开发者交流群](https://github.com/cosmo-wander-ai/cosmo-edge/discussions/112)；微信群用于开发者交流，群内形成的可复现问题和可复用结论请继续沉淀到 GitHub Discussions 或 Issues。
 

--- a/docs/en/guide/deployment.md
+++ b/docs/en/guide/deployment.md
@@ -149,6 +149,120 @@ The web console performs a local upgrade as follows:
 
 The 15-minute recovery wait is a UI timeout; it does not cancel an upgrade already running on the device. Keep power connected and inspect device networking and systemd logs if it expires. After signing in again, verify the software version against the release package; UI recovery proves reboot and service recovery, not version acceptance.
 
+## Upgrade from 1.0.0 to 1.1.0
+
+### Supported paths
+
+The public v1.0.0 device platform was BM1688, with x86 Linux/Windows available
+as developer modes. Do not describe platforms introduced in v1.1 as in-place
+upgrades from v1.0.0:
+
+| Current environment | Path to v1.1.0 | Data handling |
+| --- | --- | --- |
+| BM1688 v1.0.0 | In-place upgrade with the BM1688 Open package or corresponding controlled Protected package | Continues to use `/data/cwaiuserdata` |
+| x86 Linux/Windows v1.0.0 | Rebuild the Compose service from the `v1.1.0` source | Preserve the existing named volumes; do not run `down -v` |
+| CV186X | Fresh installation of the v1.1.0 CV186X package | No public v1.0.0 CV186X upgrade baseline exists |
+| RK3576 / RV1126B | Fresh installation for release users; devices that ran prerelease builds follow the data-root migration below | v1.1 uses `/userdata/cwaiuserdata` |
+| Apple Silicon macOS | Start fresh through the Preview guide | No v1.0.0 macOS release baseline exists |
+
+This section defines the upgrade method; it does not by itself prove that a
+candidate package passed release acceptance. Maintainers must bind the final
+commit, package SHA-256, device identity, and upgrade result in one evidence
+record before releasing an artifact.
+
+### Pre-upgrade checks
+
+1. Obtain the archive from the target chip directory together with `TARGET_CHIP`
+   and `SHA256SUMS`. Verify both the chip marker and SHA-256; never reuse a full
+   package across chips.
+2. Record the current `bin/version.txt`, `bootId`, service state, device/firmware
+   identity, and target package SHA-256:
+
+   ```bash
+   cat /appfs/cosmo_wander/cwai_data/bin/version.txt
+   cat /proc/sys/kernel/random/boot_id
+   systemctl status cosmo.service --no-pager
+   ```
+
+3. Complete or cancel active uploads in the web console. An incomplete v1.0.0
+   upload is not a resumable session and is not migrated across reboot. After
+   upgrade, verify v1.1 staged-upload creation, resume, consumption, and cancel.
+4. Stop the service and back up the current data root to a different filesystem;
+   verify that the backup can be listed. Do not place the backup inside the data
+   root being archived, and keep the old package and data until acceptance ends.
+5. Ensure the destination filesystem can hold the persistent data, archive, and
+   runtime headroom. For a device that ran an early Rockchip build, also run:
+
+   ```bash
+   findmnt -T /userdata
+   du -sk /data/cwaiuserdata
+   df -Pk /userdata
+   ```
+
+   `/userdata` must be a writable mount. The migrator requires free space equal
+   to the selected persistent data plus 64 MiB. It refuses to use an ordinary
+   `/userdata` directory that falls back to the root filesystem.
+
+### Rockchip data-root migration
+
+An RK3576 or RV1126B package performs a one-time migration from
+`/data/cwaiuserdata` to `/userdata/cwaiuserdata` before replacing the application:
+
+- It transactionally copies configuration, configuration backups, databases,
+  database backups, camera configuration, user models, image libraries, events,
+  and other persistent top-level entries. The `/data/cwaiuserdata` source remains
+  available for recovery.
+- It excludes the rebuildable or transient `cwai`, `log`, `runtime`, `temporary`,
+  `tmp`, `upload`, `upgrade`, and `web` entries and upgrade markers.
+- A successful copy creates
+  `/userdata/cwaiuserdata/.cosmo-data-root-migration-v1` with mode `0600`, so a
+  later package cannot overwrite newer target data with the retained source.
+- If the installed runtime already declares `/userdata/cwaiuserdata` and it has
+  persistent entries, that root remains authoritative and stale `/data` contents
+  are not recopied. An upgrade marker, logs, or temporary directories alone do
+  not count as persistent state and cannot hide a legacy database.
+- If both roots contain state and the installer cannot prove which one is active,
+  it fails before stopping the service or replacing the application. Do not merge
+  the two databases manually.
+
+The application tree and a newly copied data root remain one transaction until
+the installer returns. A copy or installation failure restores the old
+application and removes the uncommitted target root. Installer success confirms
+the file transaction, not post-start service health.
+
+### Installation and post-upgrade acceptance
+
+BM1688 can use the web flow above or the SSH entry below. x86 rebuilds through
+the corresponding Compose file while keeping its named volumes. After upgrade,
+complete at least these checks:
+
+1. `bootId` changed, `cosmo.service` is `active`, and the software version matches
+   the target package.
+2. Existing users, cameras, tasks, parameters, user models, and event history are
+   readable.
+3. Run one real video task and confirm inference, preview, and at least one alarm
+   with media.
+4. Create a staged upload, recover the session after restart, verify cleanup after
+   successful consumption, and verify the cancel cleanup path.
+5. Reboot once more and repeat sign-in, task, model, history, and upload-state checks.
+6. Retain before/after data inventories, service logs, and explicit PASS/FAIL results.
+
+`bash test/test_legacy_migration_installer.sh` covers data copying, transient
+exclusions, idempotence, conflict rejection, and transaction rollback. It is a
+host-filesystem test and does not replace final-package upgrade, inference, and
+alarm evidence from a real device.
+
+### Recovery boundary
+
+An error before the installer returns restores the old application, and a
+Rockchip migration retains the old data root. If the new service fails real
+business acceptance after the installer returned, this version does **not**
+automatically roll back based on HTTP health. Keep power connected, save
+`systemctl status cosmo.service` and the logs, reinstall the previous package
+whose SHA-256 was recorded, and restore its data root from the pre-upgrade backup.
+Do not delete `/data/cwaiuserdata`, `/userdata/cwaiuserdata`, or the backup before
+recovery is complete.
+
 ## SSH Installation Path
 
 In addition to web upgrade, packaged `scripts/install.sh` is the SSH entry point

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -149,10 +149,101 @@ Web 控制台的本地升级流程如下：
 
 页面等待恢复的 15 分钟是交互超时，不会中止设备端已经开始的升级。超时后应保持供电，并通过设备网络和 systemd 日志确认状态。重新登录后还应核对软件版本与本次发布包；页面恢复只证明重启与服务恢复，不替代版本验收。
 
-## SSH安装路径
+## 从 1.0.0 升级到 1.1.0
 
-除了Web升级，包内`scripts/install.sh`还提供从main版本迁移及后续兼容安装的SSH入口。
-它会安装应用、替换并启用`cosmo.service`，然后由重启启动服务：
+### 支持范围
+
+公开的 v1.0.0 设备平台只有 BM1688，另有 x86 Linux/Windows 开发模式。不要把
+v1.1 新增平台描述成从 v1.0.0 原位升级：
+
+| 当前环境 | 到 v1.1.0 的路径 | 数据处理 |
+| --- | --- | --- |
+| BM1688 v1.0.0 | 使用 BM1688 Open 或对应受控 Protected 包原位升级 | 继续使用 `/data/cwaiuserdata` |
+| x86 Linux/Windows v1.0.0 | 从 `v1.1.0` 源码重新构建 Compose 服务 | 保留原命名卷；不要运行 `down -v` |
+| CV186X | 全新安装 v1.1.0 CV186X 包 | 没有公开的 v1.0.0 CV186X 升级基线 |
+| RK3576 / RV1126B | 正式用户全新安装；曾运行发布前构建的设备按下述数据根迁移处理 | v1.1 使用 `/userdata/cwaiuserdata` |
+| Apple Silicon macOS | 按 Preview 指南全新启动 | 没有 v1.0.0 macOS 发布基线 |
+
+本节定义升级方法，但不单独证明某个候选包已经通过发布验收。维护者必须把最终
+commit、package SHA-256、设备和升级结果绑定到同一份证据，才能放行正式包。
+
+### 升级前检查
+
+1. 从目标芯片目录取得安装包，同时保留相邻的 `TARGET_CHIP`、`SHA256SUMS`，确认
+   芯片标记和 SHA-256；不要跨芯片复用完整包。
+2. 记录当前 `bin/version.txt`、`bootId`、服务状态、设备/固件身份和目标包 SHA-256：
+
+   ```bash
+   cat /appfs/cosmo_wander/cwai_data/bin/version.txt
+   cat /proc/sys/kernel/random/boot_id
+   systemctl status cosmo.service --no-pager
+   ```
+
+3. 在 Web 控制台完成或取消正在进行的上传。v1.0.0 的未完成上传不是可恢复会话，
+   不会跨重启迁移；升级后再验证 v1.1 的 staged upload 创建、续传、消费和取消。
+4. 停止服务后，把当前数据根备份到另一个文件系统，并验证备份可以列出。不要把备份
+   写回被备份的数据根，也不要删除旧包和旧数据，直至升级验收完成。
+5. 确认目标文件系统同时容纳持久化数据、安装包和运行余量。曾运行早期 Rockchip
+   构建的设备还要检查：
+
+   ```bash
+   findmnt -T /userdata
+   du -sk /data/cwaiuserdata
+   df -Pk /userdata
+   ```
+
+   `/userdata` 必须是可写挂载点。迁移器要求目标剩余空间不小于待复制持久化数据加
+   64 MiB；不能把根文件系统上的普通 `/userdata` 目录当成持久化分区。
+
+### Rockchip 数据根迁移
+
+面向 RK3576 或 RV1126B 的包会在替换应用前处理从 `/data/cwaiuserdata` 到
+`/userdata/cwaiuserdata` 的一次性迁移：
+
+- 事务复制配置、配置备份、数据库、数据库备份、摄像头配置、用户模型、图片库、
+  事件和其他持久化顶层内容；原 `/data/cwaiuserdata` 保留为恢复来源。
+- 不复制 `cwai`、`log`、`runtime`、`temporary`、`tmp`、`upload`、`upgrade`、`web`
+  和升级标记等可重建或瞬时内容。
+- 复制完成后写入权限为 `0600` 的
+  `/userdata/cwaiuserdata/.cosmo-data-root-migration-v1`，后续安装不会重新覆盖新数据。
+- 如果已安装版本明确使用 `/userdata/cwaiuserdata` 且其中已有持久化内容，继续以该
+  目录为准，不用陈旧的 `/data` 内容覆盖它；仅有升级标记、日志或临时目录不算
+  持久化内容，不能阻止旧数据库迁移。
+- 如果两个数据根都包含内容，但无法证明哪个目录正在使用，安装器会在停止服务和
+  替换应用之前失败；不要人工合并两个数据库。
+
+应用目录和新数据根在安装器返回前属于同一个事务。复制或安装失败会恢复原应用并
+移除本次未提交的新数据根。安装器成功返回只表示文件事务完成，不表示新服务已经
+通过启动健康检查。
+
+### 安装和升级后验收
+
+BM1688 可以使用前述 Web 升级流程，也可以使用下一节的 SSH 入口。x86 使用对应
+Compose 文件重新构建服务并保留原命名卷。升级后至少完成以下检查：
+
+1. `bootId` 已变化，`cosmo.service` 为 `active`，软件版本和目标包一致；
+2. 原用户、摄像头、任务、参数、用户模型和事件历史仍可读取；
+3. 启动一个真实视频任务，确认推理、预览和至少一个带媒体的告警；
+4. 创建 staged upload，会话重启后可恢复，成功消费后被清理，取消路径也能清理；
+5. 再重启一次，重复登录、任务、模型、历史和上传状态检查；
+6. 保留升级前后数据清单、服务日志和 PASS/FAIL 结果。
+
+仓库测试 `bash test/test_legacy_migration_installer.sh` 验证数据复制、瞬时目录排除、
+幂等、冲突拒绝和事务回滚；它是主机文件系统测试，不能替代最终包在真实设备上的
+升级、推理和告警证据。
+
+### 恢复边界
+
+安装器在返回前发生错误时会恢复旧应用；Rockchip 迁移也会保留旧数据根。安装器
+返回后，如果新服务无法通过实际业务验收，当前版本**不会**根据 HTTP 健康状态自动
+回滚。保持设备供电，先保存 `systemctl status cosmo.service` 和日志，再通过 SSH
+重新安装已记录 SHA-256 的旧包，并按升级前备份恢复其数据根。恢复完成前不要删除
+`/data/cwaiuserdata`、`/userdata/cwaiuserdata` 或升级前备份。
+
+## SSH 安装路径
+
+除了 Web 升级，包内 `scripts/install.sh` 还提供从 main 版本迁移及后续兼容安装的
+SSH 入口。它会安装应用、替换并启用 `cosmo.service`，然后由重启启动服务：
 
 ```bash
 scp build_output/public-runtime/<chip>/<安装包>.tar.gz root@<设备IP>:/tmp/
@@ -165,7 +256,7 @@ sudo ./scripts/install.sh
 sudo reboot
 ```
 
-该路径假设Sophon Linux基础系统和运行依赖已经准备好，不是任意空白硬件的操作系统
+该路径假设 Sophon Linux 基础系统和运行依赖已经准备好，不是任意空白硬件的操作系统
 镜像安装流程。安装前记录当前版本和恢复方案；安装器会替换当前应用树。
 
 ## systemd 服务
@@ -176,8 +267,8 @@ sudo reboot
 ExecStart=/appfs/cosmo_wander/cwai_data/scripts/inte_run_start.sh
 ```
 
-`scripts/install.sh`负责升级事务，不创建空白设备的systemd unit。服务以`root`
-运行并使用`Restart=on-failure`。
+`scripts/install.sh` 负责升级事务，不创建空白设备的 systemd unit。服务以 `root`
+运行并使用 `Restart=on-failure`。
 
 部分 Sophon 系统会在启动时把持久化数据树的属主恢复为设备管理账户。上传暂存服务允许 `sessions` 目录继承一个不可被 group/other 写入的直接父目录属主，同时继续要求：
 

--- a/scripts/legacy_migration_install.sh
+++ b/scripts/legacy_migration_install.sh
@@ -27,32 +27,245 @@ COSMO_PACKAGE_DATA_DIR='/data/cwaiuserdata'
 COSMO_PACKAGE_APP_DATA_DIR='/appfs/cosmo_wander/cwai_data'
 runtime_paths_file="${payload_root}/share/cosmo/runtime-paths.env"
 if [ -f "$runtime_paths_file" ]; then
-    # Generated and packaged by CMake; values are validated before use.
-    # shellcheck disable=SC1090
-    . "$runtime_paths_file"
+    package_data_dir_seen=0
+    package_app_data_dir_seen=0
+    while IFS= read -r runtime_line || [ -n "$runtime_line" ]; do
+        case "$runtime_line" in
+            COSMO_PACKAGE_DATA_DIR=*)
+                [ "$package_data_dir_seen" -eq 0 ] ||
+                    fail "package runtime paths contain a duplicate data directory"
+                COSMO_PACKAGE_DATA_DIR="${runtime_line#COSMO_PACKAGE_DATA_DIR=}"
+                package_data_dir_seen=1
+                ;;
+            COSMO_PACKAGE_APP_DATA_DIR=*)
+                [ "$package_app_data_dir_seen" -eq 0 ] ||
+                    fail "package runtime paths contain a duplicate application directory"
+                COSMO_PACKAGE_APP_DATA_DIR="${runtime_line#COSMO_PACKAGE_APP_DATA_DIR=}"
+                package_app_data_dir_seen=1
+                ;;
+            '') ;;
+            *) fail "package runtime paths contain an unsupported declaration" ;;
+        esac
+    done <"$runtime_paths_file"
+    [ "$package_data_dir_seen" -eq 1 ] ||
+        fail "package runtime paths are missing the data directory"
+    [ "$package_app_data_dir_seen" -eq 1 ] ||
+        fail "package runtime paths are missing the application directory"
 fi
 case "$COSMO_PACKAGE_DATA_DIR" in
-    /*) ;;
-    *) fail "package data directory must be absolute" ;;
+    /data/cwaiuserdata|/userdata/cwaiuserdata) ;;
+    *) fail "package data directory is unsupported" ;;
 esac
-[ "$COSMO_PACKAGE_DATA_DIR" != / ] || fail "package data directory is invalid"
 [ "$COSMO_PACKAGE_APP_DATA_DIR" = /appfs/cosmo_wander/cwai_data ] ||
     fail "package application directory is incompatible"
 
+legacy_package_data_dir='/data/cwaiuserdata'
 if [ -n "${COSMO_MIGRATION_TEST_ROOT:-}" ]; then
     case "$COSMO_MIGRATION_TEST_ROOT" in /*) ;; *) fail "test root must be absolute" ;; esac
     [ "$COSMO_MIGRATION_TEST_ROOT" != / ] || fail "test root is invalid"
     active_root="${COSMO_MIGRATION_TEST_ROOT}/appfs/cosmo_wander/cwai_data"
     systemd_root="${COSMO_MIGRATION_TEST_ROOT}/etc/systemd/system"
-    upgrade_sign="${COSMO_MIGRATION_TEST_ROOT}${COSMO_PACKAGE_DATA_DIR}/mqttUpgradeApp"
+    target_data_root="${COSMO_MIGRATION_TEST_ROOT}${COSMO_PACKAGE_DATA_DIR}"
+    legacy_data_root="${COSMO_MIGRATION_TEST_ROOT}${legacy_package_data_dir}"
 else
     active_root='/appfs/cosmo_wander/cwai_data'
     systemd_root='/etc/systemd/system'
-    upgrade_sign="${COSMO_PACKAGE_DATA_DIR}/mqttUpgradeApp"
+    target_data_root="$COSMO_PACKAGE_DATA_DIR"
+    legacy_data_root="$legacy_package_data_dir"
 fi
+upgrade_sign="${target_data_root}/mqttUpgradeApp"
 active_parent="${active_root%/*}"
 staging_root="${active_parent}/.cosmo-migration-staging.$$"
 backup_root="${active_parent}/.cosmo-migration-backup"
+data_migration_marker="${target_data_root}/.cosmo-data-root-migration-v1"
+data_staging_root="${target_data_root%/*}/.cwaiuserdata-migration-staging.$$"
+data_migration_action='none'
+data_migration_created=0
+app_backup_created=0
+app_new_activated=0
+service_temp=''
+
+skip_legacy_data_entry() {
+    case "$1" in
+        .cosmo-data-root-migration-v1|cwai|log|mqttHWUpgradeApp|mqttUpgradeApp|runtime|temporary|tmp|upload|upgrade|web)
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+directory_has_persistent_entries() {
+    [ -d "$1" ] || return 1
+    for data_entry in "$1"/* "$1"/.[!.]* "$1"/..?*; do
+        [ -e "$data_entry" ] || [ -L "$data_entry" ] || continue
+        data_name="${data_entry##*/}"
+        skip_legacy_data_entry "$data_name" && continue
+        return 0
+    done
+    return 1
+}
+
+installed_runtime_data_dir() {
+    installed_runtime_file="${active_root}/share/cosmo/runtime-paths.env"
+    [ -f "$installed_runtime_file" ] || return 0
+    while IFS= read -r installed_runtime_line || [ -n "$installed_runtime_line" ]; do
+        case "$installed_runtime_line" in
+            COSMO_PACKAGE_DATA_DIR=*)
+                printf '%s\n' "${installed_runtime_line#COSMO_PACKAGE_DATA_DIR=}"
+                return 0
+                ;;
+        esac
+    done <"$installed_runtime_file"
+}
+
+validate_target_storage() {
+    [ ! -L "$target_data_root" ] || fail "target data root must not be a symbolic link"
+    [ ! -e "$target_data_root" ] || [ -d "$target_data_root" ] ||
+        fail "target data root must be a directory"
+
+    if [ -z "${COSMO_MIGRATION_TEST_ROOT:-}" ] &&
+       [ "$COSMO_PACKAGE_DATA_DIR" = /userdata/cwaiuserdata ]; then
+        [ -d /userdata ] || fail "/userdata is unavailable for this Rockchip package"
+        [ -r /proc/mounts ] || fail "cannot verify the /userdata mount"
+        awk '
+            $2 == "/userdata" {
+                count = split($4, options, ",")
+                for (option_index = 1; option_index <= count; option_index++) {
+                    if (options[option_index] == "rw") writable_mount = 1
+                }
+            }
+            END { exit(writable_mount ? 0 : 1) }
+        ' /proc/mounts ||
+            fail "/userdata is not a writable mounted filesystem; refusing fallback to the root disk"
+        [ -w /userdata ] || fail "/userdata is not writable"
+    fi
+}
+
+assess_data_root_migration() {
+    [ "$COSMO_PACKAGE_DATA_DIR" != "$legacy_package_data_dir" ] || return 0
+    validate_target_storage
+
+    if [ -f "$data_migration_marker" ]; then
+        if ! grep -Fxq 'schema=1' "$data_migration_marker" ||
+           ! grep -Fxq "source=${legacy_package_data_dir}" "$data_migration_marker" ||
+           ! grep -Fxq "target=${COSMO_PACKAGE_DATA_DIR}" "$data_migration_marker"; then
+            fail "target data root contains an invalid migration marker"
+        fi
+        log "Data root migration already completed; keeping ${COSMO_PACKAGE_DATA_DIR}"
+        return 0
+    fi
+
+    [ ! -L "$legacy_data_root" ] || fail "legacy data root must not be a symbolic link"
+    [ ! -e "$legacy_data_root" ] || [ -d "$legacy_data_root" ] ||
+        fail "legacy data root must be a directory"
+
+    target_has_persistent_state=0
+    legacy_has_persistent_state=0
+    directory_has_persistent_entries "$target_data_root" && target_has_persistent_state=1
+    directory_has_persistent_entries "$legacy_data_root" && legacy_has_persistent_state=1
+
+    installed_data_dir="$(installed_runtime_data_dir)"
+    if [ "$target_has_persistent_state" -eq 1 ]; then
+        if [ "$installed_data_dir" = "$COSMO_PACKAGE_DATA_DIR" ]; then
+            log "Installed runtime already uses ${COSMO_PACKAGE_DATA_DIR}; keeping its persistent state authoritative"
+            return 0
+        fi
+        if [ "$legacy_has_persistent_state" -eq 1 ]; then
+            fail "both legacy and target data roots contain persistent state; refusing an ambiguous merge"
+        fi
+        log "Only ${COSMO_PACKAGE_DATA_DIR} contains persistent state; keeping it authoritative"
+        return 0
+    fi
+    [ "$legacy_has_persistent_state" -eq 1 ] || return 0
+
+    mkdir -p -- "${target_data_root%/*}"
+    [ ! -e "$data_staging_root" ] && [ ! -L "$data_staging_root" ] ||
+        fail "data migration staging path already exists"
+
+    if [ -z "${COSMO_MIGRATION_TEST_ROOT:-}" ]; then
+        selected_data_kib=0
+        for legacy_entry in \
+            "$legacy_data_root"/* "$legacy_data_root"/.[!.]* "$legacy_data_root"/..?*; do
+            [ -e "$legacy_entry" ] || [ -L "$legacy_entry" ] || continue
+            legacy_name="${legacy_entry##*/}"
+            skip_legacy_data_entry "$legacy_name" && continue
+            entry_kib="$(du -sk "$legacy_entry" 2>/dev/null | awk '{ print $1 }')"
+            case "$entry_kib" in
+                ''|*[!0-9]*) fail "cannot measure legacy data entry" ;;
+            esac
+            selected_data_kib=$((selected_data_kib + entry_kib))
+        done
+        available_kib="$(df -Pk "${target_data_root%/*}" | awk 'NR == 2 { print $4 }')"
+        case "$available_kib" in
+            ''|*[!0-9]*) fail "cannot determine target data-root free space" ;;
+        esac
+        required_kib=$((selected_data_kib + 65536))
+        [ "$available_kib" -ge "$required_kib" ] ||
+            fail "target data root needs the persistent data size plus 64 MiB of free space"
+    fi
+
+    data_migration_action='copy'
+    log "Persistent data will be copied from ${legacy_package_data_dir} to ${COSMO_PACKAGE_DATA_DIR}; the source will be retained"
+}
+
+migrate_data_root() {
+    [ "$data_migration_action" = copy ] || return 0
+    mkdir -m 0700 -- "$data_staging_root"
+
+    for legacy_entry in \
+        "$legacy_data_root"/* "$legacy_data_root"/.[!.]* "$legacy_data_root"/..?*; do
+        [ -e "$legacy_entry" ] || [ -L "$legacy_entry" ] || continue
+        legacy_name="${legacy_entry##*/}"
+        skip_legacy_data_entry "$legacy_name" && continue
+        cp -a -- "$legacy_entry" "$data_staging_root/"
+    done
+
+    if [ -d "$target_data_root" ]; then
+        directory_has_persistent_entries "$target_data_root" &&
+            fail "target data root gained persistent state while the service was stopping"
+        rm -rf -- "$target_data_root"
+    fi
+    mv -- "$data_staging_root" "$target_data_root"
+    data_migration_created=1
+    log "Persistent data root migrated; legacy source retained at ${legacy_package_data_dir}"
+}
+
+commit_data_root_migration() {
+    [ "$data_migration_created" -eq 1 ] || return 0
+    marker_temp="${data_migration_marker}.tmp.$$"
+    previous_umask="$(umask)"
+    umask 077
+    {
+        printf '%s\n' \
+            'schema=1' \
+            "source=${legacy_package_data_dir}" \
+            "target=${COSMO_PACKAGE_DATA_DIR}" \
+            'source_retained=true'
+    } >"$marker_temp"
+    chmod 0600 "$marker_temp"
+    mv -f -- "$marker_temp" "$data_migration_marker"
+    umask "$previous_umask"
+}
+
+rollback_installation() {
+    rollback_status="$1"
+    trap - EXIT HUP INT TERM
+    set +e
+    [ -z "$service_temp" ] || rm -f -- "$service_temp"
+    rm -rf -- "$staging_root" "$data_staging_root"
+    if [ "$app_new_activated" -eq 1 ]; then
+        rm -rf -- "$active_root"
+    fi
+    if [ "$app_backup_created" -eq 1 ] &&
+       { [ -e "$backup_root" ] || [ -L "$backup_root" ]; }; then
+        mv -- "$backup_root" "$active_root"
+    fi
+    if [ "$data_migration_created" -eq 1 ]; then
+        rm -rf -- "$target_data_root"
+    fi
+    printf '[MIGRATION] ERROR: incomplete installation transaction rolled back\n' >&2
+    exit "$rollback_status"
+}
 
 [ -f "${payload_root}/bin/cosmo-engine" ] || fail "package is missing bin/cosmo-engine"
 for required_script in stop.sh start.sh inte_run_start.sh; do
@@ -62,13 +275,16 @@ done
 
 log "Install Start"
 log "script=${script_path}, logFile=${log_file}"
+assess_data_root_migration
+trap 'rollback_installation $?' EXIT
+trap 'exit 1' HUP INT TERM
 log "Stopping active Cosmo processes"
 "${payload_root}/scripts/stop.sh"
+migrate_data_root
 
 mkdir -p -- "$active_parent"
 [ ! -e "$staging_root" ] && [ ! -L "$staging_root" ] || fail "staging path already exists"
 mkdir -- "$staging_root"
-trap 'rm -rf -- "$staging_root"' EXIT
 
 # Match the historical installer: preserve the installed resource tree by
 # default, then overlay packaged resources. Copying the installed tree first
@@ -83,13 +299,17 @@ cp -a -- "${payload_root}/." "$staging_root/"
 [ ! -e "$backup_root" ] && [ ! -L "$backup_root" ] || fail "stale migration backup exists"
 if [ -e "$active_root" ] || [ -L "$active_root" ]; then
     mv -- "$active_root" "$backup_root"
+    app_backup_created=1
 fi
 if ! mv -- "$staging_root" "$active_root"; then
-    [ ! -e "$backup_root" ] || mv -- "$backup_root" "$active_root"
     fail "cannot activate migrated application"
 fi
-trap - EXIT
-rm -rf -- "$backup_root"
+app_new_activated=1
+
+if [ -n "${COSMO_MIGRATION_TEST_ROOT:-}" ] &&
+   [ "${COSMO_MIGRATION_TEST_FAIL_AFTER_ACTIVATION:-0}" = 1 ]; then
+    fail "injected post-activation failure"
+fi
 
 # Preserve the historical post-install filesystem contract.
 mkdir -p -- "${active_root}/web/staticfile" "${active_root}/bin/nginx_conf/logs"
@@ -109,7 +329,6 @@ rm -f -- "${active_root}/scripts/install.sh"
 mkdir -p -- "$systemd_root"
 service_file="${systemd_root}/cosmo.service"
 service_temp="${service_file}.tmp.$$"
-trap 'rm -f -- "$service_temp"' EXIT
 umask 022
 {
     printf '%s\n' \
@@ -131,7 +350,7 @@ umask 022
 } >"$service_temp"
 chmod 0644 "$service_temp"
 mv -f -- "$service_temp" "$service_file"
-trap - EXIT
+service_temp=''
 
 if [ -n "${COSMO_MIGRATION_TEST_ROOT:-}" ]; then
     wants_dir="${systemd_root}/multi-user.target.wants"
@@ -142,9 +361,14 @@ else
     systemctl enable cosmo.service
 fi
 
+commit_data_root_migration
 mkdir -p -- "${upgrade_sign%/*}"
 : >"$upgrade_sign"
 sync
+trap - EXIT HUP INT TERM
+if ! rm -rf -- "$backup_root"; then
+    log "WARNING: previous application backup could not be removed: ${backup_root}"
+fi
 log "Install files Done"
 log "systemd service [cosmo] installed and enabled"
 log "installed legacy-compatible bridge at ${active_root}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -90,8 +90,15 @@ if [ -z "$package_root" ] || [ ! -x "${package_root}/scripts/install.sh" ]; then
 fi
 
 cosmo_log "$log_tag" "Installing compatible package $(basename "$archive")" "$log_file"
-"${COSMO_INSTALL_DIR}/scripts/stop.sh"
-"${package_root}/scripts/install.sh" "$log_file"
+if "${package_root}/scripts/install.sh" "$log_file"; then
+    cosmo_log "$log_tag" "Compatible package installation completed" "$log_file"
+else
+    install_status=$?
+    cosmo_log "$log_tag" \
+        "Package installation failed with status ${install_status}; restoring the active application" \
+        "$log_file"
+    run_active
+fi
 mkdir -p -- "$(dirname "$COSMO_UPGRADE_SIGN")"
 : >"$COSMO_UPGRADE_SIGN"
 sync

--- a/test/test_legacy_migration_installer.sh
+++ b/test/test_legacy_migration_installer.sh
@@ -45,7 +45,8 @@ test -L "$root/etc/systemd/system/multi-user.target.wants/cosmo.service"
 # The same permanent MD5 lifecycle must remain valid after the first bridge
 # from main; a later package uses the same installer contract.
 printf 'newer\n' >"$payload/bin/cosmo-engine"
-sed -i 's#/appfs/cosmo_wander/cwai_data#/appfs/minivision/mv_data#' "$service"
+sed -i.bak 's#/appfs/cosmo_wander/cwai_data#/appfs/minivision/mv_data#' "$service"
+rm -f -- "${service}.bak"
 COSMO_MIGRATION_TEST_ROOT="$root" \
     sh "$payload/scripts/install.sh" "$root/install-again.log"
 grep -Fxq newer "$active/bin/cosmo-engine"
@@ -81,8 +82,16 @@ grep -Fxq packaged-model "$active/resource/models/model.nn"
 rk_root="${root}/rk-case"
 rk_payload="${rk_root}/payload"
 rk_active="${rk_root}/appfs/cosmo_wander/cwai_data"
+rk_legacy_data="${rk_root}/data/cwaiuserdata"
+rk_target_data="${rk_root}/userdata/cwaiuserdata"
 mkdir -p "$rk_payload/scripts" "$rk_payload/bin" "$rk_payload/files/Interface" \
-    "$rk_payload/web" "$rk_payload/share/cosmo"
+    "$rk_payload/web" "$rk_payload/share/cosmo" \
+    "$rk_legacy_data/conf" "$rk_legacy_data/confb" "$rk_legacy_data/db" \
+    "$rk_legacy_data/db2" "$rk_legacy_data/camera" \
+    "$rk_legacy_data/resource/models" "$rk_legacy_data/weblibPic/personPicture" \
+    "$rk_legacy_data/event/2026/08/21" "$rk_legacy_data/upload/sessions/in-flight" \
+    "$rk_legacy_data/upgrade" "$rk_legacy_data/tmp" "$rk_legacy_data/log" \
+    "$rk_legacy_data/cwai" "$rk_legacy_data/runtime" "$rk_legacy_data/web"
 cp "$repo/scripts/legacy_migration_install.sh" "$rk_payload/scripts/install.sh"
 printf 'new\n' >"$rk_payload/bin/cosmo-engine"
 printf '#!/bin/sh\n' >"$rk_payload/scripts/stop.sh"
@@ -95,15 +104,178 @@ printf '%s\n' \
     'COSMO_PACKAGE_DATA_DIR=/userdata/cwaiuserdata' \
     'COSMO_PACKAGE_APP_DATA_DIR=/appfs/cosmo_wander/cwai_data' \
     >"$rk_payload/share/cosmo/runtime-paths.env"
+printf 'configuration\n' >"$rk_legacy_data/conf/device.json"
+printf 'backup-configuration\n' >"$rk_legacy_data/confb/device.json"
+printf 'database\n' >"$rk_legacy_data/db/cosmo.db"
+printf 'database-backup\n' >"$rk_legacy_data/db2/cosmo.db"
+printf 'camera\n' >"$rk_legacy_data/camera/camera.json"
+printf 'user-model\n' >"$rk_legacy_data/resource/models/model.nn"
+printf 'person\n' >"$rk_legacy_data/weblibPic/personPicture/person.jpg"
+printf 'event\n' >"$rk_legacy_data/event/2026/08/21/event.json"
+printf 'session\n' >"$rk_legacy_data/upload/sessions/in-flight/chunk.bin"
+printf 'archive\n' >"$rk_legacy_data/upgrade/cosmo.tar.gz"
+printf 'temporary\n' >"$rk_legacy_data/tmp/file"
+printf 'log\n' >"$rk_legacy_data/log/file"
+printf 'runtime\n' >"$rk_legacy_data/cwai/file"
+printf 'runtime\n' >"$rk_legacy_data/runtime/file"
+printf 'web\n' >"$rk_legacy_data/web/file"
 
 COSMO_MIGRATION_TEST_ROOT="$rk_root" \
     sh "$rk_payload/scripts/install.sh" "$rk_root/install.log"
 
 test -f "$rk_root/userdata/cwaiuserdata/mqttUpgradeApp"
 test ! -e "$rk_root/data/cwaiuserdata/mqttUpgradeApp"
+grep -Fxq configuration "$rk_target_data/conf/device.json"
+grep -Fxq backup-configuration "$rk_target_data/confb/device.json"
+grep -Fxq database "$rk_target_data/db/cosmo.db"
+grep -Fxq database-backup "$rk_target_data/db2/cosmo.db"
+grep -Fxq camera "$rk_target_data/camera/camera.json"
+grep -Fxq user-model "$rk_target_data/resource/models/model.nn"
+grep -Fxq person "$rk_target_data/weblibPic/personPicture/person.jpg"
+grep -Fxq event "$rk_target_data/event/2026/08/21/event.json"
+test ! -e "$rk_target_data/upload"
+test ! -e "$rk_target_data/upgrade"
+test ! -e "$rk_target_data/tmp"
+test ! -e "$rk_target_data/log"
+test ! -e "$rk_target_data/cwai"
+test ! -e "$rk_target_data/runtime"
+test ! -e "$rk_target_data/web"
+test -f "$rk_target_data/.cosmo-data-root-migration-v1"
+grep -Fxq 'schema=1' "$rk_target_data/.cosmo-data-root-migration-v1"
+grep -Fxq 'source=/data/cwaiuserdata' "$rk_target_data/.cosmo-data-root-migration-v1"
+grep -Fxq 'target=/userdata/cwaiuserdata' "$rk_target_data/.cosmo-data-root-migration-v1"
+grep -Fxq 'source_retained=true' "$rk_target_data/.cosmo-data-root-migration-v1"
+marker_mode="$(stat -c '%a' "$rk_target_data/.cosmo-data-root-migration-v1" 2>/dev/null || \
+    stat -f '%Lp' "$rk_target_data/.cosmo-data-root-migration-v1")"
+test "$marker_mode" = 600
+test -f "$rk_legacy_data/db/cosmo.db"
+test -f "$rk_legacy_data/upload/sessions/in-flight/chunk.bin"
+grep -Fq 'Persistent data root migrated; legacy source retained' "$rk_root/install.log"
 test -f "$rk_active/share/cosmo/runtime-paths.env"
 grep -Fxq 'EnvironmentFile=-/appfs/cosmo_wander/cwai_data/share/cosmo/runtime-paths.env' \
     "$rk_root/etc/systemd/system/cosmo.service"
+
+# A completed migration is idempotent. The retained legacy source must not
+# overwrite newer state already written below /userdata.
+printf 'authoritative-target\n' >"$rk_target_data/db/cosmo.db"
+printf 'stale-legacy\n' >"$rk_legacy_data/db/cosmo.db"
+printf 'newer\n' >"$rk_payload/bin/cosmo-engine"
+COSMO_MIGRATION_TEST_ROOT="$rk_root" \
+    sh "$rk_payload/scripts/install.sh" "$rk_root/install-again.log"
+grep -Fxq authoritative-target "$rk_target_data/db/cosmo.db"
+grep -Fq 'Data root migration already completed' "$rk_root/install-again.log"
+
+# If both roots contain state and the installed application does not already
+# declare /userdata authoritative, fail before stopping or replacing anything.
+conflict_root="${root}/rk-conflict"
+conflict_payload="${conflict_root}/payload"
+mkdir -p "$conflict_root/data/cwaiuserdata/conf" \
+    "$conflict_root/userdata/cwaiuserdata/conf" \
+    "$conflict_root/appfs/cosmo_wander/cwai_data/bin"
+cp -R "$rk_payload" "$conflict_payload"
+printf '#!/bin/sh\ntouch "$COSMO_MIGRATION_TEST_ROOT/stop.called"\n' \
+    >"$conflict_payload/scripts/stop.sh"
+chmod +x "$conflict_payload/scripts/stop.sh"
+printf 'legacy\n' >"$conflict_root/data/cwaiuserdata/conf/device.json"
+printf 'target\n' >"$conflict_root/userdata/cwaiuserdata/conf/device.json"
+printf 'old\n' >"$conflict_root/appfs/cosmo_wander/cwai_data/bin/cosmo-engine"
+if COSMO_MIGRATION_TEST_ROOT="$conflict_root" \
+    sh "$conflict_payload/scripts/install.sh" "$conflict_root/install.log" \
+    2>"$conflict_root/install.stderr"; then
+    echo "ambiguous data roots must fail" >&2
+    exit 1
+fi
+test ! -e "$conflict_root/stop.called"
+grep -Fxq old "$conflict_root/appfs/cosmo_wander/cwai_data/bin/cosmo-engine"
+grep -Fq 'refusing an ambiguous merge' "$conflict_root/install.stderr"
+
+# A pre-release Rockchip installation that already declares /userdata remains
+# authoritative even when a stale /data tree is still present.
+already_root="${root}/rk-already-active"
+already_payload="${already_root}/payload"
+already_active="${already_root}/appfs/cosmo_wander/cwai_data"
+mkdir -p "$already_root/data/cwaiuserdata/db" \
+    "$already_root/userdata/cwaiuserdata/db" "$already_active/share/cosmo" \
+    "$already_active/bin"
+cp -R "$rk_payload" "$already_payload"
+printf '%s\n' \
+    'COSMO_PACKAGE_DATA_DIR=/userdata/cwaiuserdata' \
+    'COSMO_PACKAGE_APP_DATA_DIR=/appfs/cosmo_wander/cwai_data' \
+    >"$already_active/share/cosmo/runtime-paths.env"
+printf 'stale-legacy\n' >"$already_root/data/cwaiuserdata/db/cosmo.db"
+printf 'current-target\n' >"$already_root/userdata/cwaiuserdata/db/cosmo.db"
+printf 'old-engine\n' >"$already_active/bin/cosmo-engine"
+COSMO_MIGRATION_TEST_ROOT="$already_root" \
+    sh "$already_payload/scripts/install.sh" "$already_root/install.log"
+grep -Fxq current-target "$already_root/userdata/cwaiuserdata/db/cosmo.db"
+grep -Fxq stale-legacy "$already_root/data/cwaiuserdata/db/cosmo.db"
+grep -Fq 'Installed runtime already uses /userdata/cwaiuserdata' \
+    "$already_root/install.log"
+
+# An earlier broken bridge may have created only an upgrade marker and logs in
+# /userdata. Those transient entries must not hide durable legacy state.
+transient_root="${root}/rk-transient-target"
+transient_payload="${transient_root}/payload"
+transient_active="${transient_root}/appfs/cosmo_wander/cwai_data"
+mkdir -p "$transient_root/data/cwaiuserdata/db" \
+    "$transient_root/userdata/cwaiuserdata/log" \
+    "$transient_active/share/cosmo" "$transient_active/bin"
+cp -R "$rk_payload" "$transient_payload"
+printf '%s\n' \
+    'COSMO_PACKAGE_DATA_DIR=/userdata/cwaiuserdata' \
+    'COSMO_PACKAGE_APP_DATA_DIR=/appfs/cosmo_wander/cwai_data' \
+    >"$transient_active/share/cosmo/runtime-paths.env"
+printf 'legacy-durable\n' >"$transient_root/data/cwaiuserdata/db/cosmo.db"
+printf 'old-marker\n' >"$transient_root/userdata/cwaiuserdata/mqttUpgradeApp"
+printf 'old-log\n' >"$transient_root/userdata/cwaiuserdata/log/start.log"
+printf 'old-engine\n' >"$transient_active/bin/cosmo-engine"
+COSMO_MIGRATION_TEST_ROOT="$transient_root" \
+    sh "$transient_payload/scripts/install.sh" "$transient_root/install.log"
+grep -Fxq legacy-durable "$transient_root/userdata/cwaiuserdata/db/cosmo.db"
+test ! -e "$transient_root/userdata/cwaiuserdata/log"
+test -f "$transient_root/userdata/cwaiuserdata/.cosmo-data-root-migration-v1"
+grep -Fq 'Persistent data root migrated' "$transient_root/install.log"
+
+# runtime-paths.env is parsed as data rather than sourced as shell code.
+unsafe_root="${root}/unsafe-runtime-paths"
+unsafe_payload="${unsafe_root}/payload"
+unsafe_marker="${unsafe_root}/runtime-paths-executed"
+mkdir -p "$unsafe_root"
+cp -R "$rk_payload" "$unsafe_payload"
+printf 'COSMO_PACKAGE_DATA_DIR=$(touch %s)\n%s\n' \
+    "$unsafe_marker" \
+    'COSMO_PACKAGE_APP_DATA_DIR=/appfs/cosmo_wander/cwai_data' \
+    >"$unsafe_payload/share/cosmo/runtime-paths.env"
+if COSMO_MIGRATION_TEST_ROOT="$unsafe_root" \
+    sh "$unsafe_payload/scripts/install.sh" "$unsafe_root/install.log" \
+    2>"$unsafe_root/install.stderr"; then
+    echo "unsafe runtime paths must fail" >&2
+    exit 1
+fi
+test ! -e "$unsafe_marker"
+grep -Fq 'package data directory is unsupported' "$unsafe_root/install.stderr"
+
+# A failure after activation restores both the previous application and the
+# pre-migration data-root state. A retry can therefore recopy a consistent DB.
+rollback_root="${root}/rk-rollback"
+rollback_payload="${rollback_root}/payload"
+mkdir -p "$rollback_root/data/cwaiuserdata/db" \
+    "$rollback_root/appfs/cosmo_wander/cwai_data/bin"
+cp -R "$rk_payload" "$rollback_payload"
+printf 'legacy-database\n' >"$rollback_root/data/cwaiuserdata/db/cosmo.db"
+printf 'old-engine\n' >"$rollback_root/appfs/cosmo_wander/cwai_data/bin/cosmo-engine"
+if COSMO_MIGRATION_TEST_ROOT="$rollback_root" \
+    COSMO_MIGRATION_TEST_FAIL_AFTER_ACTIVATION=1 \
+    sh "$rollback_payload/scripts/install.sh" "$rollback_root/install.log"; then
+    echo "injected post-activation failure must fail" >&2
+    exit 1
+fi
+grep -Fxq old-engine "$rollback_root/appfs/cosmo_wander/cwai_data/bin/cosmo-engine"
+grep -Fxq legacy-database "$rollback_root/data/cwaiuserdata/db/cosmo.db"
+test ! -e "$rollback_root/userdata/cwaiuserdata"
+test ! -e "$rollback_root/appfs/cosmo_wander/.cosmo-migration-backup"
+test -z "$(find "$rollback_root/appfs/cosmo_wander" -maxdepth 1 \
+    -name '.cosmo-migration-staging.*' -print -quit)"
 
 # Preserved resources must be copied into staging before the package overlays
 # them. Keeping the packaged resource tree in staging while copying the active
@@ -114,5 +286,7 @@ payload_copy_line="$(grep -nF 'cp -a -- "${payload_root}/." "$staging_root/"' "$
 test -n "$preserved_copy_line"
 test -n "$payload_copy_line"
 test "$preserved_copy_line" -lt "$payload_copy_line"
-! grep -Fq '.packaged-resource' "$installer"
+if grep -Fq '.packaged-resource' "$installer"; then
+    exit 1
+fi
 echo "legacy migration installer tests passed"

--- a/test/test_runtime_paths.sh
+++ b/test/test_runtime_paths.sh
@@ -30,15 +30,24 @@ resolve_paths() {
     )
 }
 
-mapfile -t rk_paths < <(resolve_paths "$rk_install")
+rk_paths=()
+while IFS= read -r resolved_path; do
+    rk_paths[${#rk_paths[@]}]="$resolved_path"
+done < <(resolve_paths "$rk_install")
 test "${rk_paths[0]}" = /userdata/cwaiuserdata
 test "${rk_paths[1]}" = /appfs/cosmo_wander/cwai_data
 
-mapfile -t sophon_paths < <(resolve_paths "$sophon_install")
+sophon_paths=()
+while IFS= read -r resolved_path; do
+    sophon_paths[${#sophon_paths[@]}]="$resolved_path"
+done < <(resolve_paths "$sophon_install")
 test "${sophon_paths[0]}" = /data/cwaiuserdata
 test "${sophon_paths[1]}" = /appfs/cosmo_wander/cwai_data
 
-mapfile -t override_paths < <(
+override_paths=()
+while IFS= read -r resolved_path; do
+    override_paths[${#override_paths[@]}]="$resolved_path"
+done < <(
     COSMO_DATA_DIR=/mnt/cosmo-data \
         COSMO_APP_DATA_DIR=/opt/cosmo-app \
         resolve_paths "$rk_install"
@@ -74,6 +83,7 @@ cp "${repo}/cmake/srs.conf.in" "${render_install}/bin/srs_conf/srs.conf"
 render_data_dir="${root}/userdata/cwaiuserdata"
 (
     unset COSMO_PACKAGE_DATA_DIR COSMO_PACKAGE_APP_DATA_DIR
+    # shellcheck disable=SC2034  # consumed by sourced common.sh
     COSMO_INSTALL_DIR="$render_install"
     COSMO_DATA_DIR="$render_data_dir"
     # shellcheck source=../scripts/common.sh
@@ -87,8 +97,12 @@ render_data_dir="${root}/userdata/cwaiuserdata"
     grep -Fq "alias ${render_data_dir}/event;" "$COSMO_RUNTIME_NGINX_UPSTREAM_CONF"
     grep -Fq "pid                 ${render_data_dir}/log/logs/srs.pid;" \
         "$COSMO_RUNTIME_SRS_CONF"
-    ! grep -R -Fq '@COSMO_DATA_DIR@' "$COSMO_RUNTIME_NGINX_PREFIX" "$COSMO_RUNTIME_SRS_CONF"
-    ! grep -R -Fq '/data/cwaiuserdata' "$COSMO_RUNTIME_NGINX_PREFIX" "$COSMO_RUNTIME_SRS_CONF"
+    if grep -R -Fq '@COSMO_DATA_DIR@' "$COSMO_RUNTIME_NGINX_PREFIX" "$COSMO_RUNTIME_SRS_CONF"; then
+        exit 1
+    fi
+    if grep -R -Fq '/data/cwaiuserdata' "$COSMO_RUNTIME_NGINX_PREFIX" "$COSMO_RUNTIME_SRS_CONF"; then
+        exit 1
+    fi
 )
 
 echo "runtime path resolution tests passed"

--- a/test/test_upgrade_start_fallback.sh
+++ b/test/test_upgrade_start_fallback.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "$0")/.." && pwd -P)"
+root="$(mktemp -d)"
+trap 'rm -rf -- "$root"' EXIT
+
+active="$root/active"
+data="$root/data"
+package="$data/upgrade/cosmo-V1.1.0-package"
+mkdir -p "$active/scripts" "$data/upgrade" \
+    "$package/bin" "$package/files" "$package/font" "$package/lib" \
+    "$package/scripts" "$package/web"
+
+cp "$repo/scripts/start.sh" "$active/scripts/start.sh"
+cp "$repo/scripts/common.sh" "$active/scripts/common.sh"
+chmod +x "$active/scripts/start.sh"
+
+cat >"$active/scripts/stop.sh" <<'EOF'
+#!/bin/sh
+touch "$COSMO_TEST_STOP_CALLED"
+EOF
+cat >"$active/scripts/run_start.sh" <<'EOF'
+#!/bin/sh
+touch "$COSMO_TEST_ACTIVE_STARTED"
+EOF
+cat >"$package/scripts/install.sh" <<'EOF'
+#!/bin/sh
+touch "$COSMO_TEST_INSTALL_CALLED"
+exit 42
+EOF
+chmod +x "$active/scripts/stop.sh" "$active/scripts/run_start.sh" \
+    "$package/scripts/install.sh"
+
+archive_body="$root/archive-body"
+printf 'candidate\n' >"$archive_body"
+archive_md5="$(md5sum "$archive_body" | awk '{ print $1 }')"
+archive="$data/upgrade/cosmo-V1.1.0-${archive_md5}.tar.gz"
+cp "$archive_body" "$archive"
+
+COSMO_INSTALL_DIR="$active" \
+COSMO_DATA_DIR="$data" \
+COSMO_RUNTIME_PATHS_FILE="$root/no-runtime-paths.env" \
+COSMO_TEST_STOP_CALLED="$root/stop.called" \
+COSMO_TEST_INSTALL_CALLED="$root/install.called" \
+COSMO_TEST_ACTIVE_STARTED="$root/active.started" \
+    bash "$active/scripts/start.sh" start
+
+test ! -e "$root/stop.called"
+test -f "$root/install.called"
+test -f "$root/active.started"
+test -z "$(find "$data/upgrade" -mindepth 1 -print -quit)"
+grep -Fq 'Package installation failed with status 42' \
+    "$data/log/logs/INTE_RUN_now.1"
+
+echo "upgrade start fallback tests passed"


### PR DESCRIPTION
## Summary

Close the three material v1.1 release gaps: a safe prerelease Rockchip data-root bridge and explicit v1.0.0 upgrade path, maintainer-ready per-platform release notes, and a decided English community channel.

## Related issue

N/A — this implements the directly agreed v1.1 release-readiness task; no issue was opened.

## Root cause

Target-specific runtime paths moved Rockchip mutable state from `/data/cwaiuserdata` to `/userdata/cwaiuserdata`, but the package installer changed the runtime root without migrating durable state or rejecting ambiguous dual-root contents. The deployment guide had no version-specific v1.0.0 upgrade contract, the repository had no per-platform v1.1 release-body source, and the English README did not explicitly settle Discussions versus Discord.

## Scope

### In scope

- Transactional Rockchip durable-data copy with source retention, mount/free-space admission, idempotence, transient exclusion, and fail-closed conflict handling.
- Application/data rollback before installer commit and startup fallback to the active application after a rejected installation.
- Focused Linux shell tests wired into Rockchip CI.
- Bilingual v1.0.0-to-v1.1.0 upgrade, recovery, staged-upload, and evidence guidance.
- Bilingual per-platform v1.1.0 release-note drafts.
- GitHub Discussions as the official searchable English v1.1 channel; no Discord for this release.

### Out of scope

- Publishing the final `v1.1.0` tag or release.
- Claiming final-package or real-device upgrade qualification.
- Automatic post-start HTTP-health rollback.
- Deleting the retained legacy Rockchip data root.

## Risk tags

- [x] Runtime / lifecycle
- [ ] Thread / memory safety
- [ ] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Documentation
- [x] Build / deployment
- [ ] Refactor
- [x] Test

## Area

- [ ] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [x] Build / deployment
- [x] Documentation

## Candidate identity

- Base commit: `dd3bd05220ecd52a144b9179030db723fff2f717`
- Candidate commit: `af2a825df1140911439bad1997a0350b37354daa`
- Candidate tree: `84d50c026fceb2b1a18ce84e860893a279445a2f`
- Package SHA-256: `N/A — no release package produced by this PR validation`
- Test binary SHA-256: `N/A — shell, Python, render, and policy checks only`

The candidate was replayed only to add DCO sign-offs. Its tree SHA remained unchanged, and all listed checks were rerun against the final candidate commit.

## Verification

### Parent baseline

`BLOCKED` — no separate parent package/device run was performed. Regression attribution is covered by focused tests added for the previously absent migration and fallback paths; this is not product qualification.

```text
Base: dd3bd05220ecd52a144b9179030db723fff2f717
No parent package or device mutation performed.
```

### Candidate checks

```text
PASS — Linux/amd64 locked Rockchip builder container:
  bash test/test_runtime_paths.sh
  bash test/test_legacy_migration_installer.sh
  bash test/test_upgrade_start_fallback.sh

PASS — package policy:
  python3 -m unittest discover -s test -p 'test_package_profile.py'
  18 cases, 2 environment-dependent skips

PASS — documentation-equivalent checks:
  Sophon Open model verification
  v1.1 benchmark validation: 4 platforms / 49 canonical cases / 138 bilingual reports
  macOS Preview contract check
  bilingual tutorial/link/navigation check
  VitePress build plus tutorial and benchmark smoke checks

PASS — source/policy:
  ShellCheck at warning severity for changed shell files
  actionlint for ci-build-rockchip.yml
  git diff --check

PASS — GitHub Markdown API:
  README.md
  README.zh-CN.md
  .github/release-notes/v1.1.0.md
  .github/release-notes/v1.1.0.zh-CN.md
  Tables/headings rendered with no literal unparsed ** markers.
```

### Risk-based evidence

- API/network: N/A; no API contract changed.
- Media/streaming: N/A; no media implementation changed.
- Sophon/device: Not run; final BM1688 in-place upgrade remains a release gate.
- Frontend/UI: No frontend source changed; documentation and GitHub GFM rendered successfully.
- Package/deployment: Host-filesystem transaction tests pass. Final target packages, real mounts, reboot, inference, alarm, staged-upload restart, and manual recovery remain candidate-bound release gates.

## Documentation impact

- [x] Documentation was updated.
- [ ] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [x] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

The BM1688/x86 v1.0.0 paths remain unchanged. Rockchip prerelease installs now migrate durable state or fail closed instead of silently booting against an unqualified fresh root.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] No new dependencies were added.
- [x] Documentation was updated because deployment behavior changed.
- [x] Commits include `Signed-off-by:` according to the DCO-style requirement.
- [x] `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` were considered for this submission.

## Acceptance and cleanup

- Candidate-bound acceptance: `af2a825df1140911439bad1997a0350b37354daa / host transaction and docs checks PASS; final package/device acceptance pending`
- Device test filter: `N/A — no device run in this PR`
- Device backup state: `N/A — no device changed`
- Temporary-data cleanup: `complete; test containers removed and worktree clean`
- Final Git status: `clean`
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

Keep this PR Draft until the migration policy and public wording are accepted. Merge does not make v1.1 product-qualified: freeze exact packages and rerun the documented BM1688 upgrade plus any applicable prerelease Rockchip migration/recovery journey. The release-note source intentionally retains unchecked freeze items. GitHub Discussions is the selected English v1.1 channel; Discord is deferred beyond this release.
