### PR TITLE
fix: own shell and form event listeners

### DIFF
--- a/src/web/src/views/box/basePicManagement/item/components/mVCanvas.vue
+++ b/src/web/src/views/box/basePicManagement/item/components/mVCanvas.vue
@@ -475,15 +475,18 @@ const unbindEvent = () => {
   canvasContext.value.unbindEvent()
 }
 
+const handleResetSelectPoints = () => {
+  selectPoints.value = []
+}
+
 // Lifecycle hooks
 onMounted(() => {
-  EventBus.$on('resetSelectPoints', () => {
-    selectPoints.value = []
-  })
+  EventBus.$on('resetSelectPoints', handleResetSelectPoints)
   init()
 })
 
 onBeforeUnmount(() => {
+  EventBus.$off('resetSelectPoints', handleResetSelectPoints)
   canvasContext.value.unbindEvent()
 })
 </script>

--- a/src/web/src/views/gam/countManagement/arrangeDetail/index.vue
+++ b/src/web/src/views/gam/countManagement/arrangeDetail/index.vue
@@ -106,6 +106,25 @@ watch(
   { flush: 'post' }
 )
 
+let resizeTimer = null
+const layoutResizeTimers = new Set()
+
+const handleResize = () => {
+  if (resizeTimer) clearTimeout(resizeTimer)
+  resizeTimer = setTimeout(() => {
+    resizeTimer = null
+    updateCanvasSize()
+  }, 100)
+}
+
+const handleLayoutResize = () => {
+  const timer = setTimeout(() => {
+    layoutResizeTimers.delete(timer)
+    updateCanvasSize()
+  }, 150)
+  layoutResizeTimers.add(timer)
+}
+
 // Lifecycle
 onMounted(() => {
   supplier.value = route.query?.supplier
@@ -120,9 +139,7 @@ onMounted(() => {
   window.addEventListener('resize', handleResize)
   getActionList(algorithmUsage.value)
   getTemplateList()
-  EventBus.$on('layout:resize', () => {
-    setTimeout(() => updateCanvasSize(), 150)
-  })
+  EventBus.$on('layout:resize', handleLayoutResize)
   if (arrangeContentRef.value && typeof ResizeObserver !== 'undefined') {
     const ro = new ResizeObserver(() => updateCanvasSize())
     ro.observe(arrangeContentRef.value)
@@ -132,7 +149,13 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('resize', handleResize)
-  EventBus.$off && EventBus.$off('layout:resize')
+  EventBus.$off('layout:resize', handleLayoutResize)
+  if (resizeTimer) {
+    clearTimeout(resizeTimer)
+    resizeTimer = null
+  }
+  layoutResizeTimers.forEach((timer) => clearTimeout(timer))
+  layoutResizeTimers.clear()
   if (arrangeContentRef.value && arrangeContentRef.value.__ro) {
     arrangeContentRef.value.__ro.disconnect()
     arrangeContentRef.value.__ro = null
@@ -140,12 +163,6 @@ onBeforeUnmount(() => {
   // 离开编排页面时恢复侧边栏
   EventBus.$emit('sidebar:expand')
 })
-
-let resizeTimer = null
-const handleResize = () => {
-  if (resizeTimer) clearTimeout(resizeTimer)
-  resizeTimer = setTimeout(() => updateCanvasSize(), 100)
-}
 
 const updateCanvasSize = () => {
   nextTick(() => {

--- a/src/web/src/views/gam/taskManager/editTask/paramSetting.vue
+++ b/src/web/src/views/gam/taskManager/editTask/paramSetting.vue
@@ -53,24 +53,24 @@ watch(() => props.algorithmCode, (newVal) => {
   }
 })
 
-onMounted(() => {
-  EventBus.$on('validTaskParam', () => {
-    if (submitForm.value == undefined) {
-      console.log('submitForm:undefined')
-    } else {
-      if (props.config) {
-        props.config.isValited = submitForm.value.submitForm()
-      }
+const handleValidTaskParam = () => {
+  if (submitForm.value == undefined) {
+    console.log('submitForm:undefined')
+  } else {
+    if (props.config) {
+      props.config.isValited = submitForm.value.submitForm()
     }
-  })
+  }
+}
 
+onMounted(() => {
+  EventBus.$on('validTaskParam', handleValidTaskParam)
   document.addEventListener('keydown', handleKeyDown)
 })
 
 onBeforeUnmount(() => {
-  if (props.activeName === 'params') {
-    document.removeEventListener('keydown', handleKeyDown)
-  }
+  EventBus.$off('validTaskParam', handleValidTaskParam)
+  document.removeEventListener('keydown', handleKeyDown)
 })
 
 const resetForm = (data) => {

--- a/src/web/src/views/main/index.vue
+++ b/src/web/src/views/main/index.vue
@@ -179,6 +179,20 @@ const iconMap = {
 }
 const getIconComp = (icon) => iconMap[icon] || Menu
 
+const handleSidebarCollapse = () => {
+  if (!isCollapse.value) {
+    isCollapse.value = true
+    EventBus.$emit('layout:resize')
+  }
+}
+
+const handleSidebarExpand = () => {
+  if (isCollapse.value) {
+    isCollapse.value = false
+    EventBus.$emit('layout:resize')
+  }
+}
+
 // 组件挂载时初始化菜单状态
 onMounted(() => {
   initMenuState()
@@ -192,18 +206,8 @@ onMounted(() => {
   }
 
   // 子页面可通过事件控制侧边栏收起/展开
-  EventBus.$on('sidebar:collapse', () => {
-    if (!isCollapse.value) {
-      isCollapse.value = true
-      EventBus.$emit('layout:resize')
-    }
-  })
-  EventBus.$on('sidebar:expand', () => {
-    if (isCollapse.value) {
-      isCollapse.value = false
-      EventBus.$emit('layout:resize')
-    }
-  })
+  EventBus.$on('sidebar:collapse', handleSidebarCollapse)
+  EventBus.$on('sidebar:expand', handleSidebarExpand)
 })
 
 onBeforeUnmount(() => {
@@ -212,8 +216,8 @@ onBeforeUnmount(() => {
     clearInterval(rebootTimer)
     rebootTimer = null
   }
-  EventBus.$off && EventBus.$off('sidebar:collapse')
-  EventBus.$off && EventBus.$off('sidebar:expand')
+  EventBus.$off('sidebar:collapse', handleSidebarCollapse)
+  EventBus.$off('sidebar:expand', handleSidebarExpand)
 })
 
 const toggleUserMenu = (e) => {


### PR DESCRIPTION
## Summary

Own and precisely tear down the remaining Wave A shell, form, canvas, and arrangement listeners. Track pending resize timers so route teardown cannot execute stale callbacks.

## Related issue

Closes #134

## Root cause

The task parameter form, item canvas, main shell, and arrangement page used anonymous EventBus handlers or event-name-only teardown. The parameter keydown listener was removed only when a specific tab happened to be active during unmount, and arrangement resize timeouts were not cancelled.

## Scope

### In scope

- Name and precisely unregister the task parameter validation handler.
- Remove the task parameter keydown listener unconditionally at unmount.
- Give each mVCanvas instance its own reset handler and unregister it before canvas teardown.
- Name and precisely unregister main-shell sidebar collapse/expand handlers.
- Name the arrangement layout-resize handler and preserve 100ms window debounce plus independent 150ms layout scheduling.
- Track and cancel every pending arrangement resize timer at unmount.

### Out of scope

- Replacing the global EventBus architecture.
- Adding instance IDs to the global `resetSelectPoints` payload.
- Replacing mVCanvas's existing fixed canvas DOM id with a template ref.
- Changing the existing two-owner sidebar restore behavior between Main and ArrangeDetail.
- Unrelated task form, canvas drawing, or Flow layout refactors.

## Risk tags

- [x] Runtime / lifecycle
- [ ] Thread / memory safety
- [ ] API / authentication / network
- [ ] Media / streaming
- [ ] Model / inference / flow
- [x] Frontend console
- [x] Build / package / deployment
- [x] Compatibility / migration
- [ ] None of the above

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build / deployment
- [x] Refactor
- [ ] Test

## Area

- [ ] Backend service
- [x] Frontend web console
- [x] Pipeline / scenario configuration
- [ ] Model import / model runtime
- [ ] API / MQTT / WebSocket
- [ ] Media / streaming
- [ ] Build / deployment
- [ ] Documentation

## Candidate identity

- Base commit: `5ffb96d774d77d1e61c5d934d81d33421890927b`
- Candidate commit: `15169658a9b086043112ccc345d9d427563e4117`
- Candidate tree: `e1df79b1c49926b5788502a7993b5b1f30b400b8`
- Package SHA-256: `61b77f89bd84987862a007bf077b6305eb89b2e3bb9135871e806d13a4680674`
- Test binary SHA-256: `dbc583036c5f58dd691bceb0cb95cb7a59224947a4cb8225fa20092b3b8a5597`

The candidate has not been amended, rebased, merged, or otherwise changed since this evidence was collected.

## Verification

### Parent baseline

```text
PASS — read-only inspection on origin/main confirmed:
- validTaskParam and resetSelectPoints used anonymous EventBus callbacks;
- keydown removal depended on activeName at unmount;
- sidebar and layout resize teardown removed every handler by event name;
- pending 100ms and 150ms arrangement resize timers were not cancelled at unmount.
```

### Candidate checks

```text
PASS  git diff origin/main...HEAD --check
PASS  scoped scan: no single-argument EventBus.$off remains in the four changed files
PASS  scoped scan: EventBus and DOM listeners use matching handler identities
PASS  npm run linkage-flow:check                        (Sophon container)
PASS  npm run linkage-form:check                        (Sophon container)
PASS  npm run build                                     (Sophon container)
      Full prebuild, i18n, linkage, route, task-card, and upgrade checks passed.
PASS  ./scripts/docker-compose.sh -f docker-compose.sophon.yml run --rm \
        cosmo-sophon-package --chip bm1688
      cosmo-engine, cosmo-tests, web frontend, package audits, and package regression suites passed.
PASS  two independent read-only lifecycle reviews found no PR6-introduced regression
PASS  ./.codex/validate_candidate.sh --issue '#134' --base origin/main \
        --package build_output/public-runtime/bm1688/cosmo-V1.1.0-f6b539701817ca05b6322513483aa162.tar.gz \
        --tests build/cosmo-tests
PASS  parameter tab switching: 10/10 cycles
PASS  parameter route unmount with activeName=area: 10/10 cycles
PASS  validTaskParam save and Ctrl+Alt+G shortcut; zero submitForm:undefined leak logs
PASS  normal arrangement sidebar/resize lifecycle: 10/10 cycles
PASS  rapid pending-resize unmount lifecycle: 10/10 cycles
PASS  single canvas mount/unmount count: 10/10 cycles, exactly 1 -> 0 canvases
BLOCKED / UNVERIFIED  resetSelectPoints behavior: existing mVCanvas value/v-model mismatch throws in paint()
KNOWN LIMITATION  pre-collapsed sidebar is expanded on exit by the existing two-owner restore logic
```

The standalone frontend container emitted existing Node-engine compatibility warnings because its Node 20.11 image is older than the declared Node 20.19 minimum of three installed packages. Dependency installation and production build completed successfully; the canonical package build also passed.

### Risk-based evidence

- API/network: N/A.
- Media/streaming: N/A.
- Sophon/device: Candidate deployment, parameter, default-sidebar, resize-timer, and canvas mount/unmount scenarios PASS on the authorized BM1688/aarch64 device. Canvas reset is BLOCKED/UNVERIFIED by an existing paint error.
- Frontend/UI: Production build, linkage/i18n checks, repeated parameter and arrangement route cycles, shortcut, validation, sidebar, and pending-timer scenarios PASS. Pre-collapsed sidebar restore and directed canvas reset remain documented baseline limitations.
- Package/deployment: BM1688 public-runtime package generated and audited; target chip recorded as `bm1688`.

## Documentation impact

- [ ] Documentation was updated.
- [x] Documentation is not needed for this change.
- [ ] Documentation will be handled in a follow-up.

## Compatibility and deployment impact

- [x] This change is backward compatible.
- [ ] This change may affect public APIs, configuration files, pipelines, deployment scripts, or model artifacts.
- [ ] Not applicable.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [ ] This PR adds third-party materials, and their source and license are documented.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented.
- [x] Documentation was updated if behavior changed.
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: `验证通过 15169658a9b086043112ccc345d9d427563e4117 61b77f89bd84987862a007bf077b6305eb89b2e3bb9135871e806d13a4680674` (provided after canvas reset was reported as `BLOCKED/UNVERIFIED` and the pre-collapsed sidebar limitation was documented)
- Device test filter: `N/A — UI lifecycle PASS_WITH_BASELINE_BLOCKED_CANVAS_RESET`
- Device backup state: retained; rollback was not required
- Temporary-data cleanup: `complete`; temporary service, item library, video channel, uploaded MP4, package, extraction directory, and install log were removed
- Final Git status: `clean`
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks.
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

The diff intentionally preserves current reset payloads and sidebar state transitions. Device validation confirmed the pre-collapsed sidebar limitation. Canvas reset could not be validated because the existing Capture/mVCanvas contract passes Vue 3 `v-model` to a legacy `value` prop, making `blockList` undefined and causing `paint()` to throw on every mount; the PR6 diff does not change that code. Simultaneous mVCanvas instances also remain unsupported by the fixed DOM id and untargeted reset payload. Device validation and candidate-bound acceptance are complete; the PR remains draft pending explicit Ready authorization.
