### PR TITLE
fix(watchdog): enable hardware watchdog for RKNN production builds

### DIFF
--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -12,6 +12,7 @@ on:
       - 'toolchains/**'
       - 'CMakeLists.txt'
       - 'scripts/build_cpu_test.sh'
+      - 'tools/test_watchdog_driver.py'
       - '.github/workflows/ci-build-and-test.yml'
   workflow_dispatch:
 
@@ -63,6 +64,9 @@ jobs:
           cargo --version
 
       # ── Build ────────────────────────────────────────────────────────
+      - name: Test watchdog backend selection and device failures without hardware
+        run: python3 tools/test_watchdog_driver.py
+
       - name: Configure and build cosmo-tests (x86 CPU backend)
         run: bash scripts/build_cpu_test.sh
 

--- a/src/app/app_init.cc
+++ b/src/app/app_init.cc
@@ -353,7 +353,9 @@ static void InitializeExternalComponents() {
 #ifndef COSMO_DEV_MODE
     // Hardware watchdog — feeds /dev/watchdog to prevent system reset on hang.
     // Disabled in development builds (COSMO_DEV_MODE) to avoid device resets during debugging.
-    cosmo::service::ServiceRegistry::Instance().Get<cosmo::service::IWatchDogService>().Start();
+    if (!cosmo::service::ServiceRegistry::Instance().Get<cosmo::service::IWatchDogService>().Start()) {
+        LOG_ERRO("{}", "Hardware watchdog failed to start; watchdog protection is unavailable");
+    }
 #else
     LOG_WARN("{}", "Watchdog disabled (COSMO_DEV_MODE build)");
 #endif
@@ -375,8 +377,11 @@ static void StopExternalComponents() {
     // returns non-owning references, so registry destruction is only safe after
     // ingress and background producers have joined their worker threads.
     if (registry.Has<cosmo::service::IWatchDogService>()) {
-        stop("hardware watchdog",
-             [&registry]() { static_cast<void>(registry.Get<cosmo::service::IWatchDogService>().Stop()); });
+        stop("hardware watchdog", [&registry]() {
+            if (!registry.Get<cosmo::service::IWatchDogService>().Stop()) {
+                LOG_ERRO("{}", "Hardware watchdog shutdown not confirmed");
+            }
+        });
     }
     if (registry.Has<cosmo::service::INetworkService>()) {
         stop("HTTP server",

--- a/src/platform/WatchDog.cc
+++ b/src/platform/WatchDog.cc
@@ -7,6 +7,8 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <cstring>
 #include <thread>
 
 #include "platform/PlatformConstants.h"
@@ -15,6 +17,16 @@
 
 namespace cosmo::platform {
 
+namespace {
+// Both edge backends use the Linux watchdog API. CPU evaluation and development
+// builds must never arm a hardware watchdog, even through a direct Start call.
+#if !defined(COSMO_DEV_MODE) && (defined(COSMO_NN_USE_SOPHON_BACKEND) || defined(COSMO_NN_USE_RKNN_BACKEND))
+    constexpr bool kHardwareWatchdogEnabled = true;
+#else
+    constexpr bool kHardwareWatchdogEnabled = false;
+#endif
+}  // namespace
+
 WatchDog::WatchDog() : Thread("WatchDog Thread") {}
 
 WatchDog::~WatchDog() {
@@ -22,46 +34,64 @@ WatchDog::~WatchDog() {
 }
 
 bool WatchDog::OpenDevice() {
-#ifndef COSMO_NN_USE_SOPHON_BACKEND
-    return true;
-#else
-    fd_ = open(kWatchdogDevice.c_str(), O_WRONLY);
+    fd_ = open(kWatchdogDevice.c_str(), O_WRONLY | O_CLOEXEC);
     if (fd_ == -1) {
-        LOG_ERRO("Failed to open {}", kWatchdogDevice);
+        LOG_ERRO("Failed to open {}: {}", kWatchdogDevice, std::strerror(errno));
         return false;
     }
-    ioctl(fd_, WDIOC_SETTIMEOUT, &timeout_sec_);
+    timeout_sec_ = kWatchdogTimeoutSec;
+    if (ioctl(fd_, WDIOC_SETTIMEOUT, &timeout_sec_) == -1) {
+        LOG_WARN("Failed to set watchdog timeout: {}; querying driver timeout", std::strerror(errno));
+        if (ioctl(fd_, WDIOC_GETTIMEOUT, &timeout_sec_) == -1) {
+            LOG_ERRO("Failed to read watchdog timeout: {}", std::strerror(errno));
+            CloseDevice();
+            return false;
+        }
+    }
+    if (timeout_sec_ <= kWatchdogFeedIntervalSec) {
+        LOG_ERRO("Watchdog timeout {}s must exceed feed interval {}s", timeout_sec_,
+                 kWatchdogFeedIntervalSec);
+        CloseDevice();
+        return false;
+    }
     LOG_INFO("Watchdog opened, timeout={}s", timeout_sec_);
     return true;
-#endif
 }
 
-void WatchDog::CloseDevice() {
-#ifndef COSMO_NN_USE_SOPHON_BACKEND
-    return;
-#else
+bool WatchDog::CloseDevice() {
     if (fd_ == -1) {
-        return;
+        return true;
     }
-    // Disable the watchdog before closing to prevent immediate reboot.
-    int option = WDIOS_DISABLECARD;
-    ioctl(fd_, WDIOC_SETOPTIONS, &option);
-
-    // Write magic close character 'V' to allow clean shutdown.
-    auto ret = write(fd_, "V", 1);
-    (void)ret;
-    close(fd_);
+    int option          = WDIOS_DISABLECARD;
+    const bool disabled = ioctl(fd_, WDIOC_SETOPTIONS, &option) == 0;
+    if (!disabled) {
+        LOG_ERRO("Failed to disable watchdog: {}; attempting magic close", std::strerror(errno));
+        // Best effort for drivers supporting magic close. A successful write
+        // does not prove that close can stop the timer (e.g. nowayout).
+        if (write(fd_, "V", 1) != 1) {
+            LOG_ERRO("Failed to write watchdog magic close: {}", std::strerror(errno));
+        }
+    }
+    const bool closed = close(fd_) == 0;
+    if (!closed) {
+        LOG_ERRO("Failed to close watchdog descriptor: {}", std::strerror(errno));
+    }
+    // Do not retry close: Linux may already have released the descriptor.
     fd_ = -1;
-    LOG_INFO("{}", "Watchdog closed");
-#endif
+    if (disabled && closed) {
+        LOG_INFO("{}", "Watchdog stop accepted by driver; descriptor closed");
+    } else {
+        LOG_WARN("{}", "Watchdog shutdown not confirmed; timer may still be running");
+    }
+    return disabled && closed;
 }
 
-void WatchDog::Feed() {
-#ifndef COSMO_NN_USE_SOPHON_BACKEND
-    return;
-#else
-    ioctl(fd_, WDIOC_KEEPALIVE, 0);
-#endif
+bool WatchDog::Feed() {
+    if (ioctl(fd_, WDIOC_KEEPALIVE, 0) == -1) {
+        LOG_ERRO("Failed to feed watchdog: {}", std::strerror(errno));
+        return false;
+    }
+    return true;
 }
 
 void WatchDog::run() {
@@ -72,23 +102,40 @@ void WatchDog::run() {
 }
 
 bool WatchDog::Start() {
+    if (!kHardwareWatchdogEnabled) {
+        LOG_INFO("{}", "Hardware watchdog disabled for this build");
+        return true;
+    }
+    if (is_running_) {
+        return true;
+    }
     if (!OpenDevice()) {
         return false;
     }
-    is_running_ = true;
-    if (!start()) {
-        is_running_ = false;
+    // Validate keepalive before reporting startup success.
+    if (!Feed()) {
         CloseDevice();
         return false;
     }
-    return true;
+    is_running_ = true;
+    try {
+        if (start()) {
+            return true;
+        }
+    } catch (...) {
+        is_running_ = false;
+        CloseDevice();
+        throw;
+    }
+    is_running_ = false;
+    CloseDevice();
+    return false;
 }
 
 bool WatchDog::Stop() {
     is_running_ = false;
     stop();
-    CloseDevice();
-    return true;
+    return CloseDevice();
 }
 
 }  // namespace cosmo::platform

--- a/src/platform/WatchDog.h
+++ b/src/platform/WatchDog.h
@@ -37,10 +37,10 @@ private:
     [[nodiscard]] bool OpenDevice();
 
     // Disable and close the watchdog device.
-    void CloseDevice();
+    bool CloseDevice();
 
     // Send keepalive ioctl to the watchdog.
-    void Feed();
+    bool Feed();
 
     std::atomic<bool> is_running_{false};
     int timeout_sec_{kWatchdogTimeoutSec};

--- a/test/watchdog/WatchDogStandaloneTest.cc
+++ b/test/watchdog/WatchDogStandaloneTest.cc
@@ -1,0 +1,175 @@
+// Link-wrap device syscalls: exercise the real driver and worker thread without
+// ever opening a hardware watchdog on the build host.
+#include <fcntl.h>
+#include <linux/watchdog.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+
+#include "platform/WatchDog.h"
+
+namespace {
+constexpr int kFakeFd = 12345;
+std::atomic<int> opens{0}, feeds{0}, closes{0}, disables{0}, magic_closes{0};
+bool fail_open = false, fail_timeout = false, fail_get_timeout = false;
+bool fail_feed = false, fail_disable = false, fail_close = false;
+int driver_timeout = 40;
+std::atomic<int> failures{0};
+
+void Check(bool condition, const char* message) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        ++failures;
+    }
+}
+
+void Reset() {
+    opens = feeds = closes = disables = magic_closes = 0;
+    fail_open = fail_timeout = fail_get_timeout = fail_feed = fail_disable = fail_close = false;
+    driver_timeout                                                                      = 40;
+}
+}  // namespace
+
+namespace cosmo::util {
+std::string GenerateUUID() {
+    return "watchdog-test";
+}
+}  // namespace cosmo::util
+
+extern "C" int __wrap_open(const char* path, int flags, ...) {
+    Check(std::strcmp(path, "/dev/watchdog") == 0, "opens watchdog device");
+    Check((flags & O_ACCMODE) == O_WRONLY, "opens device for writing");
+    ++opens;
+    if (fail_open) {
+        errno = EACCES;
+        return -1;
+    }
+    return kFakeFd;
+}
+
+extern "C" int __wrap_ioctl(int fd, unsigned long request, ...) {
+    Check(fd == kFakeFd, "ioctl uses the owned descriptor");
+    va_list args;
+    va_start(args, request);
+    int result = 0;
+    if (request == WDIOC_SETTIMEOUT) {
+        auto* timeout = va_arg(args, int*);
+        Check(*timeout == 30, "requests the configured timeout");
+        *timeout = driver_timeout;  // Hardware may round the requested timeout.
+        result   = fail_timeout ? -1 : 0;
+    } else if (request == WDIOC_GETTIMEOUT) {
+        *va_arg(args, int*) = driver_timeout;
+        result              = fail_get_timeout ? -1 : 0;
+    } else if (request == WDIOC_KEEPALIVE) {
+        ++feeds;
+        result = fail_feed ? -1 : 0;
+    } else if (request == WDIOC_SETOPTIONS) {
+        Check(*va_arg(args, int*) == WDIOS_DISABLECARD, "requests disable on stop");
+        ++disables;
+        result = fail_disable ? -1 : 0;
+    } else {
+        Check(false, "unexpected ioctl");
+        result = -1;
+    }
+    va_end(args);
+    if (result < 0) {
+        errno = EIO;
+    }
+    return result;
+}
+
+extern "C" ssize_t __wrap_write(int fd, const void* data, size_t size) {
+    Check(fd == kFakeFd && size == 1 && *static_cast<const char*>(data) == 'V', "writes magic close");
+    ++magic_closes;
+    return static_cast<ssize_t>(size);
+}
+
+extern "C" int __wrap_close(int fd) {
+    Check(fd == kFakeFd, "closes owned device");
+    ++closes;
+    errno = EIO;
+    return fail_close ? -1 : 0;
+}
+
+int main(int argc, char** argv) {
+    const bool enabled = argc > 1 && std::strcmp(argv[1], "enabled") == 0;
+    {
+        cosmo::platform::WatchDog dog;
+        Check(dog.Start(), "start succeeds");
+        if (enabled && argc <= 2) {
+            Check(dog.Start(), "repeated start preserves the running watchdog");
+        }
+        if (enabled) {
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(4);
+            while (feeds < 3 && std::chrono::steady_clock::now() < deadline) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+        }
+        Check(dog.Stop(), "stop succeeds");
+        Check(dog.Stop(), "second stop succeeds");
+        Check(opens == (enabled ? 1 : 0), "production RK/Sophon opens hardware; CPU/dev does not");
+        Check(closes == (enabled ? 1 : 0), "device closed exactly once");
+        Check(enabled ? feeds >= 3 : feeds == 0, "production worker feeds hardware repeatedly");
+        Check(disables == (enabled ? 1 : 0), "stop disables hardware");
+    }
+    if (!enabled || (argc > 2 && std::strcmp(argv[2], "smoke") == 0)) {
+        return failures ? 1 : 0;
+    }
+    Reset();
+    {
+        cosmo::platform::WatchDog dog;
+        fail_open = true;
+        Check(!dog.Start(), "open failure propagates");
+        Check(dog.Stop() && closes == 0, "failed open owns no descriptor");
+    }
+    Reset();
+    {
+        cosmo::platform::WatchDog dog;
+        fail_timeout = true;
+        Check(dog.Start(), "unsupported timeout uses readable driver timeout");
+        Check(dog.Stop(), "fallback timeout can stop");
+    }
+    Reset();
+    {
+        cosmo::platform::WatchDog dog;
+        fail_timeout = fail_get_timeout = true;
+        Check(!dog.Start(), "unknown timeout fails startup");
+        Check(closes == 1 && disables == 1, "timeout failure cleans up armed device");
+    }
+    Reset();
+    {
+        cosmo::platform::WatchDog dog;
+        driver_timeout = 1;
+        Check(!dog.Start(), "timeout must exceed feed interval");
+        Check(closes == 1 && disables == 1, "unsafe timeout cleans up armed device");
+    }
+    Reset();
+    {
+        cosmo::platform::WatchDog dog;
+        fail_feed = true;
+        Check(!dog.Start(), "initial keepalive failure fails startup");
+        Check(closes == 1 && disables == 1, "keepalive failure cleans up armed device");
+    }
+    Reset();
+    {
+        cosmo::platform::WatchDog dog;
+        Check(dog.Start(), "start before disable failure");
+        fail_disable = true;
+        Check(!dog.Stop(), "unconfirmed disable is not reported as success");
+        Check(magic_closes == 1 && closes == 1, "disable failure attempts magic close");
+    }
+    Reset();
+    {
+        cosmo::platform::WatchDog dog;
+        Check(dog.Start(), "start before close failure");
+        fail_close = true;
+        Check(!dog.Stop(), "close failure propagates");
+    }
+    return failures ? 1 : 0;
+}

--- a/test/watchdog/stubs/util/Log.h
+++ b/test/watchdog/stubs/util/Log.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Keep the standalone driver test independent of the application's log backend.
+#define LOG_INFO(...) ((void)0)
+#define LOG_WARN(...) ((void)0)
+#define LOG_ERRO(...) ((void)0)

--- a/tools/test_watchdog_driver.py
+++ b/tools/test_watchdog_driver.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Compile the real watchdog/worker with wrapped syscalls; never access hardware.
+
+Run on Linux with a C++17 compiler. --smoke reproduces the RKNN no-op regression
+without requiring the subsequent error-handling improvements.
+"""
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--smoke", action="store_true")
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    variants = {
+        "rknn": (["COSMO_NN_USE_RKNN_BACKEND"], "enabled"),
+        "sophon": (["COSMO_NN_USE_SOPHON_BACKEND"], "enabled"),
+        "cpu": (["COSMO_NN_USE_CPU_BACKEND"], "disabled"),
+        "rknn-dev": (["COSMO_NN_USE_RKNN_BACKEND", "COSMO_DEV_MODE"], "disabled"),
+        "sophon-dev": (["COSMO_NN_USE_SOPHON_BACKEND", "COSMO_DEV_MODE"], "disabled"),
+    }
+    with tempfile.TemporaryDirectory(prefix="watchdog-test-") as directory:
+        for name, (defines, mode) in variants.items():
+            binary = Path(directory) / name
+            command = [os.environ.get("CXX", "g++"), "-std=c++17", "-pthread"]
+            command += [f"-D{define}" for define in defines]
+            command += ["-I", str(root / "test/watchdog/stubs"), "-I", str(root / "src")]
+            command += [str(root / source) for source in (
+                "src/platform/WatchDog.cc", "src/util/Thread.cc",
+                "src/util/ThreadRegistry.cc", "test/watchdog/WatchDogStandaloneTest.cc",
+            )]
+            command += [f"-Wl,--wrap={call}" for call in ("open", "ioctl", "write", "close")]
+            command += ["-o", str(binary)]
+            subprocess.run(command, check=True)
+            subprocess.run([str(binary), mode] + (["smoke"] if args.smoke else []), check=True)
+            print(f"PASS: {name}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

RKNN production builds currently report watchdog startup success without opening or feeding `/dev/watchdog`. Enable the shared Linux watchdog implementation for RKNN as well as Sophon, while keeping CPU and development builds inactive. Surface timeout, keepalive and shutdown failures, and add hardware-free regression coverage to x86 CI.

## Related issue

No linked issue; this PR addresses a directly reported RK3576 watchdog failure.

## Root cause

`OpenDevice`, `Feed` and `CloseDevice` were guarded exclusively by `COSMO_NN_USE_SOPHON_BACKEND`. An RKNN build therefore returned success and ran an idle worker without arming the timer. Device ioctl results and the application-level Start/Stop results were also ignored.

## Scope

### In scope

- Enable Linux watchdog operations for RKNN/Sophon production builds; disable direct Start calls in CPU/dev builds.
- Open with close-on-exec, validate timeout and initial keepalive, preserve a running watchdog on repeated Start, and clean up worker-start failures.
- Query the driver timeout when setting it fails; report shutdown as unconfirmed when disabling/closing fails, with best-effort magic close.
- Test real watchdog and worker code with wrapped syscalls across five build variants, including failure paths, and run this in CI.

### Out of scope

- Business-thread health monitoring, kernel driver changes, new configuration/API fields and automatic deployment.

## Risk tags

- [x] Runtime / lifecycle
- [x] Thread / memory safety
- [x] Compatibility / migration

## Type of change

- [x] Bug fix
- [x] Test

## Area

- [x] Backend service
- [x] Build / deployment

## Candidate identity

- Base commit: `a195ed6d3e647d8bf1510291475f08062ffd1180`
- Candidate commit: `f8275527a741f4636afea1e67c3b8e3bf2a4d3aa`
- Candidate tree: `0811f1e67cfbc169bbf6c630794b38b27607fb18`
- RK3576 package SHA-256: `a262c508c99517ac08349f90bf557a8d1db39a154e40de051ea7ce85b9c0f480`
- Test binary SHA-256: not collected.

Builds ran before committing the same source contents. Local and remote changed-file hashes matched; no source amendment or rebase followed validation. The package used the public-runtime profile with `--models preserve`, not production-release acceptance.

## Verification

### Parent baseline

FAIL (expected regression reproduction): in the repository x86 Docker builder, overlay the new regression harness on the unchanged parent and run:

```text
python3 tools/test_watchdog_driver.py --smoke
RKNN reported successful startup but made no device open/feed/disable/close calls.
```

### Candidate checks

```text
Environment: repository Docker builders on Linux x86_64; no host compilation.
x86 image: ghcr.io/cosmo-wander-ai/cosmo_edge-build-env_x86:v1
RK image: ghcr.io/cosmo-wander-ai/cosmo_edge-build-env_rockchip@sha256:0810c23042cbe86d3a1c91f848b9849a34d94222f3ad7b7418913a26da19e71b

python3 tools/test_watchdog_driver.py
PASS: rknn, sophon, cpu, rknn-dev, sophon-dev.

bash scripts/build_cpu_test.sh
PASS.

./build_cpu/cosmo-tests
PASS: 38,406 assertions in 1,035 test cases, with LD_LIBRARY_PATH from the x86 CI workflow.
Initial launch without those paths failed to load libswresample.so.3; rerun passed.

COSMO_TARGET_CHIP=rk3576 COSMO_PACKAGE_MODELS=preserve COSMO_BUILD_JOBS=4 ./scripts/docker-compose.sh -p watchdog-fix-20260911 -f docker-compose.rockchip.yml run --rm cosmo-rockchip-package
PASS: ARM64 engine/tests compiled, package content verification and SHA256 check passed.

git diff --check
PASS.

clang-format 18.1.8 --dry-run --Werror on all changed C++ files
PASS. Full-tree formatter comparison found four unchanged parent violations:
src/flow/detect/AiDetectMng.cc
src/media/PixelFormatUtils.cc
src/media/VideoDemuxerStream.cc
src/network/mqtt/MqttClientInternal.h
The format shell script was unavailable in the builder and failed under Windows Git Bash;
the same native formatter was used to check all 1,329 C++ files.
```

### Risk-based evidence

- API/network: no public API changes. Web homepage returned HTTP 200 after the device reboot test.
- Media/streaming: no media code changed; detailed workload recovery was not tested.
- Sophon/device: Sophon syscall regression passed; no new Sophon physical-device test. On a user-upgraded RK3576, the engine owned `/dev/watchdog`, logged a 44-second timeout and showed repeated hardware counter reloads. A controlled `SIGSTOP` stopped keepalive; the counter decreased through 44.10 seconds, then the device rebooted near 45 seconds. A new boot ID and reset uptime confirmed a whole-system reboot. The engine automatically restarted and resumed feeding. No manual reboot command was issued. The installed package/binary hash was not remeasured, so this follow-up device evidence is not candidate-bound release acceptance.
- Frontend/UI: package build completed; no UI source changes.
- Package/deployment: public-runtime RK3576 package verified. No credentials, private addresses, boot identifiers or device logs are included in this PR.

## Documentation impact

- [x] Documentation is not needed for this change: restores the intended production behavior without new user configuration.

## Compatibility and deployment impact

- [x] This change is backward compatible with the existing API/configuration.
- RKNN production startup now really arms the watchdog. CPU/dev builds remain inactive. Stopping the process without a clean shutdown can now cause the intended hardware reset.
- Successful driver stop is logged as driver acceptance, not independent proof that the hardware timer stopped; vendor kernel/nowayout behavior still matters.

## Third-party code and assets

- [x] This PR does not add third-party code, models, datasets, media or generated assets.
- [x] This PR does not include new GPL, AGPL or other strong copyleft code.

## Security and release checklist

- [x] No secrets, tokens, private keys or certificates are included.
- [x] No real device SN values, customer names or private IPs are included.
- [x] No private model weights or proprietary download links are included.
- [x] No new dependencies.
- [ ] Commit contains a DCO `Signed-off-by:` trailer. The existing pushed commit does not contain one; this is disclosed for review rather than asserted as complete.
- [x] CONTRIBUTING.md and CODE_OF_CONDUCT.md were read.

## Acceptance and cleanup

- Candidate-bound build acceptance: PASS for the source-equivalent Docker builds above.
- Candidate-bound device/package acceptance: UNVERIFIED (installed artifact hash not remeasured).
- Device test filter: controlled whole-process SIGSTOP with a 75-second SIGCONT fallback if no reboot occurred.
- Device backup state: N/A; no persistent configuration changes.
- Temporary-data cleanup: test process ended at reboot; SSH sessions closed; private build/evidence directories retained outside Git.
- Final Git status: clean.
- [x] No source change after validation.
- [x] No temporary credentials, media, models, device exports or generated packages are included.

## Notes for reviewers

The feeding thread remains independent of business-thread health: this restores process-level watchdog protection, not detection of every inference/HTTP deadlock. Global formatting debt and the missing DCO trailer remain explicitly listed above.
