### PR TITLE
docs(release): freeze v1.1.0 publication copy

### DIFF
--- a/.github/release-notes/v1.1.0.md
+++ b/.github/release-notes/v1.1.0.md
@@ -1,9 +1,3 @@
-<!--
-Maintainer draft. Do not publish this body until every item in "Release freeze"
-is complete and all placeholders have been replaced with the final tag-bound
-identities.
--->
-
 # CosmoEdge 1.1.0
 
 [简体中文发布说明](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/.github/release-notes/v1.1.0.zh-CN.md)
@@ -19,7 +13,7 @@ Silicon macOS receives a deliberately scoped Docker Preview.
 | Sophon BM1688 | Target-specific Open installation archive, `TARGET_CHIP`, `SHA256SUMS`, and validated VLM support | Plain models; no device authorization. VLM short-run gate boundary: 6 channels at 0.1 FPS/ch. A controlled Protected package is a separate commercial-model distribution path. |
 | Sophon CV186X | Independent CV186X Open installation archive, `TARGET_CHIP`, `SHA256SUMS`, and validated VLM support | Do not reuse a complete BM1688 package even when selected model bytes happen to match. VLM short-run gate boundary: 6 channels at 0.1 FPS/ch. |
 | Rockchip RK3576 | Target-specific cross-built archive plus `TARGET_CHIP`, `MEDIA_RUNTIME_PROFILE`, `SHA256SUMS`, and validated VLM support | Includes the RKNN, MPP/RGA, and required RKLLM runtime path. VLM short-run gate boundary: 4 channels at 0.1 FPS/ch. Models and package must be qualified together. |
-| Rockchip RV1126B | Target-specific cross-build path and the same marker/profile/checksum contract | Does not include RKLLM. A deployable archive requires the platform model overlay; a preserve-model CI package is not a release asset or device acceptance. |
+| Rockchip RV1126B | Target-specific cross-built archive plus `TARGET_CHIP`, `MEDIA_RUNTIME_PROFILE`, `SHA256SUMS`, and manifested community example models | Does not include RKLLM. The bundled Ultralytics-based examples are AGPL-3.0 community assets, not commercial model deliverables; the model manifest and license remain in the archive. |
 | x86 Linux / Windows | Source release with the corresponding Docker Compose runtime | Uses ONNX Runtime CPU and persistent named volumes; no device installation archive is promised. |
 | Apple Silicon macOS | `scripts/macos-docker-preview.sh` and the isolated macOS Compose profile | Preview under `linux/amd64` emulation for one local-video workflow. |
 
@@ -91,6 +85,14 @@ for the source, package, model, environment, threshold, and duration details.
   long-run, semantic-accuracy, or production-configuration certification.
 - macOS remains a single-local-video `linux/amd64` Docker Preview.
 
+## Model and license boundary
+
+The RV1126B public archive includes the manifested community example models
+used by the public dual-CV workload. They are distributed under AGPL-3.0 and
+remain separate from CosmoEdge commercial or proprietary model delivery. The
+archive preserves `resource/model-bundle.json` and the corresponding model
+license under `resource/licenses/model-assets/`.
+
 ## Community and support
 
 [GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions)
@@ -100,17 +102,9 @@ Reproducible defects belong in
 vulnerabilities must follow [SECURITY.md](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/SECURITY.md). No Discord channel
 is operated for this release.
 
-## Release freeze
+## Release assets
 
-- [ ] Create tag `v1.1.0` from the approved commit and record commit and tree SHA.
-- [ ] Attach the BM1688 and CV186X Open archives with their chip markers and
-      SHA-256 files.
-- [ ] Attach only Rockchip archives whose required model overlays and target
-      device acceptance are complete.
-- [ ] Replace this checklist with exact asset filenames and SHA-256 values.
-- [ ] Bind upgrade, restart, inference, alarm, and recovery results to the exact
-      final packages.
-- [x] Bind VLM model load, task creation, inference, alarm, and restart recovery
-      to the three frozen candidate packages in canonical benchmark evidence.
-- [ ] Confirm required CI, documentation rendering, package audit, and release
-      approval are complete.
+Each attached device archive is target-specific. Use only the archive whose
+`TARGET_CHIP` matches the device, and verify its companion `SHA256SUMS` before
+installation. The GitHub Release asset list records the exact filenames and
+SHA-256 values for the approved release commit.

--- a/.github/release-notes/v1.1.0.zh-CN.md
+++ b/.github/release-notes/v1.1.0.zh-CN.md
@@ -1,8 +1,3 @@
-<!--
-维护者草稿。完成“发布冻结”全部事项、用最终 tag 对应的真实身份替换所有待定内容前，
-不要把本页直接发布为 GitHub Release 正文。
--->
-
 # CosmoEdge 1.1.0
 
 [English release notes](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/.github/release-notes/v1.1.0.md)
@@ -18,7 +13,7 @@ Preview。
 | Sophon BM1688 | 芯片专属 Open 安装包、`TARGET_CHIP`、`SHA256SUMS` 与已验证 VLM 支持 | 明文模型，不需要设备授权；VLM 在 0.1 FPS/路下的短时门禁边界为 6 路。受控 Protected 包属于独立的商业模型分发路径。 |
 | Sophon CV186X | 独立的 CV186X Open 安装包、`TARGET_CHIP`、`SHA256SUMS` 与已验证 VLM 支持 | 即使部分模型字节相同，也不能复用完整 BM1688 包；VLM 在 0.1 FPS/路下的短时门禁边界为 6 路。 |
 | Rockchip RK3576 | 芯片专属交叉构建包、`TARGET_CHIP`、`MEDIA_RUNTIME_PROFILE`、`SHA256SUMS` 与已验证 VLM 支持 | 包含 RKNN、MPP/RGA 和必需的 RKLLM 运行路径；VLM 在 0.1 FPS/路下的短时门禁边界为 4 路，模型与包必须一起验收。 |
-| Rockchip RV1126B | 芯片专属交叉构建路径，以及相同的芯片标记、媒体档案和校验契约 | 不包含 RKLLM；可部署包必须带平台模型覆盖层，保留模型的 CI 包不是 Release 资产或设备验收。 |
+| Rockchip RV1126B | 芯片专属交叉构建包、`TARGET_CHIP`、`MEDIA_RUNTIME_PROFILE`、`SHA256SUMS` 与带清单的社区示例模型 | 不包含 RKLLM；随包示例基于 Ultralytics、按 AGPL-3.0 分发，不属于商业模型交付；模型清单和许可证保留在安装包内。 |
 | x86 Linux / Windows | 源码 Release 与对应的 Docker Compose 运行环境 | 使用 ONNX Runtime CPU 和持久化命名卷，不承诺设备安装包。 |
 | Apple Silicon macOS | `scripts/macos-docker-preview.sh` 与隔离的 macOS Compose 配置 | 在 `linux/amd64` 仿真下覆盖单路本地视频的 Preview。 |
 
@@ -71,6 +66,13 @@ BM1688、CV186X 与 RK3576 在源码 commit
 - VLM 数据是 60 秒短时门禁边界，不代表最大容量、长稳、语义准确率或生产配置认证。
 - macOS 仍是 `linux/amd64` 仿真下的单路本地视频 Docker Preview。
 
+## 模型与许可证边界
+
+RV1126B 公开安装包包含公共双 CV 场景使用的、带清单的社区示例模型。这些模型按
+AGPL-3.0 分发，与 CosmoEdge 商业或专有模型交付相互独立。安装包保留
+`resource/model-bundle.json`，并在 `resource/licenses/model-assets/` 下携带对应
+模型许可证。
+
 ## 社区与支持
 
 [GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) 是 v1.1
@@ -79,12 +81,8 @@ BM1688、CV186X 与 RK3576 在源码 commit
 [SECURITY.md](https://github.com/cosmo-wander-ai/cosmo-edge/blob/v1.1.0/SECURITY.md) 私密报告。本次发布不运营 Discord。中文实时交流入口
 见中文版 README 的微信群说明，群内可复用结论继续回流 Discussions 或 Issues。
 
-## 发布冻结
+## Release 资产
 
-- [ ] 从批准的 commit 创建 `v1.1.0` tag，并记录 commit SHA 与 tree SHA。
-- [ ] 附加 BM1688、CV186X Open 安装包以及对应芯片标记和 SHA-256 文件。
-- [ ] 仅附加已经具备所需模型覆盖层并完成目标设备验收的 Rockchip 包。
-- [ ] 用准确的资产文件名和 SHA-256 替换本清单。
-- [ ] 把升级、重启、推理、告警和恢复结果绑定到最终包。
-- [x] 在 canonical benchmark 证据中把 VLM 模型加载、任务创建、推理、告警和重启恢复绑定到三平台冻结候选包。
-- [ ] 确认必需 CI、文档渲染、包审计和发布审批全部完成。
+每个设备安装包都只对应一个目标芯片。安装前必须确认包内 `TARGET_CHIP` 与设备匹配，
+并使用随包 `SHA256SUMS` 校验文件。GitHub Release 资产列表记录批准发布 commit 对应的
+准确文件名与 SHA-256。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows a release-note style inspired by Keep a Changelog.
 
 ## [Unreleased]
 
-### 1.1.0 release candidate
+## [1.1.0] - 2026-08-24
 
 CosmoEdge 1.1 adds CV186X, RK3576, and RV1126B release-platform support, expands the BMRT/RKNN
 media and inference paths, and publishes multi-platform short-run capacity, validated VLM performance, and


### PR DESCRIPTION
## Summary

- promote the v1.1.0 changelog entry out of release-candidate wording
- describe the now-manifested RV1126B target archive and its AGPL-3.0 community-model boundary
- replace the maintainer-only freeze checklist with public target-chip and checksum guidance

## Validation

- full VitePress build
- public v1.1 benchmark validation and 148-report regeneration
- bilingual tutorial and benchmark smoke checks
- Sophon public model hash verification
- Gitee README and macOS Preview checks
- git diff --check

## Release boundary

This remains Draft until the final commit is frozen, all four target packages are rebuilt and audited from that identity, required device/package rebind checks pass, and the GitHub Draft Release is refreshed. This PR does not create the v1.1.0 tag or publish a Release.