### PR TITLE
fix: enable factory reset on RKNN devices

### DIFF
--- a/src/platform/SystemReboot.cc
+++ b/src/platform/SystemReboot.cc
@@ -75,11 +75,13 @@ void RebootManager::Reset(const std::string& reason, const std::string& baseDir)
     JoinPendingLocked();
     thread_ = std::thread([baseDir]() {
         std::this_thread::sleep_for(cosmo::timing::kServiceReadyDelay);
-#ifndef COSMO_NN_USE_SOPHON_BACKEND
-        LOG_WARN("System reset (clear base dir and reboot) is disabled on x86 platform. Base dir: {}",
-                 baseDir);
-        return;
-#else
+        if (!SupportsSystemReboot()) {
+            LOG_WARN(
+                "System reset (clear base dir and reboot) is disabled on the current backend. "
+                "Base dir: {}",
+                baseDir);
+            return;
+        }
         LOG_INFO("Clearing factory-resettable data in: {}", baseDir);
         const auto ec = ClearFactoryResetData(baseDir);
         if (ec) {
@@ -87,7 +89,6 @@ void RebootManager::Reset(const std::string& reason, const std::string& baseDir)
         }
 
         ImmReboot();
-#endif
     });
 }
 

--- a/test/test_system_reset_backends.py
+++ b/test/test_system_reset_backends.py
@@ -1,0 +1,111 @@
+"""Exercise the real reset implementation without ever executing a reboot.
+
+Run with Python 3 and a C++17 compiler (CXX may select the compiler).
+Only OS execution, logging and delays are stubbed; reset and filesystem logic
+are compiled from src/platform/SystemReboot.cc for each supported backend.
+"""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ResetBackendTest(unittest.TestCase):
+    def test_reset_lifecycle(self):
+        compiler = (os.environ.get("CXX") or shutil.which("c++")
+                    or shutil.which("clang++") or shutil.which("cl"))
+        self.assertTrue(compiler, "C++17 compiler required; set CXX")
+        with tempfile.TemporaryDirectory(prefix="cosmo-reset-") as tmp:
+            root = Path(tmp)
+            stubs = {
+                "sys/reboot.h": "#pragma once\n",
+                "unistd.h": "#pragma once\ninline void sync() {}\n",
+                "util/Log.h": """#pragma once
+#define LOG_INFO(...) ((void)0)
+#define LOG_WARN(...) ((void)0)
+#define LOG_ERRO(...) ((void)0)
+namespace cosmo::log { inline void FlushLog() {} }
+""",
+                "util/TimingConstants.h": """#pragma once
+#include <chrono>
+namespace cosmo::timing {
+constexpr auto kServiceReadyDelay = std::chrono::milliseconds(0);
+constexpr auto kRebootGracePeriod = std::chrono::milliseconds(0);
+}
+""",
+            }
+            for name, content in stubs.items():
+                path = root / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            harness = root / "reset_test.cc"
+            harness.write_text(r'''
+#include "platform/SystemReboot.h"
+#include "util/Exec.h"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+namespace fs = std::filesystem;
+int reboot_calls = 0;
+namespace cosmo::util {
+int Exec(const std::vector<std::string>& argv, std::string&) {
+    if (argv != std::vector<std::string>{"reboot"}) return 127;
+    ++reboot_calls;
+    return 0;
+}
+}
+int main(int argc, char** argv) {
+    if (argc != 3) return 2;
+    const fs::path root = argv[1];
+    const bool device = std::string(argv[2]) == "device";
+    fs::create_directories(root / "conf");
+    fs::create_directories(root / "model-guard");
+    std::ofstream(root / "conf" / "settings.json") << "settings";
+    std::ofstream(root / "model-guard" / "certificate") << "authorization";
+    {
+        cosmo::platform::RebootManager manager;
+        manager.Reset("backend regression", root.string());
+    } // Joins the real asynchronous reset task before checking effects.
+    const bool cleared = !fs::exists(root / "conf");
+    std::string authorization;
+    std::ifstream(root / "model-guard" / "certificate") >> authorization;
+    if (cleared != device || reboot_calls != (device ? 1 : 0) ||
+        authorization != "authorization") {
+        std::cerr << "cleared=" << cleared << " reboot_calls=" << reboot_calls
+                  << " expected_device=" << device << '\n';
+        return 1;
+    }
+}
+''', encoding="utf-8")
+            for backend in ("CPU", "RKNN", "SOPHON"):
+                with self.subTest(backend=backend):
+                    binary = root / (backend + (".exe" if os.name == "nt" else ""))
+                    command = [compiler, "-std=c++17", "-pthread",
+                               f"-DCOSMO_NN_USE_{backend}_BACKEND", "-I", str(root),
+                               "-I", str(ROOT / "src"),
+                               str(ROOT / "src/platform/SystemReboot.cc"),
+                               str(harness), "-o", str(binary)]
+                    if Path(compiler).name.lower() in ("cl", "cl.exe"):
+                        command = [compiler, "/nologo", "/std:c++17", "/EHsc",
+                                   f"/DCOSMO_NN_USE_{backend}_BACKEND",
+                                   "/I" + str(root), "/I" + str(ROOT / "src"),
+                                   str(ROOT / "src/platform/SystemReboot.cc"),
+                                   str(harness), "/Fe:" + str(binary)]
+                    build = subprocess.run(command, cwd=root, capture_output=True, text=True,
+                                           errors="replace")
+                    self.assertEqual(build.returncode, 0, build.stdout + build.stderr)
+                    result = subprocess.run(
+                        [str(binary), str(root / (backend + "-data")),
+                         "host" if backend == "CPU" else "device"],
+                        capture_output=True, text=True, timeout=15)
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

修复 RK3576 / RKNN 设备恢复出厂请求被接受后，既不清理数据也不重启的问题。恢复出厂现在复用 SupportsSystemReboot() 的后端能力判断，与普通重启保持一致。

## Related issue

由设备测试发现，无关联 issue。

## Root cause

RebootManager::Reset 使用仅允许 COSMO_NN_USE_SOPHON_BACKEND 的条件编译，将 RKNN 构建也归入禁用分支并提前返回；日志还错误地将该分支描述为 x86。SupportsSystemReboot() 已支持 Sophon 和 RKNN，此处遗漏了复用。

## Scope

### In scope

- RKNN 和 Sophon 执行恢复出厂清理并请求重启；CPU 保持禁止清理和重启。
- 保留 model-guard 授权目录。
- 增加编译真实 SystemReboot.cc 的 CPU / RKNN / Sophon 回归测试，仅替换 OS 命令执行、日志和等待时间，测试不会实际重启主机。

### Out of scope

- 首次启动默认 IP 策略、前端操作完成状态、实际设备部署。

## Risk tags

- [x] Runtime / lifecycle
- [x] Compatibility / migration

## Type of change

- [x] Bug fix
- [x] Test

## Area

- [x] Backend service

## Candidate identity

- Base commit: `0dab89eea2e84835e0852dc10d2115e201237a03`
- Candidate commit: `37ee7668e36f62cc2609eaa45b8369a50dd9e685`
- Candidate tree: `74aecd76b4f5c23fa25c369ca386bda12befd78e`
- Package SHA-256: N/A
- Test binary SHA-256: N/A（测试临时目录已清理）

验证后仅进行了 clang-format 排版和提交 Signed-off-by 元数据补齐；无逻辑修改。下方测试为工作区验证记录，不声称设备候选验收。

## Verification

### Parent baseline

Windows / Python 3.12 / MSVC 14.44（vcvars64.bat 环境），设置 `CXX=cl.exe`：

```text
python test/test_system_reset_backends.py
FAIL（修复前生产源码 + 新回归测试）
仅 RKNN 失败：cleared=0 reboot_calls=0 expected_device=1
CPU、Sophon 子场景通过。
```

### Candidate checks

```text
python test/test_system_reset_backends.py
PASS：1 个 unittest，3 个后端子场景。
检查配置清理、重启命令调用次数、授权数据内容保留。

clang-format 18.1.8 --dry-run --Werror src/platform/SystemReboot.cc
PASS

git diff --check
PASS

bash scripts/build_cpu_test.sh
BLOCKED：本机 Bash/WSL 无法启动。
./build_cpu/cosmo-tests
NOT RUN：完整测试二进制未生成。
bash scripts/format_check.sh --check
BLOCKED：同上；变更 C++ 文件已直接通过 clang-format 18 检查。
```

### Risk-based evidence

- API/network: 无接口或网络配置修改。
- Media/streaming: N/A。
- Sophon/device: 主机编译条件分支回归通过；未执行真实设备清理和重启。
- Frontend/UI: 无修改。
- Package/deployment: 未构建部署包。

## Documentation impact

- [x] Documentation is not needed for this change.

## Compatibility and deployment impact

- [x] This change is backward compatible.

RKNN 恢复出厂将开始实际执行已有的数据清理逻辑，需要重新构建、部署后在获授权的设备上验证。

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media, or generated assets.
- [x] This PR does not include GPL, AGPL, or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys, or certificates are included.
- [x] No real device SN values, customer names, or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] My commits are signed off with Signed-off-by according to CONTRIBUTING.md.
- [x] I have read CONTRIBUTING.md and CODE_OF_CONDUCT.md.

## Acceptance and cleanup

- Candidate-bound acceptance: N/A，未做设备验收。
- Device test filter: N/A
- Device backup state: N/A，未操作设备。
- Temporary-data cleanup: complete
- Final Git status: clean
- [x] No temporary credentials, media, models, device exports, or generated packages are included.

## Notes for reviewers

完整 Linux CPU 构建与测试、RK3576 真机恢复出厂验证仍待完成。前端完成状态反馈和首次启动网络策略可另行处理。

