### PR TITLE
docs: add Windows x86 Docker troubleshooting section

### DIFF
--- a/docs/en/guide/troubleshooting.md
+++ b/docs/en/guide/troubleshooting.md
@@ -60,7 +60,24 @@ View logs:
   ```bash
   ./scripts/macos-docker-preview.sh logs --follow
   ```
+## Windows x86 Docker Troubleshooting
 
+If you are setting up `cosmo-edge` on Windows using the x86 Docker configuration, check the following:
+
+1. **Docker Desktop:** Make sure Docker Desktop is running and the Docker Engine has finished starting. If commands time out or report daemon errors, check that Docker Desktop is running before continuing.
+
+2. **Docker Compose V2:** Use the Compose V2 command format `docker compose` instead of the older `docker-compose` command.
+
+3. **Port 8080:** The Windows x86 setup uses host port `8080` for the web console. If Docker reports a port binding error, see [Port Conflicts](#port-conflicts) for Windows-specific checks and instructions for changing the host port.
+
+4. **Windows x86 configuration:** Use `docker-compose.x86.windows.yml` when starting the Windows x86 setup:
+
+   ```powershell
+   docker compose -f docker-compose.x86.windows.yml up -d --build
+5. **Docker logs**: To view the x86 Docker logs, run:
+   ```powershell 
+   docker compose -f docker-compose.x86.windows.yml logs -f
+   
 ## Port Conflicts
 
 The x86 Compose file publishes:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -60,6 +60,27 @@ http://127.0.0.1:8080
   ```bash
   ./scripts/macos-docker-preview.sh logs --follow
   ```
+## Windows x86 Docker 问题排查
+
+如果您在 Windows 环境下使用 x86 Docker 配置设置 `cosmo-edge`，请检查以下内容：
+
+1. **Docker Desktop:** 确保 Docker Desktop 正在运行，且 Docker 引擎已完成启动。如果命令超时或报告守护进程错误，请在继续前检查 Docker Desktop 是否正在运行。
+
+2. **Docker Compose V2:** 使用 Compose V2 命令格式 `docker compose`，而不是旧的 `docker-compose` 命令。
+
+3. **端口 8080:** Windows x86 设置使用宿主机端口 `8080` 作为 Web 控制台。如果 Docker 报告端口绑定错误，请参阅 [端口冲突](#端口冲突) 了解 Windows 特定的检查方法和修改宿主机端口的说明。
+
+4. **Windows x86 配置:** 启动 Windows x86 设置时使用 `docker-compose.x86.windows.yml`：
+
+   ```powershell
+   docker compose -f docker-compose.x86.windows.yml up -d --build
+   ```
+
+5. **Docker 日志:** 要查看 x86 Docker 日志，请运行：
+
+   ```powershell
+   docker compose -f docker-compose.x86.windows.yml logs -f
+   ```
 
 ## 端口冲突
 


### PR DESCRIPTION
I have added the Windows x86 Docker troubleshooting section to both the English and Chinese documentation files, covering the Docker Desktop application state, Compose V2 command format, port conflicts, configuration commands, and log retrieval steps. Please review my changes, thank you!
