### PR TITLE
fix: own Flow editor event listeners

### DIFF
--- a/src/web/src/views/box/strategyManagement/components/ArrangeFlow.vue
+++ b/src/web/src/views/box/strategyManagement/components/ArrangeFlow.vue
@@ -394,21 +394,7 @@ const handleCloseDetailPanel = (nodeId) => {
   }
 }
 
-EventBus.$on('flow:openDetailPanel', handleOpenDetailPanel)
-EventBus.$on('flow:closeDetailPanel', handleCloseDetailPanel)
-
-onBeforeUnmount(() => {
-  EventBus.$off('flow:openDetailPanel', handleOpenDetailPanel)
-  EventBus.$off('flow:closeDetailPanel', handleCloseDetailPanel)
-})
-
-EventBus.$on('edgeMenu:focus', (nodeId) => {
-  // requestAnimationFrame(() => {
-  //   focusNode(nodeId)
-  // })
-})
-
-EventBus.$on('flow:removeNodes', (ids) => {
+const handleRemoveNodes = (ids) => {
   if (!Array.isArray(ids) || ids.length === 0) return
   setNodes((ns) => ns.filter((n) => !ids.includes(n.id)))
   nodes.value = nodes.value.filter((n) => !ids.includes(n.id))
@@ -420,22 +406,19 @@ EventBus.$on('flow:removeNodes', (ids) => {
   nodes.value.forEach((n) => {
     if (n.data) n.data.atomicList = atomicList.value
   })
-})
+}
 
-EventBus.$on(
-  'flow:addComponentDialog:open',
-  ({ edgeId, x, y, mode, sourceId } = {}) => {
-    addDialogMode.value = mode || 'insert'
-    addDialogSourceId.value = sourceId || ''
-    addDialogEdgeId.value = edgeId || ''
-    addDialogX.value = Number(x || 0)
-    addDialogY.value = Number(y || 0)
-    addDialogVisible.value = true
-  }
-)
+const handleAddComponentDialogOpen = ({ edgeId, x, y, mode, sourceId } = {}) => {
+  addDialogMode.value = mode || 'insert'
+  addDialogSourceId.value = sourceId || ''
+  addDialogEdgeId.value = edgeId || ''
+  addDialogX.value = Number(x || 0)
+  addDialogY.value = Number(y || 0)
+  addDialogVisible.value = true
+}
 
 // 实时同步 atomicList：来自节点表单的更新
-EventBus.$on('flow:atomic:update', (payload = {}) => {
+const handleAtomicUpdate = (payload = {}) => {
   const { position, atomicCode, atomicName, labelList } = payload
   if (!position) return
   const list = atomicList.value || []
@@ -456,6 +439,20 @@ EventBus.$on('flow:atomic:update', (payload = {}) => {
   nodes.value.forEach((n) => {
     if (n.data) n.data.atomicList = atomicList.value
   })
+}
+
+EventBus.$on('flow:openDetailPanel', handleOpenDetailPanel)
+EventBus.$on('flow:closeDetailPanel', handleCloseDetailPanel)
+EventBus.$on('flow:removeNodes', handleRemoveNodes)
+EventBus.$on('flow:addComponentDialog:open', handleAddComponentDialogOpen)
+EventBus.$on('flow:atomic:update', handleAtomicUpdate)
+
+onBeforeUnmount(() => {
+  EventBus.$off('flow:openDetailPanel', handleOpenDetailPanel)
+  EventBus.$off('flow:closeDetailPanel', handleCloseDetailPanel)
+  EventBus.$off('flow:removeNodes', handleRemoveNodes)
+  EventBus.$off('flow:addComponentDialog:open', handleAddComponentDialogOpen)
+  EventBus.$off('flow:atomic:update', handleAtomicUpdate)
 })
 
 const getNodeTypeForAction = (action) => {

--- a/src/web/src/views/gam/countManagement/arrangeDetail/flow/ActionEdge.vue
+++ b/src/web/src/views/gam/countManagement/arrangeDetail/flow/ActionEdge.vue
@@ -122,18 +122,20 @@ const closeMenu = (e) => {
   }
 }
 
+const handleEdgeMenuOpen = (edgeId) => {
+  if (edgeId !== props.id) {
+    menuVisible.value = false
+  }
+}
+
 onMounted(() => {
   document.addEventListener('click', closeMenu)
-  EventBus.$on('edgeMenu:open', (edgeId) => {
-    if (edgeId !== props.id) {
-      menuVisible.value = false
-    }
-  })
+  EventBus.$on('edgeMenu:open', handleEdgeMenuOpen)
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('click', closeMenu)
-  EventBus.$off('edgeMenu:open')
+  EventBus.$off('edgeMenu:open', handleEdgeMenuOpen)
 })
 
 // 添加分支：从当前边的 source 增加一个并行分支到新节点

--- a/src/web/src/views/gam/countManagement/arrangeDetail/flow/ArrangeFlow.vue
+++ b/src/web/src/views/gam/countManagement/arrangeDetail/flow/ArrangeFlow.vue
@@ -571,37 +571,37 @@ const centerView = () => {
   }
 }
 
-EventBus.$on('edgeMenu:focus', (nodeId) => {
+const handleEdgeMenuFocus = (nodeId) => {
   requestAnimationFrame(() => {
     markNodeSelected(nodeId)
     // focusNode(nodeId)
   })
-})
+}
 
-EventBus.$on('flow:layout:request', () => {
+const handleLayoutRequest = () => {
   requestAnimationFrame(() => {
     applyLayout()
   })
-})
+}
 
-EventBus.$on('flow:collapseAll', (payload = {}) => {
+const handleCollapseAll = (payload = {}) => {
   closeDetailPanel()
-})
+}
 
-EventBus.$on('flow:openDetailPanel', (nodeId) => {
+const handleOpenDetailPanel = (nodeId) => {
   openDetailPanel(nodeId)
-})
+}
 
-EventBus.$on('flow:closeDetailPanel', (deletedNodeId) => {
+const handleCloseDetailPanel = (deletedNodeId) => {
   // 如果删除的正是当前面板展示的节点，关闭面板（不保存）
   if (detailPanelNodeId.value === deletedNodeId) {
     detailPanelNodeId.value = null
     detailPanelNodeData.value = null
     clearNodeSelected()
   }
-})
+}
 
-EventBus.$on('flow:removeNodes', (ids) => {
+const handleRemoveNodes = (ids) => {
   if (!Array.isArray(ids) || ids.length === 0) return
   setNodes((ns) => ns.filter((n) => !ids.includes(n.id)))
   nodes.value = nodes.value.filter((n) => !ids.includes(n.id))
@@ -613,23 +613,20 @@ EventBus.$on('flow:removeNodes', (ids) => {
   nodes.value.forEach((n) => {
     if (n.data) n.data.atomicList = atomicList.value
   })
-})
+}
 
-EventBus.$on(
-  'flow:addComponentDialog:open',
-  ({ edgeId, x, y, mode, sourceId } = {}) => {
-    addDialogMode.value = mode || 'insert'
-    addDialogSourceId.value = sourceId || ''
-    addDialogEdgeId.value = edgeId || ''
-    addDialogX.value = Number(x || 0)
-    addDialogY.value = Number(y || 0)
-    addDialogVisible.value = true
-    closeDetailPanel()
-  }
-)
+const handleAddComponentDialogOpen = ({ edgeId, x, y, mode, sourceId } = {}) => {
+  addDialogMode.value = mode || 'insert'
+  addDialogSourceId.value = sourceId || ''
+  addDialogEdgeId.value = edgeId || ''
+  addDialogX.value = Number(x || 0)
+  addDialogY.value = Number(y || 0)
+  addDialogVisible.value = true
+  closeDetailPanel()
+}
 
 // 实时同步 atomicList：来自节点表单的更新
-EventBus.$on('flow:atomic:update', (payload = {}) => {
+const handleAtomicUpdate = (payload = {}) => {
   const { position, atomicCode, atomicName, labelList } = payload
   if (!position) return
   const list = atomicList.value || []
@@ -651,6 +648,26 @@ EventBus.$on('flow:atomic:update', (payload = {}) => {
   nodes.value.forEach((n) => {
     if (n.data) n.data.atomicList = atomicList.value
   })
+}
+
+EventBus.$on('edgeMenu:focus', handleEdgeMenuFocus)
+EventBus.$on('flow:layout:request', handleLayoutRequest)
+EventBus.$on('flow:collapseAll', handleCollapseAll)
+EventBus.$on('flow:openDetailPanel', handleOpenDetailPanel)
+EventBus.$on('flow:closeDetailPanel', handleCloseDetailPanel)
+EventBus.$on('flow:removeNodes', handleRemoveNodes)
+EventBus.$on('flow:addComponentDialog:open', handleAddComponentDialogOpen)
+EventBus.$on('flow:atomic:update', handleAtomicUpdate)
+
+onBeforeUnmount(() => {
+  EventBus.$off('edgeMenu:focus', handleEdgeMenuFocus)
+  EventBus.$off('flow:layout:request', handleLayoutRequest)
+  EventBus.$off('flow:collapseAll', handleCollapseAll)
+  EventBus.$off('flow:openDetailPanel', handleOpenDetailPanel)
+  EventBus.$off('flow:closeDetailPanel', handleCloseDetailPanel)
+  EventBus.$off('flow:removeNodes', handleRemoveNodes)
+  EventBus.$off('flow:addComponentDialog:open', handleAddComponentDialogOpen)
+  EventBus.$off('flow:atomic:update', handleAtomicUpdate)
 })
 
 const getNodeTypeForAction = (action) => {

--- a/src/web/src/views/gam/countManagement/arrangeDetail/flow/ConditionView.vue
+++ b/src/web/src/views/gam/countManagement/arrangeDetail/flow/ConditionView.vue
@@ -118,22 +118,24 @@ watch(() => props.condition?.keyL, (newVal) => {
   }
 })
 
+const handleCondition = () => {
+  if (props.condition?.rightType === 'check' && props.condition?.keyL) {
+    handleRightData(props.condition.keyL)
+  }
+  getCurrentInstance()?.proxy?.$forceUpdate()
+}
+
 // Lifecycle
 onMounted(() => {
   console.log('condition  mounted', props.condition?.keyL)
   handleTaskData()
   handleLeftData()
   handleRightData(props.condition?.keyL)
-  EventBus.$on('onCondition', () => {
-    if (props.condition?.rightType === 'check' && props.condition?.keyL) {
-      handleRightData(props.condition.keyL)
-    }
-    getCurrentInstance()?.proxy?.$forceUpdate()
-  })
+  EventBus.$on('onCondition', handleCondition)
 })
 
 onBeforeUnmount(() => {
-  EventBus.$off('onCondition')
+  EventBus.$off('onCondition', handleCondition)
 })
 
 // Methods


### PR DESCRIPTION
## Summary

Give the Wave A Flow editor EventBus subscriptions stable handler identities, remove one no-op subscription, and ensure multi-instance edge and condition components unregister only their own listeners.

## Related issue

Closes #133

## Root cause

Several Flow editor subscriptions used anonymous callbacks, so they could not be removed during component teardown. `ActionEdge` and `ConditionView` called single-argument `$off`, which removes every handler for that event in mitt and can break sibling instances.

## Scope

### In scope

- Name and precisely unregister all eight algorithm ArrangeFlow subscriptions.
- Keep the five effective strategy ArrangeFlow subscriptions and precisely unregister them.
- Remove the strategy `edgeMenu:focus` subscription whose callback had no executable behavior.
- Give each ActionEdge and ConditionView instance its own handler identity.
- Preserve event names, payloads, callback bodies, registration order, and setup/mounted timing.

### Out of scope

- Replacing the global EventBus architecture.
- Cancelling requestAnimationFrame callbacks that were already queued before unmount.
- Changing ConditionView's existing `$forceUpdate()` behavior.
- Event names, payload formats, Flow layout behavior, or node/edge data formats.

## Risk tags

- [x] Runtime / lifecycle
- [ ] Thread / memory safety
- [ ] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [x] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build / deployment
- [x] Refactor
- [ ] Test

## Area

- [ ] Backend service
- [x] Frontend web console
- [x] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [ ] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `083c16c431cefad8b79d0e7815f9616b937f7d50`
- Candidate commit: `ad7303a1ae220312847472d5ac6a27731210bbe1`
- Candidate tree: `ac7839be70cfb11e6faf237dd5ea59e2c105d059`
- Package SHA-256: `31ba7ea8b479418e3ded3469014364ee9abc9ca2f9438a7f60378f257bef2fc1`
- Test binary SHA-256: `dbc583036c5f58dd691bceb0cb95cb7a59224947a4cb8225fa20092b3b8a5597`

The candidate has not been amended, rebased, merged, or otherwise changed since this evidence was collected.

## Verification

### Parent baseline

```text
PASS — read-only inspection on origin/main confirmed:
- algorithm ArrangeFlow registered eight setup-time anonymous handlers without teardown;
- strategy ArrangeFlow registered three anonymous effective handlers plus one no-op handler;
- ActionEdge and ConditionView used single-argument off calls that remove sibling handlers.
```

### Candidate checks

```text
PASS  git diff origin/main...HEAD --check
PASS  scoped scan: no single-argument EventBus.$off remains in the four changed files
PASS  scoped scan: every EventBus.$on in the four changed files has a matching off with the same handler
PASS  npm run linkage-flow:check                        (Sophon container)
PASS  npm run linkage-form:check                        (Sophon container)
PASS  npm run build                                     (Sophon container)
      Full prebuild, i18n, linkage, route, task-card, and upgrade checks passed.
PASS  ./scripts/docker-compose.sh -f docker-compose.sophon.yml run --rm \
        cosmo-sophon-package --chip bm1688
      cosmo-engine, cosmo-tests, web frontend, package audits, and package regression suites passed.
PASS  two independent read-only lifecycle reviews found no P0-P3 issue
PASS  ./.codex/validate_candidate.sh --issue '#133' --base origin/main \
        --package build_output/public-runtime/bm1688/cosmo-V1.1.0-fe3430ff931070a2e0f372fb34129779.tar.gz \
        --tests build/cosmo-tests
PASS  algorithm Flow route lifecycle: 10/10 entries returned 16 nodes and 9 ActionEdge instances
PASS  linkage Flow route lifecycle: 10/10 entries returned 2 nodes and 1 ActionEdge instance
PASS  ActionEdge sibling isolation after one edge unmounted: sequential menu counts remained 1 and 1
PASS  ConditionView sibling isolation: instance counts changed 1 -> 2 -> 1 -> 2
PASS  single insertion produced exactly one additional removable node and one additional edge
PASS  algorithm and linkage detail panels opened and closed
UNVERIFIED  branch creation: current UI exposes no branch action and checked device workflows were linear
```

The standalone frontend container emitted existing Node-engine compatibility warnings because its Node 20.11 image is older than the declared Node 20.19 minimum of three installed packages. Dependency installation and production build completed successfully; the canonical package build also passed.

### Risk-based evidence

- API/network: N/A.
- Media/streaming: N/A.
- Sophon/device: Candidate deployment and accessible UI lifecycle scenarios PASS on the authorized BM1688/aarch64 test device; branch creation remains UNVERIFIED because no UI entry exists.
- Frontend/UI: Production build, linkage/i18n checks, repeated 10-cycle route tests, multi-instance sibling isolation, insertion, deletion, and detail-panel scenarios PASS.
- Package/deployment: BM1688 public-runtime package generated and audited; target chip recorded as `bm1688`.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: `验证通过 ad7303a1ae220312847472d5ac6a27731210bbe1 31ba7ea8b479418e3ded3469014364ee9abc9ca2f9438a7f60378f257bef2fc1` (provided after the branch UI scenario was explicitly reported as `UNVERIFIED`)
- Device test filter: `N/A — UI lifecycle scenarios PASS_WITH_UNVERIFIED_BRANCH_UI`
- Device backup state: retained; rollback was not required
- Temporary-data cleanup: `complete`; uploaded package, extraction directory, install log, and temporary linkage strategy were removed
- Final Git status: `clean`
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

The diff intentionally preserves setup-time registration for parent Flow canvases and mounted-time registration for multi-instance children. Existing queued-RAF and ConditionView force-update behavior are unchanged. The current UI has no branch-creation control, so that scenario remains explicitly UNVERIFIED rather than inferred from hidden code. Device validation and candidate-bound acceptance are complete; the PR remains draft pending explicit Ready authorization.
