### PR TITLE
refactor: centralize HTTP URL validation

### DIFF
--- a/src/service/event/impl/AlarmPushServiceImpl.cc
+++ b/src/service/event/impl/AlarmPushServiceImpl.cc
@@ -4,11 +4,8 @@
 
 #include <unistd.h>
 
-#include <algorithm>
-#include <cctype>
 #include <exception>
 #include <filesystem>
-#include <string_view>
 #include <utility>
 
 #include "service/algorithm/IAlgorithmQuery.h"
@@ -20,6 +17,7 @@
 #include "util/CipherUtil.h"
 #include "util/DateTimeFormat.h"
 #include "util/FormatString.h"
+#include "util/HttpUrlUtil.h"
 #include "util/JsonStructUtil.h"
 #include "util/Log.h"
 #include "util/PathUtil.h"
@@ -33,43 +31,6 @@ namespace {
     constexpr int kOfflinePushIntervalMs = 60 * 1000;           // 1 minute
     constexpr int64_t kRetryWindowMs     = 24 * 3600 * 1000LL;  // 24 hours
     constexpr int64_t kMinEventAgeMs     = 60 * 1000;           // 1 minute
-    constexpr size_t kMaxPushUrlBytes    = 2048;
-
-    bool IsValidPushUrl(const std::string& url) {
-        if (url.empty() || url.size() > kMaxPushUrlBytes || url.find('\\') != std::string::npos) {
-            return false;
-        }
-        if (std::any_of(url.begin(), url.end(), [](char character) {
-                const auto byte = static_cast<unsigned char>(character);
-                return byte < 0x20 || byte == 0x7f;
-            })) {
-            return false;
-        }
-
-        constexpr std::string_view kHttpPrefix{"http://"};
-        constexpr std::string_view kHttpsPrefix{"https://"};
-        size_t authority_begin = 0;
-        if (url.compare(0, kHttpPrefix.size(), kHttpPrefix) == 0) {
-            authority_begin = kHttpPrefix.size();
-        } else if (url.compare(0, kHttpsPrefix.size(), kHttpsPrefix) == 0) {
-            authority_begin = kHttpsPrefix.size();
-        } else {
-            return false;
-        }
-        const auto authority_end = url.find_first_of("/?#", authority_begin);
-        const auto authority = std::string_view(url).substr(authority_begin, authority_end - authority_begin);
-        if (authority.empty() || authority.find('@') != std::string_view::npos) {
-            return false;
-        }
-        const bool syntax_valid = std::all_of(authority.begin(), authority.end(), [](char character) {
-            const auto byte = static_cast<unsigned char>(character);
-            return std::isalnum(byte) != 0 || character == '.' || character == '-' || character == '_' ||
-                   character == ':' || character == '[' || character == ']';
-        });
-        return syntax_valid && std::any_of(authority.begin(), authority.end(), [](char character) {
-                   return std::isalnum(static_cast<unsigned char>(character)) != 0;
-               });
-    }
 }  // namespace
 
 AlarmPushServiceImpl::AlarmPushServiceImpl() : event_post_que_("HTTP EVENT POST QUE", 100) {
@@ -78,7 +39,7 @@ AlarmPushServiceImpl::AlarmPushServiceImpl() : event_post_que_("HTTP EVENT POST 
     if (!cosmo::util::LoadStructFromJsonFile(cfg_path, loaded)) {
         LOG_WARN("Failed to load alarm push config from {}", cfg_path);
     } else if ((loaded.is_open && loaded.url.empty()) ||
-               (!loaded.url.empty() && !IsValidPushUrl(loaded.url))) {
+               (!loaded.url.empty() && !cosmo::util::IsValidHttpUrl(loaded.url))) {
         LOG_WARN("Reject invalid alarm push config from {}", cfg_path);
     } else {
         config_ = std::move(loaded);
@@ -154,7 +115,7 @@ std::string AlarmPushServiceImpl::GetUrl() {
 }
 
 cosmo::util::ErrorEnum AlarmPushServiceImpl::SetPush(bool enable, const std::string& url) {
-    if ((enable || !url.empty()) && !IsValidPushUrl(url)) {
+    if ((enable || !url.empty()) && !cosmo::util::IsValidHttpUrl(url)) {
         return cosmo::util::ErrorEnum::InvalidParam;
     }
     AlarmPushParam info;

--- a/src/service/system/impl/SystemServiceImpl.cc
+++ b/src/service/system/impl/SystemServiceImpl.cc
@@ -33,6 +33,7 @@
 #include "util/ErrorCode.h"
 #include "util/Exec.h"
 #include "util/FileUtil.h"
+#include "util/HttpUrlUtil.h"
 #include "util/JsonStructUtil.h"
 #include "util/LimitedTypeJson.h"
 #include "util/Log.h"
@@ -45,7 +46,6 @@ namespace cosmo::service {
 namespace {
 
     constexpr size_t kMaxLogoBytes           = 1024 * 1024;
-    constexpr size_t kMaxEndpointBytes       = 2048;
     constexpr size_t kMaxMqttHostBytes       = 253;
     constexpr size_t kMaxMqttIdentityBytes   = 128;
     constexpr size_t kMaxMqttCredentialBytes = 256;
@@ -85,38 +85,6 @@ namespace {
     bool IsValidMqttHost(const std::string& host) {
         return !host.empty() && host.size() <= kMaxMqttHostBytes && !ContainsControlCharacter(host) &&
                cosmo::util::IsHostnameSafe(host) && std::any_of(host.begin(), host.end(), [](char character) {
-                   return std::isalnum(static_cast<unsigned char>(character)) != 0;
-               });
-    }
-
-    bool IsValidHttpUrl(const std::string& url) {
-        if (url.empty() || url.size() > kMaxEndpointBytes || ContainsControlCharacter(url) ||
-            url.find('\\') != std::string::npos) {
-            return false;
-        }
-
-        constexpr std::string_view kHttpPrefix{"http://"};
-        constexpr std::string_view kHttpsPrefix{"https://"};
-        size_t authority_begin = 0;
-        if (url.compare(0, kHttpPrefix.size(), kHttpPrefix) == 0) {
-            authority_begin = kHttpPrefix.size();
-        } else if (url.compare(0, kHttpsPrefix.size(), kHttpsPrefix) == 0) {
-            authority_begin = kHttpsPrefix.size();
-        } else {
-            return false;
-        }
-
-        const auto authority_end = url.find_first_of("/?#", authority_begin);
-        const auto authority = std::string_view(url).substr(authority_begin, authority_end - authority_begin);
-        if (authority.empty() || authority.find('@') != std::string_view::npos) {
-            return false;
-        }
-        const bool syntax_valid = std::all_of(authority.begin(), authority.end(), [](char character) {
-            const auto byte = static_cast<unsigned char>(character);
-            return std::isalnum(byte) != 0 || character == '.' || character == '-' || character == '_' ||
-                   character == ':' || character == '[' || character == ']';
-        });
-        return syntax_valid && std::any_of(authority.begin(), authority.end(), [](char character) {
                    return std::isalnum(static_cast<unsigned char>(character)) != 0;
                });
     }
@@ -185,7 +153,7 @@ namespace {
                                 ((!stored.mqttParam.bEnable && stored.mqttParam.ip.empty()) ||
                                  IsValidMqttHost(stored.mqttParam.ip));
         const bool http_valid = (!stored.httpParam.bEnable && stored.httpParam.url.empty()) ||
-                                IsValidHttpUrl(stored.httpParam.url);
+                                cosmo::util::IsValidHttpUrl(stored.httpParam.url);
         return mqtt_valid && http_valid;
     }
 
@@ -615,9 +583,6 @@ HttpPushParam SystemServiceImpl::GetHttpInterfaceParam() {
 }
 
 cosmo::util::ErrorEnum SystemServiceImpl::SetHttpInterfaceParam(const HttpPushParam& param) {
-    if ((param.enable || !param.url.empty()) && !IsValidHttpUrl(param.url)) {
-        return cosmo::util::ErrorEnum::InvalidParam;
-    }
     return service::ServiceRegistry::Instance().Get<service::IAlarmPushService>().SetPush(param.enable,
                                                                                           param.url);
 }
@@ -721,7 +686,8 @@ IotNetworkParam SystemServiceImpl::GetIotNetworkParam() {
 
 cosmo::util::ErrorEnum SystemServiceImpl::SetIotNetworkParam(const std::string& httpUrl,
                                                              const std::string& mqttIp, int mqtt_port) {
-    if (!IsValidHttpUrl(httpUrl) || !IsValidMqttHost(mqttIp) || mqtt_port < 1 || mqtt_port > 65535) {
+    if (!cosmo::util::IsValidHttpUrl(httpUrl) || !IsValidMqttHost(mqttIp) || mqtt_port < 1 ||
+        mqtt_port > 65535) {
         return cosmo::util::ErrorEnum::InvalidParam;
     }
     std::lock_guard<std::shared_mutex> lock(sys_config_state_->mtx);

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(cosmo_util OBJECT
     FpsCalc.cc           FpsCalc.h
     FpsCtrl.cc           FpsCtrl.h
     GeometricPos.cc      GeometricPos.h
+    HttpUrlUtil.cc       HttpUrlUtil.h
     JsonFileUtil.cc      JsonFileUtil.h
     Log.cc               Log.h
     NToL.cc              NToL.h

--- a/src/util/HttpUrlUtil.cc
+++ b/src/util/HttpUrlUtil.cc
@@ -1,0 +1,50 @@
+#include "util/HttpUrlUtil.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace cosmo::util {
+
+namespace {
+    constexpr size_t kMaxHttpUrlBytes = 2048;
+    constexpr std::string_view kHttpPrefix{"http://"};
+    constexpr std::string_view kHttpsPrefix{"https://"};
+}  // namespace
+
+bool IsValidHttpUrl(std::string_view url) {
+    if (url.empty() || url.size() > kMaxHttpUrlBytes || url.find('\\') != std::string_view::npos) {
+        return false;
+    }
+    if (std::any_of(url.begin(), url.end(), [](char character) {
+            const auto byte = static_cast<unsigned char>(character);
+            return byte < 0x20 || byte == 0x7f;
+        })) {
+        return false;
+    }
+
+    size_t authority_begin = 0;
+    if (url.compare(0, kHttpPrefix.size(), kHttpPrefix) == 0) {
+        authority_begin = kHttpPrefix.size();
+    } else if (url.compare(0, kHttpsPrefix.size(), kHttpsPrefix) == 0) {
+        authority_begin = kHttpsPrefix.size();
+    } else {
+        return false;
+    }
+
+    const auto authority_end = url.find_first_of("/?#", authority_begin);
+    const auto authority     = url.substr(authority_begin, authority_end - authority_begin);
+    if (authority.empty() || authority.find('@') != std::string_view::npos) {
+        return false;
+    }
+
+    const bool syntax_valid = std::all_of(authority.begin(), authority.end(), [](char character) {
+        const auto byte = static_cast<unsigned char>(character);
+        return std::isalnum(byte) != 0 || character == '.' || character == '-' || character == '_' ||
+               character == ':' || character == '[' || character == ']';
+    });
+    return syntax_valid && std::any_of(authority.begin(), authority.end(), [](char character) {
+               return std::isalnum(static_cast<unsigned char>(character)) != 0;
+           });
+}
+
+}  // namespace cosmo::util

--- a/src/util/HttpUrlUtil.h
+++ b/src/util/HttpUrlUtil.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string_view>
+
+namespace cosmo::util {
+
+[[nodiscard]] bool IsValidHttpUrl(std::string_view url);
+
+}  // namespace cosmo::util

--- a/test/test_http_url_util.cc
+++ b/test/test_http_url_util.cc
@@ -1,0 +1,37 @@
+#include <string>
+
+#include "catch_amalgamated.hpp"
+#include "util/HttpUrlUtil.h"
+
+TEST_CASE("HttpUrlUtil: accepts supported HTTP endpoints", "[http-url]") {
+    REQUIRE(cosmo::util::IsValidHttpUrl("http://example.com"));
+    REQUIRE(cosmo::util::IsValidHttpUrl("https://example.com"));
+    REQUIRE(cosmo::util::IsValidHttpUrl("http://192.168.1.10:8080/push"));
+    REQUIRE(cosmo::util::IsValidHttpUrl("https://[2001:db8::1]:8443/push"));
+    REQUIRE(cosmo::util::IsValidHttpUrl("https://example.com/path?event=alarm#latest"));
+    REQUIRE(cosmo::util::IsValidHttpUrl("http://device_name/push"));
+    REQUIRE(cosmo::util::IsValidHttpUrl("http://example.com/path?recipient=user@example.com"));
+}
+
+TEST_CASE("HttpUrlUtil: enforces the endpoint length limit", "[http-url]") {
+    std::string url{"https://example.com/"};
+    url.append(2048 - url.size(), 'a');
+    REQUIRE(cosmo::util::IsValidHttpUrl(url));
+
+    url.push_back('a');
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl(url));
+}
+
+TEST_CASE("HttpUrlUtil: rejects unsupported or malformed endpoints", "[http-url]") {
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl(""));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("file:///etc/passwd"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("ftp://example.com/data"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("HTTP://example.com"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("http://"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("http:///push"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("http://user@example.com/push"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("http://example.com/line\nbreak"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("http://example.com\\push"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("http://example!.com/push"));
+    REQUIRE_FALSE(cosmo::util::IsValidHttpUrl("http://[]:-._/push"));
+}

--- a/test/test_system_config_service_impl.cc
+++ b/test/test_system_config_service_impl.cc
@@ -373,8 +373,10 @@ TEST_CASE("SystemServiceImpl: HttpInterface delegates to AlarmPushService", "[Sy
         REQUIRE(result == cosmo::util::ErrorEnum::Success);
     }
 
-    SECTION("SetHttpInterfaceParam rejects unsafe URL before delegation") {
+    SECTION("SetHttpInterfaceParam propagates validation failure from IAlarmPushService") {
         cosmo::service::HttpPushParam param{true, "file:///etc/passwd"};
+        REQUIRE_CALL(mocks.alarmPushSvc, SetPush(true, std::string("file:///etc/passwd")))
+            .RETURN(cosmo::util::ErrorEnum::InvalidParam);
         REQUIRE(sut.SetHttpInterfaceParam(param) == cosmo::util::ErrorEnum::InvalidParam);
     }
 }


### PR DESCRIPTION
## Summary

Centralize the duplicated HTTP/HTTPS endpoint validation used by AlarmPushService and SystemService. SystemService now delegates standalone HTTP push validation to AlarmPushService while retaining direct validation for persisted and IoT endpoints.

## Related issue

Closes #132

## Root cause

Two service implementations carried equivalent validators, which could drift over time. The standalone SystemService path also validated the same endpoint immediately before delegating to AlarmPushService.

## Scope

### In scope

- Add `cosmo::util::IsValidHttpUrl` with the existing 2048-byte, lowercase scheme, authority, control-character, and backslash rules.
- Migrate AlarmPushService persisted configuration and `SetPush()` validation.
- Migrate SystemService persisted and IoT validation.
- Let `SetHttpInterfaceParam()` delegate and propagate `IAlarmPushService::SetPush()` errors.
- Add focused URL and delegation tests.

### Out of scope

- DNS resolution, private-network or SSRF policy.
- URL decoding, uppercase scheme acceptance, or broader URL normalization.
- Public API or configuration-format changes.

## Risk tags

- [ ] Runtime / lifecycle
- [ ] Thread / memory safety
- [x] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [ ] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build / deployment
- [x] Refactor
- [x] Test

## Area

- [x] Backend service
- [ ] Frontend web console
- [ ] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [x] API / MQTT / WebSocket
- [ ] Media / streaming
- [ ] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `92ecab579f824b1759b5b463100b41b3db1d9b3d`
- Candidate commit: `5b90398bf6fa99dd73e9dc3c9a6779821fb0a050`
- Candidate tree: `2dd11b88717638833ea200105e70a260721f6664`
- Package SHA-256: `accee21b0c1a6af375663f85d7cc88bc74834e5916fb5cc806459aafd1033710`
- Test binary SHA-256: `12362edec68426a4919124886581e4330f22e81916e0a9ce237380d24b8e4e03`

The candidate has not been amended, rebased, merged, or otherwise changed since this evidence was collected.

## Verification

### Parent baseline

```text
PASS — read-only comparison on origin/main confirmed AlarmPushServiceImpl.cc and
SystemServiceImpl.cc implemented the same lowercase HTTP/HTTPS, 2048-byte,
authority, control-character, and backslash rules.
```

### Candidate checks

```text
PASS  ./scripts/format_check.sh --staged --check
      Run after each of the three commits; all changed C++ files formatted by clang-format 18.1.3.
PASS  ./scripts/static_analysis.sh --staged --cppcheck
      Run after each of the three commits; no changed-file issues.
PASS  git diff --cached --check
      Run after each of the three commits.
PASS  git diff origin/main...HEAD --check
PASS  ./scripts/docker-compose.sh -f docker-compose.sophon.yml run --rm cosmo-sophon-package --chip bm1688
      Run after every commit. Final build compiled and linked cosmo-engine and cosmo-tests;
      package regression suites passed 23/23 and 7/7.
PASS  ./.codex/validate_candidate.sh --issue '#132' --base origin/main \
        --package build_output/public-runtime/bm1688/cosmo-V1.1.0-5812171d1d87b0d19334a6ef420f739a.tar.gz \
        --tests build/cosmo-tests
```

```text
PASS  LD_LIBRARY_PATH=<installed-bm1688-runtime>/lib ./cosmo-tests "[http-url]"
      20 assertions in 3 test cases.
PASS  LD_LIBRARY_PATH=<installed-bm1688-runtime>/lib ./cosmo-tests "[alarm-push]"
      29 assertions in 5 test cases.
PASS  LD_LIBRARY_PATH=<installed-bm1688-runtime>/lib ./cosmo-tests "[SystemConfigService]"
      6047 assertions in 25 test cases.
```

### Risk-based evidence

- API/network: Shared helper has focused protocol, authority, character, IPv4/IPv6, path/query/fragment, and 2048/2049-byte boundary tests; delegation error propagation is mocked.
- Media/streaming: N/A.
- Sophon/device: PASS on the authorized BM1688/aarch64 test device. Valid HTTPS save, invalid `file://` and userinfo rejection, rejected-write state preservation, enabled and disabled restart persistence, and invalid persisted-config rejection all passed.
- Frontend/UI: N/A; no frontend files changed.
- Package/deployment: BM1688 public-runtime package generated and audited; target chip recorded as `bm1688`.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: `验证通过 5b90398bf6fa99dd73e9dc3c9a6779821fb0a050 accee21b0c1a6af375663f85d7cc88bc74834e5916fb5cc806459aafd1033710`
- Device test filter: `[http-url]`, `[alarm-push]`, `[SystemConfigService]` — `PASS`
- Device backup state: retained; rollback was not required
- Temporary-data cleanup: `complete`; the uploaded package, test binary, extraction directory, install log, and HTTP fixtures were removed
- Final Git status: `clean`
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

The shared validator intentionally preserves the previous narrow behavior. It does not add DNS, SSRF, private-network, decoding, or case-insensitive scheme rules. Device validation and candidate-bound acceptance are complete; the PR remains draft pending explicit Ready authorization.
