### PR TITLE
docs: improve Gitee access and support paths

### DIFF
--- a/MIRRORING.md
+++ b/MIRRORING.md
@@ -1,8 +1,8 @@
 # Repository Mirroring / 仓库镜像说明
 
-CosmoEdge maintains a read-only mirror on [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) for users in mainland China.
+CosmoEdge automatically mirrors its code to [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) for reliable access in mainland China. The mirrored code is managed from GitHub and must not be edited directly on Gitee; Gitee Releases and Issues are maintained as mainland-facing entry points.
 
-CosmoEdge 在 [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) 维护只读镜像，方便国内用户访问。
+CosmoEdge 在 [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) 自动同步代码，方便国内用户稳定访问。镜像代码由 GitHub 主仓管理，不在 Gitee 直接修改；Gitee Releases 与 Issues 作为国内版本获取和中文问题反馈入口持续维护。
 
 ---
 
@@ -11,21 +11,23 @@ CosmoEdge 在 [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) 维护只读
 | | GitHub (Primary / 主仓) | Gitee (Mirror / 镜像) |
 |---|---|---|
 | URL | [github.com/cosmo-wander-ai/cosmo-edge](https://github.com/cosmo-wander-ai/cosmo-edge) | [gitee.com/cosmo-wander-ai/cosmo-edge](https://gitee.com/cosmo-wander-ai/cosmo-edge) |
-| Role | Source of Truth (主仓) | Read-only mirror (只读镜像) |
+| Role | Source of Truth and code review (主仓与代码评审) | Auto-synced code access plus mainland Releases and Issues (自动同步代码、国内版本与问题入口) |
 | Sync | — | Auto-sync via GitHub Actions (自动同步) |
 
 ## Issues & Pull Requests / 问题与贡献
 
 | Action | Where / 位置 |
 |--------|-------------|
-| Bug reports (问题反馈) | [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues) 或 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues) |
+| General reproducible defects (通用可复现缺陷) | [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues) |
+| Mainland access, installation, usage, release, or device questions (国内访问、安装、使用、版本或设备问题) | [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues) |
 | Feature requests (功能建议) | [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues) 或 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues) |
 | Pull Requests (代码贡献) | [GitHub](https://github.com/cosmo-wander-ai/cosmo-edge/pulls) only |
 | Discussions (讨论) | [GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) |
+| Releases (版本获取) | [GitHub Releases](https://github.com/cosmo-wander-ai/cosmo-edge/releases) 或 [Gitee Releases](https://gitee.com/cosmo-wander-ai/cosmo-edge/releases) |
 
-> **Note / 说明**: Gitee Issues are monitored, but pull requests should be submitted to GitHub. Code merged on GitHub is automatically mirrored to Gitee.
+> **Note / 说明**: Gitee Issues and Releases are maintained for mainland users, but pull requests should be submitted to GitHub. Code merged on GitHub is automatically mirrored to Gitee, so direct code edits on Gitee can be overwritten.
 >
-> Gitee Issues 会被关注处理，但代码贡献请提交到 GitHub。合并到 GitHub 的代码会自动同步到 Gitee。
+> Gitee Issues 与 Releases 面向国内用户持续维护，但代码贡献请提交到 GitHub。合并到 GitHub 的代码会自动同步到 Gitee，因此不要直接修改 Gitee 上的镜像代码。
 
 ## Sync Frequency / 同步频率
 
@@ -59,3 +61,7 @@ If you experience slow access to GitHub, use the Gitee mirror:
 ```bash
 git clone https://gitee.com/cosmo-wander-ai/cosmo-edge.git
 ```
+
+For installation, usage, release-download, or device-adaptation questions in mainland China, use [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues).
+
+国内用户遇到安装、使用、版本获取或设备适配问题，可使用 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues) 反馈。

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Certified devices add preconfigured acceleration, validated commercial model pac
 
 Contributions are welcome through scoped bug reports, documentation improvements, scenarios, and integration notes. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) is the official searchable English Q&A and community-support channel for v1.1. Send reproducible defects to [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues), use [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues) for the mainland China mirror, and report vulnerabilities privately through [SECURITY.md](SECURITY.md). No Discord channel is operated for this release.
+[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) is the official searchable English Q&A and community-support channel for v1.1, and general reproducible defects belong in [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues). Users in mainland China can use [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues) for repository access, installation, usage, release downloads, and device-adaptation questions. Code changes and pull requests remain on GitHub; report vulnerabilities privately through [SECURITY.md](SECURITY.md). No Discord channel is operated for this release.
 
 ## FAQ
 
@@ -302,6 +302,6 @@ An open-source project by Cosmo Wander AI and the CosmoEdge contributors.
 
 Turn video AI models into deployable edge applications.
 
-📦 This repository is mirrored read-only to [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) for mainland China access. See [MIRRORING.md](MIRRORING.md).
+📦 GitHub remains the development and pull-request source of truth. [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) automatically mirrors the code and provides release access and a Chinese issue channel for users in mainland China. See [MIRRORING.md](MIRRORING.md).
 
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -240,7 +240,7 @@ v1.1 报告覆盖 BM1688、CV186X、RK3576 与 RV1126B。报告包含人员检�
 
 欢迎提交范围明确的 bug 报告、文档改进、场景示例和集成说明。提交 pull request 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
-[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) 是 v1.1 官方、可检索的英文问答与社区支持渠道；可复现缺陷请提交到 [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues)，中国大陆镜像问题可使用 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues)，安全问题请按 [SECURITY.md](SECURITY.md) 私密报告。本次发布不运营 Discord。
+中国大陆用户遇到代码访问、安装、使用、版本获取或设备适配问题，可提交到 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues)；[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) 是 v1.1 官方、可检索的英文问答与社区支持渠道，通用可复现缺陷可提交到 [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues)。代码变更与 Pull Request 仍统一在 GitHub 处理；安全问题请按 [SECURITY.md](SECURITY.md) 私密报告。本次发布不运营 Discord。
 
 中文实时交流可加入 [CosmoEdge 微信开发者交流群](https://github.com/cosmo-wander-ai/cosmo-edge/discussions/112)；微信群用于开发者交流，群内形成的可复现问题和可复用结论请继续沉淀到 GitHub Discussions 或 Issues。
 
@@ -286,6 +286,6 @@ An open-source project by Cosmo Wander AI and the CosmoEdge contributors.
 
 Turn video AI models into deployable edge applications.
 
-📦 本仓库在 [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) 维护只读镜像，代码自动从 GitHub 同步。详见 [MIRRORING.md](MIRRORING.md)。
+📦 GitHub 管理代码主线和 Pull Request；[Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) 自动同步代码，并为中国大陆用户提供版本获取与中文问题反馈入口。详见 [MIRRORING.md](MIRRORING.md)。
 
 </div>

--- a/Readme.osc.md
+++ b/Readme.osc.md
@@ -67,7 +67,7 @@ CosmoEdge 提供统一的引擎架构与编排体验，但每次构建只选择�
 
 ```bash
 # 1. 克隆
-git clone https://github.com/cosmo-wander-ai/cosmo-edge.git
+git clone https://gitee.com/cosmo-wander-ai/cosmo-edge.git
 cd cosmo-edge
 
 # 2. 在 Linux 启动
@@ -83,7 +83,7 @@ sudo docker compose -f docker-compose.x86.yml up -d --build
 ### 为 Sophon 构建
 
 ```bash
-git clone https://github.com/cosmo-wander-ai/cosmo-edge.git
+git clone https://gitee.com/cosmo-wander-ai/cosmo-edge.git
 cd cosmo-edge
 # BM1688（省略芯片型号时的默认值）
 ./scripts/docker-compose.sh -f docker-compose.sophon.yml run --rm cosmo-sophon-package --chip bm1688
@@ -248,7 +248,7 @@ v1.1 报告覆盖 BM1688、CV186X、RK3576 与 RV1126B。报告包含人员检�
 
 欢迎提交范围明确的 bug 报告、文档改进、场景示例和集成说明。提交 pull request 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
-[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) 是 v1.1 官方、可检索的英文问答与社区支持渠道；可复现缺陷请提交到 [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues)，中国大陆镜像问题可使用 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues)，安全问题请按 [SECURITY.md](SECURITY.md) 私密报告。本次发布不运营 Discord。
+中国大陆用户遇到代码访问、安装、使用、版本获取或设备适配问题，可提交到 [Gitee Issues](https://gitee.com/cosmo-wander-ai/cosmo-edge/issues)；[GitHub Discussions](https://github.com/cosmo-wander-ai/cosmo-edge/discussions) 是 v1.1 官方、可检索的英文问答与社区支持渠道，通用可复现缺陷可提交到 [GitHub Issues](https://github.com/cosmo-wander-ai/cosmo-edge/issues)。代码变更与 Pull Request 仍统一在 GitHub 处理；安全问题请按 [SECURITY.md](SECURITY.md) 私密报告。本次发布不运营 Discord。
 
 中文实时交流可加入 [CosmoEdge 微信开发者交流群](https://github.com/cosmo-wander-ai/cosmo-edge/discussions/112)；微信群用于开发者交流，群内形成的可复现问题和可复用结论请继续沉淀到 GitHub Discussions 或 Issues。
 
@@ -294,6 +294,6 @@ An open-source project by Cosmo Wander AI and the CosmoEdge contributors.
 
 Turn video AI models into deployable edge applications.
 
-📦 本仓库在 [Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) 维护只读镜像，代码自动从 GitHub 同步。详见 [MIRRORING.md](MIRRORING.md)。
+📦 GitHub 管理代码主线和 Pull Request；[Gitee](https://gitee.com/cosmo-wander-ai/cosmo-edge) 自动同步代码，并为中国大陆用户提供版本获取与中文问题反馈入口。详见 [MIRRORING.md](MIRRORING.md)。
 
 </div>

--- a/docs/en/tutorials/01-quickstart/quickstart.md
+++ b/docs/en/tutorials/01-quickstart/quickstart.md
@@ -43,12 +43,17 @@ Docker 29.1.3, and Docker Compose v5.1.4. This is a recorded validation environm
 
 Docker Compose V2 uses `docker compose`. If the host still uses the standalone legacy Compose binary, replace `docker compose` with `docker-compose`.
 
-Get the source:
+Get the source from the GitHub source of truth:
 
 ```bash
 git clone https://github.com/cosmo-wander-ai/cosmo-edge.git
-# A project-maintained Gitee mirror is also available for networks in mainland China:
-# git clone https://gitee.com/cosmo-wander-ai/cosmo-edge.git
+cd cosmo-edge
+```
+
+For networks in mainland China, use the project-maintained Gitee mirror instead:
+
+```bash
+git clone https://gitee.com/cosmo-wander-ai/cosmo-edge.git
 cd cosmo-edge
 ```
 

--- a/docs/tutorials/01-quickstart/quickstart.md
+++ b/docs/tutorials/01-quickstart/quickstart.md
@@ -43,12 +43,17 @@ Docker 29.1.3 和 Docker Compose v5.1.4。它只是一次验证快照，不是�
 Docker Compose V2 使用 `docker compose`。若环境仍安装独立的旧版 Compose，需要把命令中的
 `docker compose` 替换为 `docker-compose`。
 
-获取代码：
+中国大陆网络建议从 Gitee 获取代码：
+
+```bash
+git clone https://gitee.com/cosmo-wander-ai/cosmo-edge.git
+cd cosmo-edge
+```
+
+也可以从 GitHub 主仓获取：
 
 ```bash
 git clone https://github.com/cosmo-wander-ai/cosmo-edge.git
-# 中国大陆网络也可以使用项目维护的 Gitee 镜像：
-# git clone https://gitee.com/cosmo-wander-ai/cosmo-edge.git
 cd cosmo-edge
 ```
 

--- a/scripts/generate-gitee-readme.mjs
+++ b/scripts/generate-gitee-readme.mjs
@@ -11,6 +11,9 @@ const checkMode = process.argv.includes('--check');
 const generatedHeader = '<!-- Generated from README.zh-CN.md by scripts/generate-gitee-readme.mjs. Do not edit directly. -->\n\n';
 const githubReleaseBadge = '[![Release](https://img.shields.io/badge/release-v1.1.0-2ea44f?style=flat-square)](https://github.com/cosmo-wander-ai/cosmo-edge/releases/tag/v1.1.0)';
 const giteeReleaseBadge = '[![Release](https://img.shields.io/badge/release-v1.1.0-2ea44f?style=flat-square)](https://gitee.com/cosmo-wander-ai/cosmo-edge/releases)';
+const githubCloneCommand = 'git clone https://github.com/cosmo-wander-ai/cosmo-edge.git';
+const giteeCloneCommand = 'git clone https://gitee.com/cosmo-wander-ai/cosmo-edge.git';
+const giteeIssuesUrl = 'https://gitee.com/cosmo-wander-ai/cosmo-edge/issues';
 
 const replacements = [
   {
@@ -40,6 +43,11 @@ const replacements = [
   {
     source: githubReleaseBadge,
     target: giteeReleaseBadge
+  },
+  {
+    source: githubCloneCommand,
+    target: giteeCloneCommand,
+    expectedOccurrences: 2
   }
 ];
 
@@ -48,10 +56,11 @@ let body = source;
 
 for (const replacement of replacements) {
   const occurrences = countOccurrences(body, replacement.source);
-  if (occurrences !== 1) {
-    fail('Expected exactly one source pattern, found ' + occurrences + ': ' + replacement.source);
+  const expectedOccurrences = replacement.expectedOccurrences ?? 1;
+  if (occurrences !== expectedOccurrences) {
+    fail('Expected ' + expectedOccurrences + ' source pattern occurrence(s), found ' + occurrences + ': ' + replacement.source);
   }
-  body = body.replace(replacement.source, replacement.target);
+  body = body.split(replacement.source).join(replacement.target);
 }
 
 const generated = generatedHeader + body;
@@ -61,10 +70,10 @@ if (checkMode) {
   if (!fs.existsSync(targetPath)) fail('Readme.osc.md is missing; run npm run gitee:readme:generate');
   const actual = fs.readFileSync(targetPath, 'utf8');
   if (actual !== generated) fail('Readme.osc.md is stale; run npm run gitee:readme:generate');
-  console.log('Gitee README check passed: generated copy is current, all 3 videos route to official playback pages, and the release badge routes to Gitee.');
+  console.log('Gitee README check passed: generated copy is current, clone commands and the release badge route to Gitee, Gitee Issues is visible, and all 3 videos route to official playback pages.');
 } else {
   fs.writeFileSync(targetPath, generated);
-  console.log('Generated Readme.osc.md from README.zh-CN.md with 3 official video-page replacements and the Gitee release link.');
+  console.log('Generated Readme.osc.md from README.zh-CN.md with Gitee clone, release, and issue entry points plus 3 official video-page replacements.');
 }
 
 function validateGenerated(content) {
@@ -73,6 +82,15 @@ function validateGenerated(content) {
   }
   if (content.includes(githubReleaseBadge)) {
     fail('Generated Gitee README still routes the release badge to GitHub');
+  }
+  if (content.includes(githubCloneCommand)) {
+    fail('Generated Gitee README still contains a GitHub clone command');
+  }
+  if (countOccurrences(content, giteeCloneCommand) !== 2) {
+    fail('Expected both Gitee README clone commands to route to Gitee');
+  }
+  if (!content.includes(`[Gitee Issues](${giteeIssuesUrl})`)) {
+    fail('Generated Gitee README is missing the Gitee Issues entry point');
   }
   if (countOccurrences(content, giteeReleaseBadge) !== 1) {
     fail('Expected exactly one Gitee release badge');


### PR DESCRIPTION
## Summary

- route generated Gitee README clone commands and release entry points to Gitee
- clarify GitHub source-of-truth boundaries while documenting maintained Gitee Releases and Issues
- expose copyable Gitee clone commands in the bilingual quick-start guide
- add generation assertions that prevent Gitee access paths from regressing

## Validation

- Gitee README generation and consistency checks
- Sophon model-resource and ScenarioBench validation
- macOS Preview and bilingual tutorial checks
- VitePress documentation build
- public-copy, tutorial-page, and benchmark-page smoke tests

## Scope

Documentation and validation tooling only; no runtime behavior changes.
