### PR TITLE
fix(nn): correct center-coordinate IoU in Sophon YOLO NMS

### DIFF
--- a/src/nn/device/sophon/sophon_yolo_decode_npu_node.cc
+++ b/src/nn/device/sophon/sophon_yolo_decode_npu_node.cc
@@ -148,33 +148,7 @@ Status SophonYoloDecodeNPUNode::Forward(std::vector<std::shared_ptr<Blob>>& bott
 }
 
 std::vector<YoloBox> SophonYoloDecodeNPUNode::NMS(std::vector<YoloBox>& detections, float iou_threshold) {
-    std::vector<YoloBox> result;
-    std::sort(detections.begin(), detections.end(),
-              [](const YoloBox& a, const YoloBox& b) { return a.confidence > b.confidence; });
-
-    while (!detections.empty()) {
-        result.push_back(detections[0]);
-        for (auto it = detections.begin() + 1; it != detections.end();) {
-            float x1 = std::max(result.back().x, it->x);
-            float y1 = std::max(result.back().y, it->y);
-            float x2 = std::min(result.back().x + result.back().width, it->x + it->width);
-            float y2 = std::min(result.back().y + result.back().height, it->y + it->height);
-
-            float intersection = std::max(0.0f, x2 - x1) * std::max(0.0f, y2 - y1);
-            float area1        = result.back().width * result.back().height;
-            float area2        = it->width * it->height;
-            float iou          = intersection / (area1 + area2 - intersection);
-
-            if (iou > iou_threshold) {
-                it = detections.erase(it);
-            } else {
-                ++it;
-            }
-        }
-        detections.erase(detections.begin());
-    }
-
-    return result;
+    return SophonYoloNms(detections, iou_threshold);
 }
 
 void SophonYoloDecodeNPUNode::ResetTopBlob(std::shared_ptr<Blob> top_blob) {

--- a/src/nn/device/sophon/sophon_yolo_decode_npu_node.h
+++ b/src/nn/device/sophon/sophon_yolo_decode_npu_node.h
@@ -1,23 +1,16 @@
 #pragma once
 
+#include "nn/device/sophon/sophon_yolo_nms.h"
 #include "nn/node/node.h"
 
 namespace cosmo::nn {
-
-struct YoloBox {
-    float x, y, width, height;
-    float confidence;
-    int class_id;
-};
-
-using YoloBoxVec = std::vector<YoloBox>;
 
 /**
  * @brief YoloDecodeNode is a node for yolo decode.
  *
  * It will decode the output of yolo network.
  * while `YOLO` output is formatted as `(x, y, w, h, obj, c0, c1, ... ,cn)`,
- * `YoloDecodeNode` output is formatted as `(x, y, w, h, conf, class_id)`.
+ * `YoloDecodeNode` output is formatted as `(center_x, center_y, w, h, conf, class_id)`.
  */
 class SophonYoloDecodeNPUNode : public Node {
 public:

--- a/src/nn/device/sophon/sophon_yolo_nms.h
+++ b/src/nn/device/sophon/sophon_yolo_nms.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+namespace cosmo::nn {
+
+struct YoloBox {
+    // Decoded YOLO coordinates remain center-based through NMS and output.
+    float x, y, width, height;
+    float confidence;
+    int class_id;
+};
+
+using YoloBoxVec = std::vector<YoloBox>;
+
+inline std::vector<YoloBox> SophonYoloNms(std::vector<YoloBox>& detections, float iou_threshold) {
+    std::vector<YoloBox> result;
+    std::sort(detections.begin(), detections.end(),
+              [](const YoloBox& a, const YoloBox& b) { return a.confidence > b.confidence; });
+
+    while (!detections.empty()) {
+        result.push_back(detections[0]);
+        for (auto it = detections.begin() + 1; it != detections.end();) {
+            const auto& selected = result.back();
+            // Convert each center to its own edges only for the IoU calculation.
+            float x1 = std::max(selected.x - selected.width / 2, it->x - it->width / 2);
+            float y1 = std::max(selected.y - selected.height / 2, it->y - it->height / 2);
+            float x2 = std::min(selected.x + selected.width / 2, it->x + it->width / 2);
+            float y2 = std::min(selected.y + selected.height / 2, it->y + it->height / 2);
+
+            float intersection = std::max(0.0f, x2 - x1) * std::max(0.0f, y2 - y1);
+            float area1        = selected.width * selected.height;
+            float area2        = it->width * it->height;
+            float iou          = intersection / (area1 + area2 - intersection);
+
+            if (iou > iou_threshold) {
+                it = detections.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        detections.erase(detections.begin());
+    }
+
+    return result;
+}
+
+}  // namespace cosmo::nn

--- a/test/test_sophon_yolo_nms.cc
+++ b/test/test_sophon_yolo_nms.cc
@@ -1,0 +1,95 @@
+#include "catch_amalgamated.hpp"
+#include "nn/device/sophon/sophon_yolo_nms.h"
+
+using cosmo::nn::SophonYoloNms;
+using cosmo::nn::YoloBox;
+using cosmo::nn::YoloBoxVec;
+
+TEST_CASE("Sophon YOLO NMS suppresses unequal boxes using center coordinates", "[nn][sophon][nms]") {
+    // The smaller box is contained: IoU = (70 * 90) / (80 * 200) = 0.39375.
+    // Treating these centers as upper-left corners instead gives about 0.1234.
+    YoloBox full{100.0f, 150.0f, 80.0f, 200.0f, 0.91f, 3};
+    YoloBox part{100.0f, 95.0f, 70.0f, 90.0f, 0.82f, 3};
+
+    SECTION("higher confidence full box survives") {}
+
+    SECTION("higher confidence partial box survives") {
+        std::swap(full.confidence, part.confidence);
+    }
+
+    SECTION("translation does not change suppression") {
+        full.x += 200.25f;
+        full.y -= 180.5f;
+        part.x += 200.25f;
+        part.y -= 180.5f;
+    }
+
+    const auto expected = full.confidence > part.confidence ? full : part;
+    YoloBoxVec detections{part, full};
+    const auto result = SophonYoloNms(detections, 0.35f);
+
+    REQUIRE(result.size() == 1);
+    // NMS must leave the surviving center, size and metadata unchanged for the parser.
+    CHECK(result[0].x == expected.x);
+    CHECK(result[0].y == expected.y);
+    CHECK(result[0].width == expected.width);
+    CHECK(result[0].height == expected.height);
+    CHECK(result[0].confidence == expected.confidence);
+    CHECK(result[0].class_id == expected.class_id);
+}
+
+TEST_CASE("Sophon YOLO NMS preserves adjacent boxes of different sizes", "[nn][sophon][nms]") {
+    // Actual overlap is 40 * 140, giving IoU = 5600 / 22800, about 0.2456.
+    // Treating the centers as upper-left corners inflates IoU to 0.42.
+    YoloBoxVec detections{{140.0f, 100.0f, 60.0f, 140.0f, 0.87f, 0},
+                          {100.0f, 100.0f, 100.0f, 200.0f, 0.91f, 0}};
+
+    const auto result = SophonYoloNms(detections, 0.35f);
+
+    REQUIRE(result.size() == 2);
+    CHECK(result[0].confidence == 0.91f);
+    CHECK(result[0].x == 100.0f);
+    CHECK(result[1].confidence == 0.87f);
+    CHECK(result[1].x == 140.0f);
+}
+
+TEST_CASE("Sophon YOLO NMS keeps the strict IoU threshold boundary", "[nn][sophon][nms]") {
+    YoloBoxVec detections{{0.0f, 0.0f, 8.0f, 8.0f, 0.9f, 0}, {0.0f, 0.0f, 4.0f, 8.0f, 0.8f, 0}};
+
+    SECTION("IoU equal to the threshold is retained") {
+        CHECK(SophonYoloNms(detections, 0.5f).size() == 2);
+    }
+
+    SECTION("IoU above the threshold is suppressed") {
+        CHECK(SophonYoloNms(detections, 0.49f).size() == 1);
+    }
+}
+
+TEST_CASE("Sophon YOLO NMS retains touching and separate boxes", "[nn][sophon][nms]") {
+    YoloBoxVec detections{{0.0f, 12.0f, 8.0f, 8.0f, 0.7f, 0},
+                          {0.0f, 0.0f, 8.0f, 8.0f, 0.9f, 0},
+                          {8.0f, 0.0f, 8.0f, 8.0f, 0.8f, 0}};
+
+    const auto result = SophonYoloNms(detections, 0.0f);
+
+    REQUIRE(result.size() == 3);
+    CHECK(result[0].confidence == 0.9f);
+    CHECK(result[1].confidence == 0.8f);
+    CHECK(result[2].confidence == 0.7f);
+}
+
+TEST_CASE("Sophon YOLO NMS handles empty and single candidate input", "[nn][sophon][nms]") {
+    YoloBoxVec detections;
+
+    SECTION("empty input") {
+        CHECK(SophonYoloNms(detections, 0.35f).empty());
+    }
+
+    SECTION("single candidate") {
+        detections.push_back({1.5f, -2.25f, 4.0f, 6.0f, 0.9f, 2});
+        const auto result = SophonYoloNms(detections, 0.35f);
+        REQUIRE(result.size() == 1);
+        CHECK(result[0].x == 1.5f);
+        CHECK(result[0].y == -2.25f);
+    }
+}


### PR DESCRIPTION
## Summary

Fix Sophon YOLO NPU postprocessing so NMS compares overlap using each box's center coordinates. Unequal full-body and partial-body detections can now suppress correctly at the configured threshold, while adjacent unequal boxes avoid an inflated overlap calculation.

## Related issue

Closes #158.

## Root cause

The NPU decoder emits center-format `x, y, width, height`. NMS previously interpreted `x, y` as upper-left corners. The output parser subsequently converts centers to upper-left coordinates, so saved event coordinates were correct even though the earlier NMS calculation was wrong.

The fix converts each center to its own edges only during IoU calculation. The surviving coordinates, score ordering, strict `IoU > threshold` comparison, and output contract remain unchanged.

## Scope

### In scope

- Extract the existing NMS implementation into a dependency-free helper used by the production Sophon node.
- Correct overlap geometry and add five focused regression cases.

### Out of scope

- Threshold defaults, confidence filtering, model weights, tracking, and class policy.
- Authorization status UI/CLI compatibility and external configuration synchronization.

## Risk tags

- [x] Model / inference / flow

## Type of change

- [x] Bug fix
- [x] Test

## Area

- [x] Model import / model runtime

## Candidate identity

- Base commit: `0dab89eea2e84835e0852dc10d2115e201237a03`
- Candidate commit: `f535c487ca951e68ca9ab7f32ad754bfb5bdb236`
- Candidate tree: `06eba0b56f1486b2e88547d47eae864188166659`
- Package SHA-256: `9e82f7bd05734e4d8fe6bc2e1f1b9ff97e51baee26f010c83b625c5eb3c7eef4`
- AArch64 test binary SHA-256: `d3ea266033589286be14c46a7a7bd7ca0bc87f7c5a5d2cf95fd7e09cc1aa33d2`

No source changes, amendments, or rebases occurred after validation.

## Verification

### Parent baseline

Existing BM1688 installation: normal authenticated picture-task inference reproduced one same-person double detection in a set of 59 identical input images, with NMS 0.35 and task confidence 0.8. This is a measured deployed-version baseline, not a full build/test of the parent commit. A separate full parent suite was not run.

### Candidate checks

```text
Linux x86_64 build host:
  bash scripts/build_cpu_test.sh
  ./build_cpu/cosmo-tests --reporter junit --out <private-run>/cpu-tests-retry1.xml
  PASS: full suite, exit 0; JUnit failures=0, errors=0, skipped=0.

Formatting:
  bash scripts/format_check.sh --staged --check
  PASS before commit; final clang-format 18 dry-run over all four changed files also passed.

BM1688 Protected package:
  COSMO_MODEL_GUARD_BUILD_PROFILE=production-release
  COSMO_MODEL_GUARD_SDK_ROOT=<admitted-production-sdk>
  COSMO_PACKAGE_MODELS=preserve bash scripts/build.sh -T -c bm1688
  PASS: build, SDK admission, package regression checks, installed ELF audit,
  and final package verification; development mode disabled.

Actual BM1688 device, package libraries:
  LD_LIBRARY_PATH=<candidate-package>/lib <candidate-tests> '[nn][sophon][nms]'
  PASS: 5 test cases, 36 assertions.
```

Initial build attempts failed on host tool availability/compatibility. Task-local tools resolved those failures; failed and successful attempts are retained in private evidence. No tracked third-party files or global host configuration were changed.

### Risk-based evidence

- API/network: normal authenticated picture APIs; temporary runtime had isolated user, mount, PID and network namespaces with loopback-only routes.
- Media/streaming: 59 still-image comparisons from the same input bytes, followed by a 110-second recording of the actual installed channel preview (more than three source loops). The operator independently confirmed that NMS 0.35 suppresses the duplicate and 0.4 retains both, consistent with the corrected overlap boundary. Preview output can reuse recent detection results and is not an exact raw per-frame NMS trace; no broad tracking or recall claim is made.
- Sophon/device: real BM1688 and the same protected model/configuration. At NMS 0.35 and confidence 0.8, the reproduced duplicate changed from two boxes to the higher-confidence full-body box. The other 58 target lists were exactly unchanged, including two visually checked adjacent-person pairs. No additional target was removed in this sample set.
- Frontend/UI: no UI change. A pre-existing authorization status query passes an unsupported `--store-dir` argument to the production provisioner and reports `unknown`; direct provisioner `status` returned `valid`, and protected CEM v2 loading and real inference succeeded.
- Package/deployment: after the temporary device validation, the same production Protected package was installed through the normal authenticated upload and System/Upgrade path. The device rebooted successfully and reports V1.1.115.0. The running process executable SHA-256 is `acda69e87a64d481427d9c2b185a8bbf116b2dcdaf12409a2208728655881860`, matching the verified package. Existing protected model bytes and authorization certificates were preserved; direct provisioner status is valid and model initialization/inference succeeded. The temporary engine, picture task and algorithm were cleaned up.

## Documentation impact

- [x] Documentation is not needed for this change.

## Compatibility and deployment impact

- [x] This change is backward compatible.

Configuration and model formats are unchanged. Corrected overlap can change detection selection when box sizes differ. These samples do not establish universal recall in crowded or heavily occluded scenes.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] New dependencies have an acceptable license and are documented. (No new dependencies.)
- [x] Documentation was updated if behavior changed. (Internal geometry correction; no configuration/API change.)
- [x] My commits are signed off with `Signed-off-by:` according to the DCO-style requirement in `CONTRIBUTING.md`.
- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Acceptance and cleanup

- Candidate-bound acceptance: measured PASS for candidate and package hashes above, including official installation and running-binary identity. The final observed model NMS is 0.35 and task confidence is 0.8. A separate configuration save replaced a temporary 0.29 setting; the latest base code reloads affected tasks on SaveConfig. This is not attributed to an internal default-reset timer. GitHub checks passed (frontend build was correctly skipped for this C++ change).
- Device test filter: `[nn][sophon][nms]`.
- Device backup state: a complete pre-upgrade application/configuration/certificate archive and a consistent SQLite backup were verified and retained privately for recovery. Post-upgrade model and certificate identities were checked. Concurrent operator configuration changes were preserved rather than overwritten.
- Temporary-data cleanup: temporary task/algorithm deleted and temporary runtime stopped; private validation artifacts retained outside tracked paths.
- Final Git status: clean.
- [x] Evidence was collected from the candidate commit listed above.
- [x] Any source change after validation invalidated and restarted the required checks. (No subsequent source change.)
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

Regression cases cover unequal duplicate boxes, reversed confidence order, translated coordinates, adjacent unequal boxes, strict threshold boundaries, touching/separate boxes, and empty/single input. Saved integer boxes alone cannot prove the exact floating-point IoU used before NMS; acceptance above uses actual before/after inference.
