### PR TITLE
refactor(flow): reuse OSD geometry

### DIFF
--- a/src/flow/common/AlgDataUnit.cc
+++ b/src/flow/common/AlgDataUnit.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 
+#include "flow/common/AreaLineUtil.h"
 #include "util/GeometricPos.h"
 #include "util/Log.h"
 #include "util/MsgBaseTypes.h"
@@ -208,93 +209,7 @@ void TargetSignAreas(DataDetTrackClassifyPtr detRet, const std::vector<MsgTaskAr
 }
 
 std::vector<std::pair<util::Point, util::Point>> GetAreaOsdLines(MsgTaskArea area, int width, int height) {
-    std::vector<std::pair<util::Point, util::Point>> lines;
-    for (auto assArea : area.associatedAreas) {
-        auto assLines = GetAreaOsdLines(assArea, width, height);
-        if (!assLines.empty())
-            lines.insert(lines.end(), assLines.begin(), assLines.end());
-    }
-
-    if (!area.points.empty()) {
-        for (size_t index = 1; index < area.points.size(); index++) {
-            std::pair<util::Point, util::Point> line;
-            line.first.x  = static_cast<int>(area.points[index - 1].x * width);
-            line.first.y  = static_cast<int>(area.points[index - 1].y * height);
-            line.second.x = static_cast<int>(area.points[index].x * width);
-            line.second.y = static_cast<int>(area.points[index].y * height);
-            lines.push_back(line);
-        }
-        if (area.points.size() > 2) {
-            std::pair<util::Point, util::Point> line;
-            line.first.x  = static_cast<int>(area.points[area.points.size() - 1].x * width);
-            line.first.y  = static_cast<int>(area.points[area.points.size() - 1].y * height);
-            line.second.x = static_cast<int>(area.points[0].x * width);
-            line.second.y = static_cast<int>(area.points[0].y * height);
-            lines.push_back(line);
-        }
-    }
-
-    if (!area.linePoints.empty()) {
-        auto pointTrans = [width, height](const MsgPoint& origin) {
-            return util::Point{static_cast<int>(origin.x * width), static_cast<int>(origin.y * height)};
-        };
-
-        size_t drawDirectionIndex = area.linePoints.size() / 2;
-        for (size_t i = 1; i < area.linePoints.size(); ++i) {
-            auto lastPoint = pointTrans(area.linePoints[i - 1]);
-            auto currPoint = pointTrans(area.linePoints[i]);
-
-            auto lineDir    = currPoint - lastPoint;
-            auto lineLength = util::Length(lineDir);
-            if (lineLength == 0) {
-                continue;
-            }
-
-            std::pair<util::Point, util::Point> line;
-            line.first  = lastPoint;
-            line.second = currPoint;
-            lines.push_back(line);
-
-            // Draw only one direction line
-            if (drawDirectionIndex != i)
-                continue;
-
-            // Perpendicular line
-            auto centPoint  = (lastPoint + currPoint) / 2;
-            auto perpLength = height * 0.04;
-            auto perpDir    = util::LineDirection(util::Perpendicular(lineDir), perpLength);
-            auto finaPoint  = centPoint + perpDir;
-            if (area.iderectionType == DirectionType::DirectionTypeOneWay) {
-                // Vertical line
-                lines.push_back(std::make_pair(centPoint, finaPoint));
-            }
-
-            // Arrow
-            auto centPerpPoint = (centPoint + finaPoint) / 2;
-            auto arrowDir      = util::LineDirection(lineDir, perpLength / 2);
-            lines.push_back(std::make_pair(finaPoint, centPerpPoint + arrowDir));
-            lines.push_back(std::make_pair(finaPoint, centPerpPoint + arrowDir * -1));
-
-            // Two-way line   negative direction
-            if (area.iderectionType == DirectionType::DirectionTypeTwoWay) {
-                // Perpendicular line
-                auto negativeLineDir = lastPoint - currPoint;
-                auto negativePerpDir = util::LineDirection(util::Perpendicular(negativeLineDir), perpLength);
-                auto negativeFinaPoint = centPoint + negativePerpDir;
-                lines.push_back(
-                    std::make_pair(finaPoint, negativeFinaPoint));  // Draw one less perpendicular line
-
-                // Arrow
-                auto negativeCentPerpPoint = (centPoint + negativeFinaPoint) / 2;
-                auto negativeArrowDir      = util::LineDirection(negativeLineDir, perpLength / 2);
-                lines.push_back(std::make_pair(negativeFinaPoint, negativeCentPerpPoint + negativeArrowDir));
-                lines.push_back(
-                    std::make_pair(negativeFinaPoint, negativeCentPerpPoint + negativeArrowDir * -1));
-            }
-        }
-    }
-
-    return lines;
+    return GetAreaLines(area, width, height);
 }
 
 std::vector<std::pair<util::Point, util::Point>> GetAreasOsdLines(const std::vector<MsgTaskArea>& areas,

--- a/src/flow/stream/StreamViewerLiveData.cc
+++ b/src/flow/stream/StreamViewerLiveData.cc
@@ -277,13 +277,6 @@ void StreamViewerOverview::LiveDataAiFrameToLocal(std::vector<MsgAiDetFrame>& ai
     }
 }
 
-void StreamViewerOverview::LiveDataSensitityToLocal(std::vector<MsgRecSensitity>& /*aiDatas*/) {}
-
-void StreamViewerOverview::LiveDataPosSaveSensitityToLocal(std::vector<MsgRecPosSaveSensitity>& /*aiDatas*/) {
-}
-
-void StreamViewerOverview::LiveDataAiFilterToLocal(std::vector<MsgAiFilterFrame>& /*aiDatas*/) {}
-
 void StreamViewerOverview::LiveDataToLocal() {
     auto liveDatas =
         service::ServiceRegistry::Instance().Get<service::ITaskQuery>().GetTaskLiveOverviewInfo(task_id_);
@@ -324,12 +317,11 @@ void StreamViewerOverview::LiveDataToLocal() {
                     }
                 }
             }
-        } else if (MsgOverviewMemDataType::MsgOverviewMemDataTypeSensitity == livedata.type) {
-            LiveDataSensitityToLocal(livedata.sensititys);
-        } else if (MsgOverviewMemDataType::MsgOverviewMemDataTypePosSaveSensitity == livedata.type) {
-            LiveDataPosSaveSensitityToLocal(livedata.posSaveSens);
-        } else if (MsgOverviewMemDataType::MsgOverviewMemDataTypeAiFilter == livedata.type) {
-            LiveDataAiFilterToLocal(livedata.aiFilters);
+        } else if (MsgOverviewMemDataType::MsgOverviewMemDataTypeSensitity == livedata.type ||
+                   MsgOverviewMemDataType::MsgOverviewMemDataTypePosSaveSensitity == livedata.type ||
+                   MsgOverviewMemDataType::MsgOverviewMemDataTypeAiFilter == livedata.type) {
+            // Sensitivity and filter records currently do not produce live OSD elements.
+            continue;
         } else if (MsgOverviewMemDataType::MsgOverviewMemDataTypeAlarm == livedata.type) {
             LiveDataAlarmToLocal(livedata.alarms);
         } else if (MsgOverviewMemDataType::MsgOverviewMemDataTypeParams == livedata.type) {

--- a/src/flow/stream/StreamViewerOverview.h
+++ b/src/flow/stream/StreamViewerOverview.h
@@ -134,9 +134,6 @@ private:
     bool IsOverlappingTracked(const MsgTarget& target, const std::vector<MsgTarget>& targets);
 
     void LiveDataAiFrameToLocal(std::vector<MsgAiDetFrame>& aiData);
-    void LiveDataSensitityToLocal(std::vector<MsgRecSensitity>& aiData);
-    void LiveDataPosSaveSensitityToLocal(std::vector<MsgRecPosSaveSensitity>& aiData);
-    void LiveDataAiFilterToLocal(std::vector<MsgAiFilterFrame>& aiData);
     void LiveDataAlarmToLocal(std::vector<MsgRecAlarm>& aiData);
     void OldLocalData();
     void LiveDataToLocal();

--- a/test/test_alg_data_unit.cc
+++ b/test/test_alg_data_unit.cc
@@ -4,9 +4,38 @@
  */
 #include "flow/common/AlgDataRecord.h"
 #include "flow/common/AlgDataUnit.h"
+#include "flow/common/AreaLineUtil.h"
 #include "mock/MockServiceRegistry.h"
 
 using namespace cosmo;
+
+namespace {
+
+using AreaLine = std::pair<cosmo::util::Point, cosmo::util::Point>;
+
+AreaLine MakeLine(int x1, int y1, int x2, int y2) {
+    return {{x1, y1}, {x2, y2}};
+}
+
+void RequireLinesEqual(const std::vector<AreaLine>& actual, const std::vector<AreaLine>& expected) {
+    REQUIRE(actual.size() == expected.size());
+    for (size_t index = 0; index < expected.size(); ++index) {
+        CAPTURE(index);
+        REQUIRE(actual[index].first.x == expected[index].first.x);
+        REQUIRE(actual[index].first.y == expected[index].first.y);
+        REQUIRE(actual[index].second.x == expected[index].second.x);
+        REQUIRE(actual[index].second.y == expected[index].second.y);
+    }
+}
+
+std::vector<AreaLine> GetAreaOsdLinesWithParityCheck(const MsgTaskArea& area, int width, int height) {
+    auto osd_lines  = GetAreaOsdLines(area, width, height);
+    auto area_lines = GetAreaLines(area, width, height);
+    RequireLinesEqual(osd_lines, area_lines);
+    return osd_lines;
+}
+
+}  // namespace
 
 TEST_CASE("AlgDataCopy: nullptr returns nullptr", "[AlgDataUnit]") {
     REQUIRE(AlgDataCopy(nullptr) == nullptr);
@@ -68,40 +97,81 @@ TEST_CASE("AlgData::SetTaskResult and GetTaskResult roundtrip", "[AlgDataUnit]")
 
 TEST_CASE("GetAreaOsdLines: Empty area returns empty", "[AlgDataUnit]") {
     MsgTaskArea area;
-    auto lines = GetAreaOsdLines(area, 1920, 1080);
+    auto lines = GetAreaOsdLinesWithParityCheck(area, 1920, 1080);
     REQUIRE(lines.empty());
 }
 
-TEST_CASE("GetAreaOsdLines: Polygon area generates edges", "[AlgDataUnit]") {
-    MsgTaskArea area;
-    // Triangle: (0,0) -> (1,0) -> (0.5,1)
-    area.points = {{0.0, 0.0}, {1.0, 0.0}, {0.5, 1.0}};
-
-    auto lines = GetAreaOsdLines(area, 1000, 1000);
-    // 3 vertices => 2 edges + 1 closing edge = 3 lines
-    REQUIRE(lines.size() == 3);
-}
-
-TEST_CASE("GetAreaOsdLines: Two-point area (line segment)", "[AlgDataUnit]") {
+TEST_CASE("GetAreaOsdLines: Two-point area preserves its single segment", "[AlgDataUnit]") {
     MsgTaskArea area;
     area.points = {{0.0, 0.0}, {1.0, 1.0}};
 
-    auto lines = GetAreaOsdLines(area, 100, 100);
-    // 2 points => 1 edge, no closing edge (need >2 for closing)
-    REQUIRE(lines.size() == 1);
+    auto lines = GetAreaOsdLinesWithParityCheck(area, 100, 100);
+    RequireLinesEqual(lines, {MakeLine(0, 0, 100, 100)});
+}
+
+TEST_CASE("GetAreaOsdLines: Polygon area closes its final edge", "[AlgDataUnit]") {
+    MsgTaskArea area;
+    area.points = {{0.0, 0.0}, {1.0, 0.0}, {0.5, 1.0}};
+
+    auto lines = GetAreaOsdLinesWithParityCheck(area, 100, 100);
+    RequireLinesEqual(lines, {MakeLine(0, 0, 100, 0), MakeLine(100, 0, 50, 100), MakeLine(50, 100, 0, 0)});
+}
+
+TEST_CASE("GetAreaOsdLines: Associated areas are collected recursively before their parent",
+          "[AlgDataUnit]") {
+    MsgTaskArea grandchild;
+    grandchild.points = {{0.0, 0.0}, {0.5, 0.0}};
+
+    MsgTaskArea child;
+    child.points = {{0.0, 0.5}, {0.5, 0.5}};
+    child.associatedAreas.push_back(grandchild);
+
+    MsgTaskArea parent;
+    parent.points = {{0.0, 1.0}, {0.5, 1.0}};
+    parent.associatedAreas.push_back(child);
+
+    auto lines = GetAreaOsdLinesWithParityCheck(parent, 100, 100);
+    RequireLinesEqual(lines, {MakeLine(0, 0, 50, 0), MakeLine(0, 50, 50, 50), MakeLine(0, 100, 50, 100)});
+}
+
+TEST_CASE("GetAreaOsdLines: One-way line keeps its direction arrow", "[AlgDataUnit]") {
+    MsgTaskArea area;
+    area.linePoints     = {{0.0, 0.5}, {1.0, 0.5}};
+    area.iderectionType = DirectionType::DirectionTypeOneWay;
+
+    auto lines = GetAreaOsdLinesWithParityCheck(area, 100, 100);
+    RequireLinesEqual(lines, {MakeLine(0, 50, 100, 50), MakeLine(50, 50, 50, 54), MakeLine(50, 54, 52, 52),
+                              MakeLine(50, 54, 48, 52)});
+}
+
+TEST_CASE("GetAreaOsdLines: Two-way line keeps both direction arrows", "[AlgDataUnit]") {
+    MsgTaskArea area;
+    area.linePoints     = {{0.0, 0.5}, {1.0, 0.5}};
+    area.iderectionType = DirectionType::DirectionTypeTwoWay;
+
+    auto lines = GetAreaOsdLinesWithParityCheck(area, 100, 100);
+    RequireLinesEqual(lines, {MakeLine(0, 50, 100, 50), MakeLine(50, 54, 52, 52), MakeLine(50, 54, 48, 52),
+                              MakeLine(50, 54, 50, 46), MakeLine(50, 46, 48, 48), MakeLine(50, 46, 52, 48)});
+}
+
+TEST_CASE("GetAreaOsdLines: Zero-length line does not produce segments", "[AlgDataUnit]") {
+    MsgTaskArea area;
+    area.linePoints = {{0.5, 0.5}, {0.5, 0.5}};
+
+    auto lines = GetAreaOsdLinesWithParityCheck(area, 100, 100);
+    REQUIRE(lines.empty());
 }
 
 TEST_CASE("GetAreasOsdLines: Multiple areas combined", "[AlgDataUnit]") {
     MsgTaskArea area1;
-    area1.points = {{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}};  // Quad
+    area1.points = {{0.0, 0.0}, {1.0, 0.0}};
 
     MsgTaskArea area2;
-    area2.points = {{0.0, 0.0}, {1.0, 0.0}, {0.5, 1.0}};  // Triangle
+    area2.points = {{0.0, 1.0}, {1.0, 1.0}};
 
     std::vector<MsgTaskArea> areas = {area1, area2};
     auto lines                     = GetAreasOsdLines(areas, 100, 100);
-    // Quad=4 + Triangle=3 = 7
-    REQUIRE(lines.size() == 7);
+    RequireLinesEqual(lines, {MakeLine(0, 0, 100, 0), MakeLine(0, 100, 100, 100)});
 }
 
 TEST_CASE("GenRandomDetBoxs: Generates non-empty targets", "[AlgDataUnit]") {


### PR DESCRIPTION
## Summary

Remove three empty live-overlay handlers and make the existing ignore policy explicit. Delegate `GetAreaOsdLines` to `AreaLineUtil` so recursion, pixel rounding, zero-length handling, and directional-arrow geometry have one implementation.

## Related issue

Closes #131
Parent: #128

## Scope

### In scope

- Remove empty sensitivity, saved-position sensitivity, and AI-filter helper declarations/definitions.
- Keep one explicit ignore branch for those non-visual records.
- Preserve the existing `GetAreaOsdLines` signature while delegating to `GetAreaLines`.
- Add fixed-coordinate tests for empty, line, polygon, recursion, arrows, zero-length, and merge order.

### Out of scope

- Public Flow interfaces or payload formats.
- Changes to AIData, Alarm, or Params handling order.
- New live-overlay behavior for currently ignored record types.
- Geometry changes inside `AreaLineUtil`.

## Candidate identity

- Base commit: `2e9d1f4dc0621e95934f8da903f18805b1483e15`
- Candidate commit: `fe9ac9707e9d32e28aa03854dd13728f87bf83c2`
- Candidate tree: `12030384cc58e83222c46621216096d508f3efff`
- Package SHA-256: `c6655933e050c637f23c5711d7e7e00215fe09d5731cfe1d90b0ea8d770196cf`
- Test binary SHA-256: `7e755d3667128619e24defaf897eae7b078b746734f93f32d581e47fe8ddbc03`

## Verification

```text
clang-format --dry-run --Werror <changed C++ files>
./scripts/docker-compose.sh -f docker-compose.sophon.yml run --rm cosmo-sophon-package --chip bm1688
./.codex/validate_candidate.sh --issue '#131' --base origin/main --package build_output/public-runtime/bm1688/cosmo-V1.1.0-76f6298f9a621179a4d9b33e9543aaa4.tar.gz --tests build/cosmo-tests
```

- PASS: each commit passed the repository pre-commit clang-format 18 and cppcheck hooks.
- PASS: aggregate diff check and reviewed-target equivalence.
- PASS: BM1688 compile/link, AArch64 ELF audit, frontend/resource checks, and package regression suites.
- PASS: BM1688 device `[AlgDataUnit]` completed 208 assertions in 14 test cases; `[TaskService][concurrency]` completed 11 assertions in 3 test cases.
- PASS: exact package installed on matching BM1688 hardware; observed offline/online reboot completed; service, ports, installed engine hash, and HTTP root are healthy.
- PASS: persisted one-way flow task had 2 line points, 1 associated quadrilateral, and direction type 0; persisted tripwire task had 2 diagonal line points and explicit direction type 1.
- PASS: task editor and live 1920x1080 overlay showed the one-way line, center direction marker, associated rectangle, diagonal two-way line, and both-direction arrow structure at the expected positions.
- PASS: switching live overlays kept video at readyState 4 and the ignored sensitivity/filter records caused no page or engine failure.
- NOTE: initial unauthenticated navigation produced expected 401s before login; non-fatal WHEP ICE-candidate warnings occurred while video playback remained healthy.
- PASS: candidate-bound acceptance is recorded below.

## Behavioral boundaries

- AIData, Alarm, and Params dispatch order is unchanged.
- Sensitivity, saved-position sensitivity, and AI-filter records remain ignored.
- `AlgDataUnit.h` is intentionally unchanged because the public signature is preserved.
- `GetAreasOsdLines` still traverses input areas in order and appends each result.
- No public API, event payload, locale, or data-format change.

## Acceptance and cleanup

- Candidate-bound acceptance: PASS — `验证通过 fe9ac9707e9d32e28aa03854dd13728f87bf83c2 c6655933e050c637f23c5711d7e7e00215fe09d5731cfe1d90b0ea8d770196cf`
- Device validation: PASS, including deployment, focused aarch64 tests, persisted geometry, editor preview, and live OSD.
- Temporary-data cleanup: complete; tasks, channel, test binary, task config/overview directories, stream process, media, PID/log, HLS manifest, and segments were removed, and the device returned to zero channels.
- Device backup state: task-specific pre-deployment backup retained and checksum-verified.
- Final Git status: clean
- No credentials, private device identifiers, media, models, or generated packages are included.
