### PR TITLE
refactor(web): remove unreachable console paths

### DIFF
--- a/src/web/src/views/box/bigScreen/warnningScreen/index.vue
+++ b/src/web/src/views/box/bigScreen/warnningScreen/index.vue
@@ -296,8 +296,9 @@ const isVideoFullScreen = ref(null)
 const detailDialogVisible = ref(false)
 const captureDialogVisible = ref(false)
 const showAlert = ref(false)
-const alertPosition = ref(-383)
 const alertTimer = ref(null)
+const alertEnterTimer = ref(null)
+const alertExitTimer = ref(null)
 const socket = ref(null)
 const socketTimer = ref(null)
 const reconnectTimer = ref(null)
@@ -328,6 +329,33 @@ const selectedAlgorithmList = ref([])
 const detailData = ref({})
 const currentSocketData = ref({})
 const audioUnlocked = ref(false)
+const ALERT_ENTER_DELAY_MS = 50
+const ALERT_EXIT_DELAY_MS = 500
+let alertAnimationFrame = null
+
+const clearAlertTimers = () => {
+  if (alertAnimationFrame !== null) {
+    cancelAnimationFrame(alertAnimationFrame)
+    alertAnimationFrame = null
+  }
+  const timers = [alertTimer, alertEnterTimer, alertExitTimer]
+  timers.forEach((timer) => {
+    if (timer.value) {
+      clearTimeout(timer.value)
+      timer.value = null
+    }
+  })
+}
+
+const scheduleAlertDismiss = () => {
+  alertTimer.value = setTimeout(() => {
+    alertTimer.value = null
+    alertExitTimer.value = setTimeout(() => {
+      alertExitTimer.value = null
+      showAlert.value = false
+    }, ALERT_EXIT_DELAY_MS)
+  }, realSettingForm.value.popUpDuration * 1000)
+}
 
 // Validation
 const validatePopUpDuration = (rule, value, callback) => {
@@ -536,6 +564,7 @@ const handleCameraNodeClick = (node) => {
 
 const handleSettingClick = () => {
   unlockAudio()
+  clearAlertTimers()
   showAlert.value = false
   settingForm.value = { ...realSettingForm.value }
   settingFormRef.value && settingFormRef.value.clearValidate()
@@ -848,9 +877,7 @@ const socketOnMessage = (data) => {
     eventList.value.unshift(currentSocketData.value)
   }
 
-  if (alertTimer.value) {
-    clearTimeout(alertTimer.value)
-  }
+  clearAlertTimers()
 
   if (realSettingForm.value.audioPlay == 1 && audioUnlocked.value) {
     const audioEl = audio.value
@@ -868,32 +895,18 @@ const socketOnMessage = (data) => {
     return
 
   if (showAlert.value) {
-    alertTimer.value && clearTimeout(alertTimer.value)
-    alertTimer.value = setTimeout(() => {
-      alertPosition.value = window.innerWidth
-      setTimeout(() => {
-        showAlert.value = false
-      }, 500)
-    }, realSettingForm.value.popUpDuration * 1000)
+    scheduleAlertDismiss()
     return
   }
 
-  alertPosition.value = window.innerWidth
   showAlert.value = true
 
-  requestAnimationFrame(() => {
-    setTimeout(() => {
-      // 居中位置 = (窗口宽度 - 弹窗宽度) / 2
-      alertPosition.value = (window.innerWidth - 900) / 2
-
-      alertTimer.value = setTimeout(() => {
-        alertPosition.value = window.innerWidth
-
-        setTimeout(() => {
-          showAlert.value = false
-        }, 500)
-      }, realSettingForm.value.popUpDuration * 1000)
-    }, 50)
+  alertAnimationFrame = requestAnimationFrame(() => {
+    alertAnimationFrame = null
+    alertEnterTimer.value = setTimeout(() => {
+      alertEnterTimer.value = null
+      scheduleAlertDismiss()
+    }, ALERT_ENTER_DELAY_MS)
   })
 }
 
@@ -943,6 +956,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   EventBus.$emit('changeScreen', false)
+  clearAlertTimers()
   timeInterval.value && clearInterval(timeInterval.value)
   socketTimer.value && clearInterval(socketTimer.value)
   reconnectTimer.value && clearTimeout(reconnectTimer.value)

--- a/src/web/src/views/box/bigScreen/warnningScreen/index.vue
+++ b/src/web/src/views/box/bigScreen/warnningScreen/index.vue
@@ -80,7 +80,7 @@
                 </template>
               </el-input>
               <div class="tree-body">
-                <el-tree id="onboarding-camera-tree" ref="tree" class="filter-tree" :data="camearList" :highlight-current="true" node-key="id" default-expand-all :filter-node-method="filterNode" draggable @node-drag-start="handleDragStart" :allow-drop="handleDrop">
+                <el-tree id="onboarding-camera-tree" ref="tree" class="filter-tree" :data="camearList" :highlight-current="true" node-key="id" default-expand-all :filter-node-method="filterNode">
                   <template #default="{ node, data }">
                     <div class="custom-tree-node" :class="{'padding-left-18': nodeLabel(data) !== t('common.all')}" @dblclick="handleCameraNodeClick(data)">
                       <div v-if="data.channelType == 0 && data.status == 0" class="stnode">
@@ -542,9 +542,6 @@ const handleSettingClick = () => {
   settingFormRef.value && settingFormRef.value.clearValidate()
   settingDialogVisible.value = true
 }
-
-const handleDragStart = () => {}
-const handleDrop = () => {}
 
 const handleInput = (val, key) => {
   settingForm.value[key] = val.replace(/[^\d]/g, '')

--- a/src/web/src/views/box/bigScreen/warnningScreen/index.vue
+++ b/src/web/src/views/box/bigScreen/warnningScreen/index.vue
@@ -328,7 +328,6 @@ const selectedAlgorithmList = ref([])
 const detailData = ref({})
 const currentSocketData = ref({})
 const audioUnlocked = ref(false)
-let _unlockAudio = null
 
 // Validation
 const validatePopUpDuration = (rule, value, callback) => {
@@ -536,7 +535,7 @@ const handleCameraNodeClick = (node) => {
 }
 
 const handleSettingClick = () => {
-  playAudio()
+  unlockAudio()
   showAlert.value = false
   settingForm.value = { ...realSettingForm.value }
   settingFormRef.value && settingFormRef.value.clearValidate()
@@ -898,8 +897,7 @@ const socketOnMessage = (data) => {
   })
 }
 
-const playAudio = () => {
-  // handleSettingClick 是用户点击触发的，利用此交互解锁音频
+const unlockAudio = () => {
   const audioEl = audio.value
   if (audioEl && !audioUnlocked.value) {
     audioEl.muted = true
@@ -910,6 +908,8 @@ const playAudio = () => {
       audioUnlocked.value = true
     }).catch(() => {})
   }
+  document.removeEventListener('click', unlockAudio)
+  document.removeEventListener('touchstart', unlockAudio)
 }
 
 const checkPropertyKey = (data, key) => {
@@ -933,23 +933,9 @@ onMounted(() => {
   )
   window.addEventListener('mozfullscreenchange', handleFullScreenChange)
 
-  // 用户首次交互时解锁音频元素，使后续 WebSocket 回调中的 play() 不会被浏览器拦截
-  _unlockAudio = () => {
-    const audioEl = audio.value
-    if (audioEl && !audioUnlocked.value) {
-      audioEl.muted = true
-      audioEl.play().then(() => {
-        audioEl.pause()
-        audioEl.muted = false
-        audioEl.currentTime = 0
-        audioUnlocked.value = true
-      }).catch(() => {})
-    }
-    document.removeEventListener('click', _unlockAudio)
-    document.removeEventListener('touchstart', _unlockAudio)
-  }
-  document.addEventListener('click', _unlockAudio)
-  document.addEventListener('touchstart', _unlockAudio)
+  // Unlock audio on the first user interaction so WebSocket callbacks can play it.
+  document.addEventListener('click', unlockAudio)
+  document.addEventListener('touchstart', unlockAudio)
 
   // 点击通道列表外部时自动收起
   document.addEventListener('click', handleClickOutside)
@@ -979,11 +965,8 @@ onBeforeUnmount(() => {
     'mozfullscreenchange',
     handleFullScreenChange
   )
-  // 清理音频解锁监听器
-  if (_unlockAudio) {
-    document.removeEventListener('click', _unlockAudio)
-    document.removeEventListener('touchstart', _unlockAudio)
-  }
+  document.removeEventListener('click', unlockAudio)
+  document.removeEventListener('touchstart', unlockAudio)
   document.removeEventListener('click', handleClickOutside)
 })
 </script>

--- a/src/web/src/views/gam/countManagement/atomicModel/index.vue
+++ b/src/web/src/views/gam/countManagement/atomicModel/index.vue
@@ -177,21 +177,6 @@
       </template>
     </el-dialog>
 
-    <el-dialog :title="t('glossary.algorithmList')" v-model="listDialogVisible" center width="400px" @close="listDialogVisible = false">
-      <div v-if="algorithmicList.length !==0" class="div-center">
-        <span v-for="(item, index) in algorithmicList" :key="index">
-          <span>{{ item }}</span>
-          <span v-if="index !== algorithmicList.length-1">，</span>
-        </span>
-      </div>
-      <div v-else class="div-center">{{ t('common.noData') }}</div>
-      <template #footer>
-        <div class="dialog-footer">
-          <el-button type="primary" size="small" @click="listDialogVisible = false">{{ t('action.close') }}</el-button>
-        </div>
-      </template>
-    </el-dialog>
-
     <el-dialog :title="t('glossary.modelDetail')" v-model="modelDetailDialogVisible" width="620px" @close="modelDetailDialogVisible = false">
       <div class="detail-header">
         <div class="detail-icon" :class="getModelIconClass(detailModel)" v-html="getModelSvg(detailModel)"></div>
@@ -247,27 +232,6 @@
         <el-button @click="editFromDetail">{{ t('action.editModel') }}</el-button>
         <el-button v-if="detailModel.isExportable" type="danger" plain @click="deleteFromDetail">{{ t('action.delete') }}</el-button>
         <el-button type="primary" @click="modelDetailDialogVisible = false">{{ t('action.close') }}</el-button>
-      </template>
-    </el-dialog>
-
-    <el-dialog :title="t('glossary.uploadResult')" v-model="uploadReultVisible" center width="600">
-      <div>
-        <el-table :data="uploadResult" style="width: 100%" stripe border>
-          <el-table-column type="index"></el-table-column>
-          <el-table-column prop="fileName" :label="t('field.fileName')">
-          </el-table-column>
-          <el-table-column prop="message" :label="t('field.result')">
-            <template #default="scope">
-              <span v-if="scope.row.success" style="color:green;">{{ scope.row.message }}</span>
-              <span v-else style="color:red;">{{ scope.row.message }}</span>
-            </template>
-          </el-table-column>
-        </el-table>
-      </div>
-      <template #footer>
-        <div class="dialog-footer">
-          <el-button type="primary" size="small" @click="uploadReultVisible = false">{{ t('action.close') }}</el-button>
-        </div>
       </template>
     </el-dialog>
 
@@ -494,13 +458,11 @@ const getModelSvg = (model) => {
 }
 
 // ── 模型使用状态（通过 algorithmInquire 获取算法列表中的 models 字段关联） ──
-const algList = ref([])
 const modelUsageMap = ref({})
 const loadAlgUsage = () => {
   const params = { pageNum: 1, pageSize: 999 }
   proxy.$API.algorithmInquire && proxy.$API.algorithmInquire(params).then(res => {
     const rows = res?.resData?.rows || []
-    algList.value = rows
     const usageMap = {}
     rows.forEach(alg => {
       const models = alg.models || []
@@ -559,27 +521,11 @@ const pageData = reactive({
 
 const gpuCodes = ref([])
 const uploadAlgorithmicVisible = ref(false)
-const uploadAlgorithmicName = ref('')
-const uploadAlgorithmicData = ref([])
-const listDialogVisible = ref(false)
-const algorithmicList = ref([])
 const modelDetailDialogVisible = ref(false)
 const detailModel = ref({})
 const modelLabelData = ref([])
 const engineTypeList = ref([])
 const platformType = ref(localStorage.getItem('platformType') || '')
-const topBarData = computed(() => ({
-  formList: [
-    { label: t('field.modelName'), model: 'modelName' },
-    { label: t('field.modelId'), model: 'modelCode' },
-    {
-      label: t('glossary.computeType'),
-      model: 'gpuCode',
-      type: 'select',
-      dataList: gpuCodes.value
-    }
-  ]
-}))
 const isX86 = ref(false)
 const isRknn = ref(false)
 const isRkllm = ref(false)
@@ -592,9 +538,6 @@ const addModelPrimaryFileExtension = computed(() =>
 const importedModelFileName = computed(() => isRknn.value ? 'model.rknn' : (isX86.value ? 'model.onnx' : 'model.nn'))
 const addModelDialogTitle = computed(() => addModelMode.value === 'edit' ? t('action.editModel') : t('action.addModel'))
 const addModelMode = ref('add')
-const isMultiple = ref(false)
-const uploadResult = ref([])
-const uploadReultVisible = ref(false)
 
 const addModelFormRef = ref(null)
 const editModelFormRef = ref(null)
@@ -866,10 +809,6 @@ const importModelFile = ref(null)
 const importModelLoading = ref(false)
 const importModelUploadRef = ref(null)
 
-const indexcount = (index) => {
-  return (pageData.pageNum - 1) * pageData.pageSize + index + 1
-}
-
 const getGPUCodes = () => {
   gpuCodes.value = [{ labelI18nKey: 'common.all', value: '' }]
   proxy.$API.getGPUCodes().then((res) => {
@@ -1025,11 +964,6 @@ const returnLabelWithCode = (code) => {
   return index === -1 ? '' : gpuCodes.value[index].label
 }
 
-const algorithmicListClick = (obj) => {
-  algorithmicList.value = obj.algorithmList
-  listDialogVisible.value = true
-}
-
 const addClick = () => {
   addModelMode.value = 'add'
   uploadAlgorithmicVisible.value = true
@@ -1052,79 +986,6 @@ const batchUpdateClick = () => {
   })
 }
 
-const sureUploadAlgorithmic = () => {
-  if (uploadAlgorithmicData.value.length === 0) {
-    return proxy.$message.warning(t('validate.uploadFileFirst'))
-  }
-  const uploadResults = uploadAlgorithmicData.value.map(async (file) => {
-    const rawFile = file.raw || file
-    const fileName = rawFile.name
-    try {
-      const resData = await uploadFile({ file: rawFile })
-      if (resData?.resCode == 1) {
-        return { fileName, success: true, message: t('validate.uploadSucceeded') }
-      } else {
-        return {
-          fileName,
-          success: false,
-          message: t('validate.uploadFailed') + localeColon + (resData?.resMsg[0].msgText || t('validate.unknownError'))
-        }
-      }
-    } catch (error) {
-      return {
-        fileName,
-        success: false,
-        message: t('validate.uploadFailed') + localeColon + (error.message || t('validate.unknownError'))
-      }
-    }
-  })
-  Promise.all(uploadResults).then((results) => {
-    uploadResult.value = results
-    uploadReultVisible.value = true
-    uploadAlgorithmicVisible.value = false
-    uploadAlgorithmicData.value = []
-    searchList()
-    // 延迟二次刷新，等待后端完成文件处理
-    setTimeout(() => { searchList() }, 1500)
-  })
-}
-
-const uploadFile = async (params) => {
-  let stagedUpload
-  try {
-    stagedUpload = await uploadFileInChunks(params.file, {
-      purpose: UploadPurpose.MODEL_ARCHIVE,
-      uploadChunk: formData => proxy.$API.uploadAtomicModelTemp(formData),
-      cancelUpload: data => proxy.$API.cancelAtomicModelUpload(data),
-      getCapabilities: () => proxy.$API.getUploadCapabilities()
-    })
-    if (!stagedUpload.uploadId) {
-      throw new Error(t('validate.missingUploadId'))
-    }
-    return await proxy.$API.uploadAtomicModel({
-      uploadId: stagedUpload.uploadId
-    })
-  } catch (error) {
-    if (stagedUpload?.uploadId) {
-      try {
-        await proxy.$API.cancelAtomicModelUpload({ uploadId: stagedUpload.uploadId })
-      } catch (_) {
-        // The staging service also expires abandoned sessions by TTL.
-      }
-    }
-    throw error
-  }
-}
-const handleChange = (file, fileList) => {
-  if (!isMultiple.value) {
-    uploadAlgorithmicData.value = [file]
-  } else {
-    uploadAlgorithmicData.value = fileList
-  }
-}
-const handleRemove = (file, fileList) => {
-  uploadAlgorithmicData.value = fileList
-}
 const importModelClick = () => {
   importModelFileName.value = ''
   importModelFile.value = null
@@ -1191,7 +1052,6 @@ const sureImportModel = async () => {
 }
 
 const uploadAlgorithmicClosed = () => {
-  uploadAlgorithmicData.value = []
   addModelForm.modelFileList = []
   addModelForm.modelFile = ''
   addModelForm.encoderFileList = []
@@ -1880,9 +1740,5 @@ onMounted(() => {
 }
 .form-content {
   width: calc(100% - 50px);
-}
-.div-center {
-  text-align: center;
-  padding: 10px;
 }
 </style>

--- a/src/web/src/views/gam/taskManager/index.vue
+++ b/src/web/src/views/gam/taskManager/index.vue
@@ -39,7 +39,7 @@
           <template #default="scope">
             <div>
               <div id="onboarding-task-switch" class="task_table" v-for="(item, index) in scope.row.taskList" :key="index">
-                <div class="analytical" @click="analyticalEngine(item)">
+                <div class="analytical">
                   <div class="task_text">{{ resolveResourceAlgorithmName(item) }}</div>
                 </div>
                 <el-switch class="task-switch" v-model="item.enableStatus" active-color="#00f944" :active-value="1" :inactive-value="0" @change="taskEnableChange(item, scope.row.videoChannelId)"></el-switch>
@@ -284,21 +284,7 @@ const tableData = ref([])
 const pageData = reactive({ pageNum: 1, pageSize: 10, total: 0 })
 const formData = reactive({})
 const multipleSelection = ref([])
-const platformType = ref(localStorage.getItem('platformType'))
 const algorithms = ref(JSON.parse(localStorage.getItem('algorithms')))
-const analyticalEngineVisible = ref(false)
-const analyticalData = ref([])
-const taskId = ref('')
-const runVideoDialogVisible = ref(false)
-const runVideoUrl = ref('')
-const runVideoLoading = ref(true)
-const runVideoStyle = ref({ height: '300px' })
-const imgStyle = ref({})
-const runVideoTimestamp = ref(Date.now())
-const dialogWidth = ref('700px')
-const dialogHeight = ref('500px')
-const runDetailDialogVisible = ref(false)
-const currentTaskObj = ref({})
 const channelImgSrc = ref('')
 const usbCameraList = ref([])
 
@@ -773,20 +759,6 @@ const rowClass = ({ rowIndex }) => {
   }
 }
 
-const analyticalEngine = (data) => {
-  if (platformType.value != 1) return
-  const custId = window.localStorage.getItem('taskCustId')
-    ? window.localStorage.getItem('taskCustId')
-    : window.localStorage.getItem('currentCustId')
-  const param = { custId: custId || '', algorithmId: data.algorithmId }
-  proxy.$API.allHostInfo(param).then((res) => {
-    const { resData } = res.data
-    analyticalData.value = resData
-  })
-  taskId.value = data.taskId
-  analyticalEngineVisible.value = true
-}
-
 const handleDeleteChannel = (row) => {
   proxy
     .$confirm(t('validate.deleteConfirm'), t('common.notice'), {
@@ -932,10 +904,6 @@ const setDefaultImage = (e) => {
   padding: 10px 20px;
   display: flex;
   justify-content: space-between;
-}
-
-.analytical {
-  cursor: pointer;
 }
 
 .task-node {


### PR DESCRIPTION
## Summary

Remove unreachable model-management workflows, an inactive task-analysis request path, and no-op big-screen hooks. Unify audio unlock handling and make alert timer cleanup explicit while preserving current visible behavior.

## Related issue

Closes #130
Parent: #128

## Scope

### In scope

- Remove unreachable atomic-model dialogs, state, and legacy upload handlers.
- Remove the task-name request whose response had no user-visible consumer.
- Remove empty camera-tree drag hooks.
- Reuse one named audio-unlock handler.
- Remove unused alert-position state and pair alert timers/RAF with cleanup.

### Out of scope

- The `allHostInfo` API definition.
- Global EventBus cleanup.
- Popup duration or CSS transition changes.
- Retaining permanent device channels, tasks, models, or synthetic alert data.

## Candidate identity

- Base commit: `06250bd51aae7a8a7defa56d94c4d6bad4d3837d`
- Candidate commit: `1d29a696f5b06befb84d0460f4a9a0194c2fc803`
- Candidate tree: `ca2501686c344f615e849ca12164504deca62519`
- Package SHA-256: `782787720cb6a1a66cb9f09ff0b7ba808a9ee2adf8d0177e41714d2bc2985d1a`
- Test binary SHA-256: `8376405073f6bd20d3f9fc4cc14768044b372e51a1d21396e18222e4dcfc0c07`

## Verification

```text
git diff --check origin/main...HEAD
./scripts/format_check.sh --staged --check
./scripts/static_analysis.sh --staged --cppcheck
./scripts/docker-compose.sh -f docker-compose.sophon.yml run --rm --entrypoint /bin/bash cosmo-sophon-package -lc 'cd /workspace/src/web && npm ci && npm run build'
./scripts/docker-compose.sh -f docker-compose.sophon.yml run --rm cosmo-sophon-package --chip bm1688
./.codex/validate_candidate.sh --issue '#130' --base origin/main --package build_output/public-runtime/bm1688/cosmo-V1.1.0-a82a32391037de7d4df20be36b484bf1.tar.gz --tests build/cosmo-tests
```

- PASS: scoped diff/checks and clean worktree.
- PASS: Sophon frontend production build, linkage checks, and all i18n checks.
- PASS: BM1688 AArch64 package audit and package regression suites.
- PASS: exact package installed on matching BM1688 hardware; observed offline/online reboot completed; service, ports, installed hashes, and HTTP root are healthy.
- PASS: atomic-model list/search and add/import/detail/edit entry dialogs; removed legacy dialogs did not appear; no console errors or state-changing submission.
- PASS: task-management route/search/reset/add dialog; no console errors or unintended submission.
- PASS: one temporary HLS channel and `No Safety Helmet` task ran online; clicking the task name kept the nginx `allHostInfo` request count at zero, with no dialog or navigation and cursor `auto`.
- PASS: big-screen channel drawer, no draggable nodes, named audio unlock, settings dialog, 10 route cycles, single-response behavior, and post-leave DOM/audio cleanup.
- PASS: with popup duration set to 5 seconds, three consecutive alert timestamps updated while the popup had no hidden sample, proving repeated alerts reset dismissal.
- PASS: after restoring the original 2-second setting, three measured leave transitions began 2.51-2.54 seconds after enter, matching duration plus the 500 ms exit delay within sampling error.
- PASS: leaving the page while an alert was visible left zero alert/audio/settings DOM after 3.5 seconds and produced no console error.
- NOTE: staged-only host checks had no files after the five committed changes; the aggregate committed diff was checked separately.
- NOTE: the existing Node engine advisory remains non-fatal.

## Behavioral boundaries

- Current model add/import/edit/delete/export paths remain intact; installed built-in models did not expose delete/export buttons, so those submissions were not exercised.
- Task-name click behavior was verified on a running temporary task; the removed request stayed at zero and the API definition remains.
- The current base already contains only one mount-time `queryPopUpParam()`; the save-success refresh remains intentionally.
- Alert entry delay remains 50 ms and exit delay remains 500 ms.
- No public API, event payload, locale, or data-format change.

## Acceptance and cleanup

- Candidate-bound acceptance: PASS — `验证通过 1d29a696f5b06befb84d0460f4a9a0194c2fc803 782787720cb6a1a66cb9f09ff0b7ba808a9ee2adf8d0177e41714d2bc2985d1a`
- Device validation: PASS, including temporary channel/task, live repeated-alert, timing, and active-unmount scenarios.
- Device backup state: task-specific pre-deployment backup retained and checksum-verified.
- Temporary device package/extraction state: clean after reboot; temporary channel, task, stream process, media, PID/log, HLS manifest, and segments were removed, and the device returned to zero channels.
- Final Git status: clean
- No credentials, private device identifiers, media, models, or generated packages are included.
